### PR TITLE
fix: fix parameters not showing in doc bug

### DIFF
--- a/generator/wrapper_gen.py
+++ b/generator/wrapper_gen.py
@@ -1003,12 +1003,11 @@ cdef extern from "daal4py_cpp.h":
 
 # this is our actual algorithm class for Python
 cdef class {{algo}}{{'('+iface[0]|lower+'__iface__)' if iface[0] else ''}}:
-    cdef tuple _params
-
     '''
     {{algo}}
     {{params_all|fmt('{}', 'sphinx', sep='\n')|indent(4)}}
     '''
+    cdef tuple _params
     # Init simply forwards to the C++ construction function
     def __cinit__(self,
                   {{params_all|fmt('{}', 'decl_dflt_cy', sep=',\n')|indent(18)}}):


### PR DESCRIPTION
## Description
Hi to whom is reviewing this PR!
This PR fixed a bug in documentation generation where the Parameters section under all classes are missing. The root problem was because the template in wrapper_gen.py was putting cdef tuple _params above the parameters doc strings. As a result, sphinx cannot extract the docstring out and parameters under all classes are missing. The fix was a simple one line change that put docstring on top. The doc pipeline in this branch does not work, fixed in another PR that has not been merged yet. To see the effect, either get the branch or try out the one line change.
Best,
Yue


---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.