### PR TITLE
DOC : Fix misrendered docstrings in `IncrementalLinearRegression`

### DIFF
--- a/sklearnex/linear_model/incremental_linear.py
+++ b/sklearnex/linear_model/incremental_linear.py
@@ -63,9 +63,9 @@ class IncrementalLinearRegression(
     Parameters
     ----------
     fit_intercept : bool, default=True
-    Whether to calculate the intercept for this model. If set
-    to False, no intercept will be used in calculations
-    (i.e. data is expected to be centered).
+        Whether to calculate the intercept for this model. If set
+        to False, no intercept will be used in calculations
+        (i.e. data is expected to be centered).
 
     copy_X : bool, default=True
         If True, X will be copied; else, it may be overwritten.


### PR DESCRIPTION
## Description

This PR fixes some misrendered docstrings:
git push --set-upstream origin fix_inclinreg_docstrings

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.

**Performance**

Not applicable.
