### PR TITLE
Pin py-lief dependency version to fix LinuxCondaRecipe

### DIFF
--- a/.ci/pipeline/conda-recipe-lnx.yml
+++ b/.ci/pipeline/conda-recipe-lnx.yml
@@ -20,7 +20,7 @@ steps:
       conda update -y -q --all
     displayName: "Conda update"
   - script: |
-      conda create -y -q -n build-env conda-build conda-verify
+      conda create -y -q -n build-env conda-build conda-verify py-lief=0.14
     displayName: "Conda create"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh


### PR DESCRIPTION
## Description

Automatic update of `py-lief` from 0.14 to 0.15 version caused conda packaging error in `LinuxCondaRecipe` job:

https://dev.azure.com/daal/daal4py/_build/results?buildId=42078&view=logs&jobId=86a6398b-b7de-5f94-fbc2-d77efadbf283&j=86a6398b-b7de-5f94-fbc2-d77efadbf283&t=7f82ec3a-3339-52c0-64a4-16d2d4ad0d36

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

N/A
