### PR TITLE
[bug, CI] fix issues with forks, force green, and concurrency in codecov report uploading

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -18,12 +18,13 @@ coverage:
     project:
       default:
         target: 0
-        # Set targets to zero so that it will always stay green leave information
-        # on thresholds such that future coverage percentage enforcement can
-        # be easily implemented by adjusting the threshold and setting target: auto
+        # Set targets to zero so that it will always stay green. Also leave
+        # information on thresholds so that future coverage percentage
+        # enforcement can be easily implemented by only adjusting the threshold
+        # and setting target: auto.
         # threshold: 50
     patch:
       default:
         target: 0
-        # allow for diffs to have no code coverage when included
+        # Allow for diffs to have no code coverage.
         # threshold: 50

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -18,9 +18,9 @@ coverage:
     project:
       default:
         target: 0
-        # Set thresholds very conservatively so that it will always stay green
-        # leave information such that future coverage percentage enforcement can
-        # be easily implemented by adjusting the threshold only.
+        # Set targets to zero so that it will always stay green leave information
+        # on thresholds such that future coverage percentage enforcement can
+        # be easily implemented by adjusting the threshold and setting target: auto
         # threshold: 50
     patch:
       default:

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -17,12 +17,13 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        target: 0
         # Set thresholds very conservatively so that it will always stay green
-        # leave target: auto such that future coverage percentage enforcement can
+        # leave information such that future coverage percentage enforcement can
         # be easily implemented by adjusting the threshold only.
-        threshold: 50
+        # threshold: 50
     patch:
       default:
-        target: auto
-        threshold: 50
+        target: 0
+        # allow for diffs to have no code coverage when included
+        # threshold: 50

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,28 @@
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # Set thresholds very conservatively so that it will always stay green
+        # leave target: auto such that future coverage percentage enforcement can
+        # be easily implemented by adjusting the threshold only.
+        threshold: 50
+    patch:
+      default:
+        target: auto
+        threshold: 50

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,10 +23,6 @@ on:
 
 permissions: read-all
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
-
 jobs:
   upload_coverage:
     name: Codecov
@@ -50,9 +46,18 @@ jobs:
           chmod +x codecov
       - name: Upload to codecov
         run: |
-          export PR=${{ github.event.workflow_run.pull_requests[0].number }}
-          export SHA=${{ github.event.workflow_run.head_sha }}
-          export VARARGS="-n github"
-          # if a PR, pass proper information to codecov about SHA and PR, otherwise use main branch info
-          if [ -n "${PR}" ]; then export VARARGS="${VARARGS}-${PR}-${SHA} -P ${PR} -C ${SHA}"; fi
+          # github's webhooks for workflow_run are unreliable, this guarantees to pull the PR number if a PR
+          OWNER="${FULL_NAME%/$NAME}"
+          if [ "${{ github.repository_owner }}" != "${OWNER}" ]; then BRANCH="${OWNER}:${BRANCH}"; fi
+          if [ $(git branch --show-current) != $BRANCH ]; then PR=$(gh pr view $BRANCH --json number -q .number); fi
+          echo uploading $BRANCH
+          SHA=${{ github.event.workflow_run.head_sha }}
+          VARARGS="-C ${SHA} -n github-${SHA}"
+          # if a PR, pass proper information to codecov-cli about the PR number
+          if [ -n "${PR}" ]; then VARARGS="${VARARGS}-${PR} -P ${PR}"; fi
           ./codecov -v upload-process -Z -t ${{ secrets.CODECOV_TOKEN }} $VARARGS -F github -s ./coverage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          NAME: ${{ github.event.workflow_run.head_repository.name }}
+          FULL_NAME: ${{ github.event.workflow_run.head_repository.full_name }}


### PR DESCRIPTION
## Description

This PR fixes 4 issues with the recent codecov roll-out, where fork testing did not cover all scenarios occurring in the main repo:

1) Most importantly, it fixes issues with pull requests, where PRs from forks are not being properly uploaded to codecov (and defaulting to main).  Unfortunately default github webhooks for workflow_run are not complete enough to get the requisite pull request information unless the PR comes from the repo itself. A workaround uses the github cli along with other more reliable aspects of the webhook (branch name, name and full_name) to construct the necessary information to get the PR number.

2) Default settings of codecov can lead to failures in CI. As discussed internally, we would like this not to be enforced to start. A configuration yaml file is added to ```.github``` with very conservative settings. In the case that enforcement will be added, all the necessary information is already included.

3) Concurrency protection is not necessary for this github action: it is a service to PRs and pushes by accomplishing higher-security tasks (i.e. with secrets) on their behalf without using the PR/push code (see ultralytics hack from this week as to why pull_request_target must be avoided). Multiple PRs may run the same action at the same time, and so concurrency is a feature.

4) If multiple pushes to main occur at the same time, it was using only the latest SHA which comes from the repo, which will not properly map into codecov, instead use the head_ref SHA so that the older pushes maintains their SHAs.


See:
icfaust/scikit-learn-intelex#8
icfaust/scikit-learn-intelex#7


---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.
