### PR TITLE
Remove license header from PR template

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -58,6 +58,7 @@ header:
     - 'requirements*.txt'
     # Some files from .ci/.github
     - '.github/CODEOWNERS'
+    - '.github/Pull_Request_template.md'
     - '.github/renovate.json'
     # Specific files
     - 'setup.cfg'

--- a/.github/Pull_Request_template.md
+++ b/.github/Pull_Request_template.md
@@ -1,19 +1,3 @@
-<!--
-  ~ Copyright 2020 Intel Corporation
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
--->
-
 ## Description
 
 _Add a comprehensive description of proposed changes_


### PR DESCRIPTION
## Description

Remove bloat from writing the description on new PRs.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).
