### PR TITLE
TEST: Use deterministic seeds in tests

### DIFF
--- a/onedal/utils/tests/test_validation.py
+++ b/onedal/utils/tests/test_validation.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-import time
-
 import numpy as np
 import numpy.random as rand
 import pytest
@@ -65,7 +63,7 @@ def test_sum_infinite_actually_finite(dtype, shape, allow_nan, dataframe, queue)
 )
 @pytest.mark.parametrize("allow_nan", [False, True])
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
-@pytest.mark.parametrize("seed", [0, int(time.time())])
+@pytest.mark.parametrize("seed", [0, 123456])
 @pytest.mark.parametrize(
     "dataframe, queue", get_dataframes_and_queues("numpy,dpnp,dpctl")
 )
@@ -92,7 +90,7 @@ def test_assert_finite_random_location(
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("allow_nan", [False, True])
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
-@pytest.mark.parametrize("seed", [0, int(time.time())])
+@pytest.mark.parametrize("seed", [0, 123456])
 @pytest.mark.parametrize(
     "dataframe, queue", get_dataframes_and_queues("numpy,dpnp,dpctl")
 )
@@ -120,7 +118,7 @@ def test_assert_finite_random_shape_and_location(
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("allow_nan", [False, True])
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
-@pytest.mark.parametrize("seed", [0, int(time.time())])
+@pytest.mark.parametrize("seed", [0, 123456])
 def test_assert_finite_sparse(dtype, allow_nan, check, seed):
     lb, ub = 2, 2056
     rand.seed(seed)

--- a/sklearnex/utils/tests/test_validation.py
+++ b/sklearnex/utils/tests/test_validation.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-import time
-
 import numpy as np
 import numpy.random as rand
 import pytest
@@ -67,7 +65,7 @@ def test_sum_infinite_actually_finite(dtype, shape, ensure_all_finite):
 )
 @pytest.mark.parametrize("ensure_all_finite", ["allow-nan", True])
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
-@pytest.mark.parametrize("seed", [0, int(time.time())])
+@pytest.mark.parametrize("seed", [0, 123456])
 @pytest.mark.parametrize(
     "dataframe, queue",
     get_dataframes_and_queues(_dataframes_supported),
@@ -110,7 +108,7 @@ def test_validate_data_random_location(
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("ensure_all_finite", ["allow-nan", True])
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
-@pytest.mark.parametrize("seed", [0, int(time.time())])
+@pytest.mark.parametrize("seed", [0, 123456])
 @pytest.mark.parametrize(
     "dataframe, queue",
     get_dataframes_and_queues(_dataframes_supported),
@@ -151,7 +149,7 @@ def test_validate_data_random_shape_and_location(
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
-@pytest.mark.parametrize("seed", [0, int(time.time())])
+@pytest.mark.parametrize("seed", [0, 123456])
 @pytest.mark.parametrize(
     "dataframe, queue",
     get_dataframes_and_queues(_dataframes_supported),


### PR DESCRIPTION
## Description

This PR modifies tests parameterized by non-deterministic seeds to use fixed seeds.

Having these randomly-determined seeds has the issue that it makes it hard to compare a specific test over several runs (e.g. for different configurations), in addition to making it harder to reproduce potential failures.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
