### PR TITLE
TEST: Backport adjustments to linear regression tolerances

### DIFF
--- a/onedal/linear_model/tests/test_incremental_linear_regression.py
+++ b/onedal/linear_model/tests/test_incremental_linear_regression.py
@@ -91,7 +91,7 @@ def test_full_results(queue, num_blocks, dtype):
     if queue and queue.sycl_device.is_gpu:
         tol = 5e-3 if model.coef_.dtype == np.float32 else 1e-5
     else:
-        tol = 2e-3 if model.coef_.dtype == np.float32 else 1e-5
+        tol = 3e-3 if model.coef_.dtype == np.float32 else 1e-5
     assert_allclose(coef, model.coef_.T, rtol=tol)
 
     tol = 3e-3 if model.intercept_.dtype == np.float32 else 1e-5

--- a/onedal/linear_model/tests/test_incremental_linear_regression.py
+++ b/onedal/linear_model/tests/test_incremental_linear_regression.py
@@ -94,7 +94,7 @@ def test_full_results(queue, num_blocks, dtype):
         tol = 2e-3 if model.coef_.dtype == np.float32 else 1e-5
     assert_allclose(coef, model.coef_.T, rtol=tol)
 
-    tol = 2e-3 if model.intercept_.dtype == np.float32 else 1e-5
+    tol = 3e-3 if model.intercept_.dtype == np.float32 else 1e-5
     assert_allclose(intercept, model.intercept_, rtol=tol)
 
     Xt = gen.random(size=(num_samples_test, num_features), dtype=dtype)


### PR DESCRIPTION
## Description

This PR backports to the 2025.1 release branch some changes to test tolerances that were giving issues in some platforms.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
