### PR TITLE
ci: resolve overdetermined CI issue

### DIFF
--- a/sklearnex/linear_model/tests/test_linear.py
+++ b/sklearnex/linear_model/tests/test_linear.py
@@ -37,10 +37,10 @@ from sklearnex.tests.utils import _IS_INTEL
 def test_sklearnex_import_linear(
     dataframe, queue, dtype, macro_block, overdetermined, multi_output
 ):
-    if (overdetermined or multi_output) and not daal_check_version((2025, "P", 1)):
+    if (not overdetermined or multi_output) and not daal_check_version((2025, "P", 1)):
         pytest.skip("Functionality introduced in later versions")
     if (
-        overdetermined
+        not overdetermined
         and queue
         and queue.sycl_device.is_gpu
         and not daal_check_version((2025, "P", 200))
@@ -50,7 +50,7 @@ def test_sklearnex_import_linear(
     from sklearnex.linear_model import LinearRegression
 
     rng = np.random.default_rng(seed=123)
-    X = rng.standard_normal(size=(10, 20) if overdetermined else (20, 5))
+    X = rng.standard_normal(size=(10, 20) if not overdetermined else (20, 5))
     y = rng.standard_normal(size=(X.shape[0], 3) if multi_output else X.shape[0])
 
     Xi = np.c_[X, np.ones((X.shape[0], 1))]

--- a/sklearnex/linear_model/tests/test_linear.py
+++ b/sklearnex/linear_model/tests/test_linear.py
@@ -50,7 +50,7 @@ def test_sklearnex_import_linear(
     from sklearnex.linear_model import LinearRegression
 
     rng = np.random.default_rng(seed=123)
-    X = rng.standard_normal(size=(10, 20) if not overdetermined else (20, 5))
+    X = rng.standard_normal(size=(10, 20) if overdetermined else (20, 5))
     y = rng.standard_normal(size=(X.shape[0], 3) if multi_output else X.shape[0])
 
     Xi = np.c_[X, np.ones((X.shape[0], 1))]


### PR DESCRIPTION
## Description

Minor follow-up to https://github.com/uxlfoundation/scikit-learn-intelex/pull/2167 and https://github.com/uxlfoundation/scikit-learn-intelex/pull/2154 with update to test_linear to align all overdetermined conditions.

Fixes public CI failure

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.
