### PR TITLE
[CI, bugfix] Skip test if openCL CPU runtime not installed, but DPC portion built

### DIFF
--- a/onedal/common/tests/test_sycl.py
+++ b/onedal/common/tests/test_sycl.py
@@ -109,7 +109,11 @@ def test_sycl_device_attributes(queue):
 
 @pytest.mark.skipif(not _is_dpc_backend, reason="requires dpc backend")
 def test_backend_queue():
-    q = _backend.SyclQueue("cpu")
+    try:
+        q = _backend.SyclQueue("cpu")
+    except RuntimeError:
+        pytest.skip("openCL CPU runtime not installed")
+
     # verify copying via a py capsule object is functional
     q2 = _backend.SyclQueue(q._get_capsule())
     # verify copying via the _get_capsule attribute

--- a/onedal/common/tests/test_sycl.py
+++ b/onedal/common/tests/test_sycl.py
@@ -112,7 +112,7 @@ def test_backend_queue():
     try:
         q = _backend.SyclQueue("cpu")
     except RuntimeError:
-        pytest.skip("openCL CPU runtime not installed")
+        pytest.skip("OpenCL CPU runtime not installed")
 
     # verify copying via a py capsule object is functional
     q2 = _backend.SyclQueue(q._get_capsule())


### PR DESCRIPTION
## Description

Make necessary changes for oneCI testing environment.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
