### PR TITLE
ci: run_examples warnings to errors

### DIFF
--- a/examples/daal4py/readcsv.py
+++ b/examples/daal4py/readcsv.py
@@ -14,19 +14,26 @@
 # limitations under the License.
 # ==============================================================================
 
-from importlib.machinery import SourceFileLoader
+from importlib.util import spec_from_file_location, module_from_spec
 from pathlib import Path
 
 utils_path = Path(__file__).parent.parent / "utils"
+module_name = "readcsv"
+module_path = str(utils_path / "readcsv.py")
 
-readcsv = SourceFileLoader("readcsv", str(utils_path / "readcsv.py")).load_module()
+spec = spec_from_file_location(module_name, module_path)
+readcsv = module_from_spec(spec)
+spec.loader.exec_module(readcsv)
 
 np_read_csv = readcsv.np_read_csv
 pd_read_csv = readcsv.pd_read_csv
 csr_read_csv = readcsv.csr_read_csv
+read_next = readcsv.read_next
 
 __all__ = [
     "np_read_csv",
     "pd_read_csv",
     "csr_read_csv",
+    "read_next",
 ]
+

--- a/examples/daal4py/readcsv.py
+++ b/examples/daal4py/readcsv.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from importlib.util import spec_from_file_location, module_from_spec
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
 utils_path = Path(__file__).parent.parent / "utils"

--- a/examples/daal4py/readcsv.py
+++ b/examples/daal4py/readcsv.py
@@ -36,4 +36,3 @@ __all__ = [
     "csr_read_csv",
     "read_next",
 ]
-

--- a/examples/mb/readcsv.py
+++ b/examples/mb/readcsv.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from importlib.util import spec_from_file_location, module_from_spec
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
 utils_path = Path(__file__).parent.parent / "utils"

--- a/examples/mb/readcsv.py
+++ b/examples/mb/readcsv.py
@@ -28,4 +28,3 @@ spec.loader.exec_module(readcsv)
 np_read_csv = readcsv.np_read_csv
 pd_read_csv = readcsv.pd_read_csv
 csr_read_csv = readcsv.csr_read_csv
-

--- a/examples/mb/readcsv.py
+++ b/examples/mb/readcsv.py
@@ -14,13 +14,18 @@
 # limitations under the License.
 # ==============================================================================
 
-from importlib.machinery import SourceFileLoader
+from importlib.util import spec_from_file_location, module_from_spec
 from pathlib import Path
 
 utils_path = Path(__file__).parent.parent / "utils"
+module_name = "readcsv"
+module_path = str(utils_path / "readcsv.py")
 
-readcsv = SourceFileLoader("readcsv", str(utils_path / "readcsv.py")).load_module()
+spec = spec_from_file_location(module_name, module_path)
+readcsv = module_from_spec(spec)
+spec.loader.exec_module(readcsv)
 
 np_read_csv = readcsv.np_read_csv
 pd_read_csv = readcsv.pd_read_csv
 csr_read_csv = readcsv.csr_read_csv
+

--- a/examples/sklearnex/knn_bf_regression_spmd.py
+++ b/examples/sklearnex/knn_bf_regression_spmd.py
@@ -21,7 +21,7 @@ import dpctl.tensor as dpt
 import numpy as np
 from mpi4py import MPI
 from numpy.testing import assert_allclose
-from sklearn.metrics import mean_squared_error
+from sklearn.metrics import root_mean_squared_error
 
 from sklearnex.spmd.neighbors import KNeighborsRegressor
 
@@ -80,6 +80,6 @@ print(
 )
 print(
     "RMSE for entire rank {}: {}\n".format(
-        rank, mean_squared_error(y_test, dpt.to_numpy(y_predict), squared=False)
+        rank, root_mean_squared_error(y_test, dpt.to_numpy(y_predict))
     )
 )

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -223,7 +223,9 @@ def get_exe_cmd(ex, args):
             return None
     if not args.nodist and ex.endswith("spmd.py"):
         if IS_WIN:
-            return 'mpiexec -localonly -n 4 "' + sys.executable + '" -W error "' + ex + '"'
+            return (
+                'mpiexec -localonly -n 4 "' + sys.executable + '" -W error "' + ex + '"'
+            )
         return 'mpirun -n 4 "' + sys.executable + '" -W error "' + ex + '"'
     else:
         return '"' + sys.executable + '" -W error "' + ex + '"'

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -223,10 +223,10 @@ def get_exe_cmd(ex, args):
             return None
     if not args.nodist and ex.endswith("spmd.py"):
         if IS_WIN:
-            return 'mpiexec -localonly -n 4 "' + sys.executable + '" "' + ex + '"'
-        return 'mpirun -n 4 "' + sys.executable + '" "' + ex + '"'
+            return 'mpiexec -localonly -n 4 "' + sys.executable + '" -W error "' + ex + '"'
+        return 'mpirun -n 4 "' + sys.executable + '" -W error "' + ex + '"'
     else:
-        return '"' + sys.executable + '" "' + ex + '"'
+        return '"' + sys.executable + '" -W error "' + ex + '"'
 
 
 def run(exdir, logdir, args):


### PR DESCRIPTION
## Description

Our examples should not contain deprecated code usage or yield similar warnings. This PR raises an error if an example has a warning. Fixes include replacing deprecated load_module() in daal4py readcsv, deprecated use of mean_squared_error with squared arg - covers all current warnings aside from Basic Stats.

Pending https://github.com/uxlfoundation/scikit-learn-intelex/pull/2189

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.
