### PR TITLE
feature: new rng engines support

### DIFF
--- a/generator/wrappers.py
+++ b/generator/wrappers.py
@@ -887,6 +887,12 @@ no_warn = {
     "algorithms::engines::mt2203": [
         "ParameterType",
     ],
+    "algorithms::engines::mrg32k3a": [
+        "ParameterType",
+    ],
+    "algorithms::engines::philox4x32x10": [
+        "ParameterType",
+    ],
     "algorithms::gbt": [
         "Result",
     ],

--- a/generator/wrappers.py
+++ b/generator/wrappers.py
@@ -106,6 +106,8 @@ no_constructor = {
     "algorithms::engines::mt19937::Batch": {"seed": ["size_t", "seed"]},
     "algorithms::engines::mt2203::Batch": {"seed": ["size_t", "seed"]},
     "algorithms::engines::mcg59::Batch": {"seed": ["size_t", "seed"]},
+    "algorithms::engines::mrg32k3a::Batch": {"seed": ["size_t", "seed"]},
+    "algorithms::engines::philox4x32x10::Batch": {"seed": ["size_t", "seed"]},
 }
 
 # Some algorithms require a setup function, to provide input without actual compute


### PR DESCRIPTION
## Description

PR is necessary to enable new rng engines on oneDAL side. See https://github.com/uxlfoundation/oneDAL/pull/2968

---


**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.


