### PR TITLE
Version support and automatic CI build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: publish
+'on':
+  push:
+    branches:
+      docs-ci
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y pandoc git
+        pip3 install -r requirements-doc.txt
+        pip3 install scikit-learn-intelex
+        cd doc
+        source set_version.sh
+        echo Generating version $DOC_VERSION
+    - name: build docs
+      run: |
+        cd doc
+        chmod +x build-doc.sh
+        ./build-doc.sh
+        mv _build/scikit-learn-intelex ../../output
+    - name: deploy docs
+      run: |
+        cd doc
+        source set_version.sh
+        cd ..
+        git fetch
+        git checkout -- doc/build-doc.sh
+        git checkout gh-pages
+        rm -rf $DOC_VERSION
+        mv -f ../output/$DOC_VERSION .
+        mv ../output/versions.json .
+        mv ../output/index.html .
+        rm -rf doc
+        git config --global user.name "${GITHUB_ACTOR}"
+        git config --global user.email "${GITHUB_ACTOR}@github.com"
+        git add .
+        git commit -m "latest HTML output"
+        git push -f https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git HEAD:gh-pages
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: publish
 'on':
   push:
     branches:
-      docs-ci
+      ktp-docs-ci
 
 jobs:
   build:

--- a/doc/build-doc.sh
+++ b/doc/build-doc.sh
@@ -27,6 +27,13 @@ mkdir $SAMPLES_DIR
 cd ..
 rsync -a --exclude='doc/$SAMPLES_DIR/daal4py_data_science.ipynb' examples/notebooks/*.ipynb doc/$SAMPLES_DIR
 
-# build the documentation
 cd doc
-make html
+
+source ./set_version.sh
+export SPHINXPROJ=scikit-learn-intelex
+export BUILDDIR=_build
+export SOURCEDIR=sources
+
+sphinx-build -b html $SOURCEDIR $BUILDDIR/$SPHINXPROJ/$DOC_VERSION
+cp versions.json $BUILDDIR/$SPHINXPROJ
+echo "<meta http-equiv=\"refresh\" content=\"0; URL='/$SPHINXPROJ/$DOC_VERSION/'\" / >" >> $BUILDDIR/$SPHINXPROJ/index.html

--- a/doc/get_doc_version.py
+++ b/doc/get_doc_version.py
@@ -1,0 +1,15 @@
+import subprocess
+import os
+
+def get_version():
+    major = ''
+    minor = ''
+    pip_output = subprocess.run(["pip","list"],capture_output=True,encoding='utf-8')
+    lines = pip_output.stdout.split("\n")
+    for line in lines:
+        if line.startswith("scikit-learn-intelex"):
+            version = line.split()[1].split(".")
+            major = version[0]
+            minor = version[1]
+
+    return major + "." + minor

--- a/doc/set_version.sh
+++ b/doc/set_version.sh
@@ -1,0 +1,2 @@
+export DOC_VERSION=$(python -c "from get_doc_version import get_version; print(get_version())")
+

--- a/doc/sources/_static/custom.css
+++ b/doc/sources/_static/custom.css
@@ -121,3 +121,11 @@ div.quotation {
 
 a#wap_dns {display: none;}
 
+
+button#version-switcher-button {
+   background-color:  #2980b9;
+}
+
+div#version-switcher-dropdown {
+   display: inline;
+}

--- a/doc/sources/_static/version_switcher.js
+++ b/doc/sources/_static/version_switcher.js
@@ -1,0 +1,31 @@
+function load_versions(json){
+    var button = document.getElementById('version-switcher-button')
+    var container = document.getElementById('version-switcher-dropdown')
+    var loc = window.location.href;
+    var s = document.createElement('select');
+    s.style = "border-radius:5px;"
+    const versions = JSON.parse(json);
+    for (entry of versions){
+        var o = document.createElement('option');
+        var optionText = '';
+        if ('name' in entry){
+            optionText = entry.name;
+        }else{
+            optionText = entry.version;
+        }
+        o.value = entry.url;
+        if (current_version == entry.version){
+            o.selected = true;
+        }
+        o.innerHTML = optionText;
+        s.append(o);
+    }
+    s.addEventListener("change", ()=> {
+        var current_url = new URL(window.location.href);
+        var path = current_url.pathname;
+        //strip version from path
+        var page_path = path.substring(project_name.length+current_version.length+3);
+        window.location.href = s.value + page_path;
+    });
+    container.append(s);
+}

--- a/doc/sources/_templates/layout.html
+++ b/doc/sources/_templates/layout.html
@@ -2,6 +2,7 @@
 {% block extrahead %}
     <script defer type="text/javascript" src="https://www.intel.com/content/dam/www/global/wap/performance-config.js" ></script>
     <script type="text/javascript">
+        fetch("{{ switcher_url }}").then(response => response.text()).then(respText=> load_versions(respText));
         // Configure TMS settings
         var wapLocalCode = 'us-en'; // Dynamically set per localized site, see mapping table for values
         var wapSection = "scikit-learn"; // WAP team will give you a unique section for your site
@@ -14,4 +15,9 @@
           })();
       }
       </script>
+{% endblock %}
+
+{% block menu %}
+  {% include "versions.html" %}
+  {{ super() }}
 {% endblock %}

--- a/doc/sources/_templates/versions.html
+++ b/doc/sources/_templates/versions.html
@@ -1,0 +1,23 @@
+<div class="version-switcher__container dropdown">
+    <script>
+      current_version = "{{current_version}}"
+      project_name = "{{project_name}}"
+    </script>
+    <div id="version-switcher-button"
+      class="version-switcher__button"
+      data-bs-toggle="dropdown"
+      aria-haspopup="listbox"
+      aria-controls="version-switcher-dropdown"
+      aria-label="Version switcher list"
+      style="display:inline-block;padding-left:10px;padding-right:10px;"
+    >
+      Choose version  <!-- this text may get changed later by javascript -->
+      <span class="caret"></span>
+    </div>
+    <div id="version-switcher-dropdown"
+      class="version-switcher__menu dropdown-menu list-group-flush py-0"
+      role="listbox" aria-labelledby="{{ button_id }}">
+      <!-- dropdown will be populated by javascript on page load -->
+    </div>
+  </div>
+  

--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -23,7 +23,11 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
+bench_test = False
+
 # -- Path setup --------------------------------------------------------------
+
+import json
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -34,7 +38,6 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../"))
 
-
 # -- Project information -----------------------------------------------------
 
 project = "Intel(R) Extension for Scikit-learn*"
@@ -42,9 +45,9 @@ copyright = "Intel"
 author = "Intel"
 
 # The short X.Y version
-version = "2025.0.0"
+version = os.environ.get('DOC_VERSION','')
 # The full version, including alpha/beta/rc tags
-release = "2025.0.0"
+release = version
 
 
 # -- General configuration ---------------------------------------------------
@@ -154,6 +157,13 @@ html_theme_options = {
     "titles_only": False,
 }
 
+switcher_url = "/scikit-learn-intelex/versions.json"
+if bench_test:
+    switcher_url = "/versions.json"
+
+html_context = {"current_version": version,
+                "project_name": "scikit-learn-intelex",
+                "switcher_url": switcher_url}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -163,6 +173,7 @@ html_static_path = ["_static"]
 
 def setup(app):
     app.add_css_file("custom.css")
+    app.add_js_file("version_switcher.js")
 
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -23,8 +23,6 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
-bench_test = False
-
 # -- Path setup --------------------------------------------------------------
 
 import json
@@ -158,8 +156,6 @@ html_theme_options = {
 }
 
 switcher_url = "/scikit-learn-intelex/versions.json"
-if bench_test:
-    switcher_url = "/versions.json"
 
 html_context = {"current_version": version,
                 "project_name": "scikit-learn-intelex",

--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -43,7 +43,7 @@ copyright = "Intel"
 author = "Intel"
 
 # The short X.Y version
-version = os.environ.get('DOC_VERSION','')
+version = os.environ.get("DOC_VERSION", "")
 # The full version, including alpha/beta/rc tags
 release = version
 
@@ -144,7 +144,6 @@ html_favicon = "_static/favicons.png"
 
 html_theme_options = {
     "logo_only": False,
-    "version_selector": True,
     "prev_next_buttons_location": "bottom",
     "style_external_links": False,
     "vcs_pageview_mode": "",
@@ -157,9 +156,11 @@ html_theme_options = {
 
 switcher_url = "/scikit-learn-intelex/versions.json"
 
-html_context = {"current_version": version,
-                "project_name": "scikit-learn-intelex",
-                "switcher_url": switcher_url}
+html_context = {
+    "current_version": version,
+    "project_name": "scikit-learn-intelex",
+    "switcher_url": switcher_url,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -25,8 +25,6 @@
 
 # -- Path setup --------------------------------------------------------------
 
-import json
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/doc/versions.json
+++ b/doc/versions.json
@@ -1,0 +1,19 @@
+[
+    {
+        "name": "2025.0 (latest)",
+        "version": "2025.0",
+        "url": "/scikit-learn-intelex/2025.0/"
+    },
+    {
+        "version": "2024.6",
+        "url": "/scikit-learn-intelex/2024.6/"
+    },
+    {
+        "version": "2024.3",
+        "url": "/scikit-learn-intelex/2024.3/"
+    },
+    {
+        "version": "2023.2",
+        "url": "/scikit-learn-intelex/2023.2/"
+    }
+]

--- a/doc/versions.json
+++ b/doc/versions.json
@@ -1,6 +1,11 @@
 [
     {
-        "name": "2025.0 (latest)",
+        "name": "2025.1",
+        "version": "2025.1",
+        "url": "/scikit-learn-intelex/2025.0/"
+    },
+    {
+        "name": "2025.0",
         "version": "2025.0",
         "url": "/scikit-learn-intelex/2025.0/"
     },

--- a/doc/versions.json
+++ b/doc/versions.json
@@ -2,7 +2,7 @@
     {
         "name": "2025.1 (latest)",
         "version": "2025.1",
-        "url": "/scikit-learn-intelex/2025.0/"
+        "url": "/scikit-learn-intelex/2025.1/"
     },
     {
         "name": "2025.0",

--- a/doc/versions.json
+++ b/doc/versions.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "2025.1",
+        "name": "2025.1 (latest)",
         "version": "2025.1",
         "url": "/scikit-learn-intelex/2025.0/"
     },


### PR DESCRIPTION
## Description

replaces #1785 

Version of docs built using CI: https://intelkevinputnam.github.io/scikit-learn-intelex/

There are two major changes in this PR:

1. Version switching support
2. CI deployment to GitHub pages via GitHub action

### Version Switching Support

All published versions must be tracked in doc/versions.json as this will allow all subsequent versions of the docs to automatically be able to switch to the latest without needing to rebuild the docs.

The version is supplied by the **installed** version of scikit-learn-intelex (latest by default in the CI script). This way building the docs is not dependent on the oneDAL environment with the goal of making it easier to contribute to and edit the docs. It should also make builds faster.

Since the move to the UXL Foundation, version switching is broken in the latest version of the docs because of there is a hard coded path to the versions.json that no longer exists (it was intel.github.com/scikit-learn-intelex). It also is now settable in the conf.py (html_context)

### CI Deployment to GitHub Pages via GitHub Action

GitHub pages will be updated automatically.  A new directory will be **added** for each version of scikit-learn-intelex. When the same version is built twice, it is overwritten. See ``.github/workflows/publish.yml`` for the script. The branch will need to be changed to ``main`` before it will work on the main branch. I'm not sure it is necessary to have the docs built on every merge into ``main``. Adding ``workflow_dispatch:`` to the list of conditions for running the action can provide a handy "deploy whenever you feel like it" option. 

To build the docs locally, run ``./build-docs.sh``. Docs can be previewed locally by starting a web server (``python3 -m http.server``) in the ``_build`` directory and using ``localhost:8000/scikit-learn-intelex`` as the URL.

---
Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [X] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [X] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [X] I have resolved any merge conflicts that might occur with the base branch.

