### PR TITLE
[bug] fix ```to_table``` for a non-array input when a low-precision queue is used

### DIFF
--- a/onedal/basic_statistics/basic_statistics.py
+++ b/onedal/basic_statistics/basic_statistics.py
@@ -83,12 +83,7 @@ class BasicStatistics(BaseBasicStatistics):
 
         is_single_dim = data.ndim == 1
 
-        data_table = to_table(data, queue=queue)
-        weights_table = (
-            to_table(sample_weight, queue=queue)
-            if sample_weight is not None
-            else to_table(None)
-        )
+        data_table, weights_table = to_table(data, sample_weight, queue=queue)
 
         dtype = data_table.dtype
         raw_result = self._compute_raw(data_table, weights_table, policy, dtype, is_csr)

--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -154,6 +154,14 @@ inline csr_table_t convert_to_csr_impl(PyObject *py_data,
 
 dal::table convert_to_table(py::object inp_obj, py::object queue) {
     dal::table res;
+
+    PyObject *obj = inp_obj.ptr();
+
+    if (obj == nullptr || obj == Py_None) {
+        return res;
+    }
+    if (is_array(obj)) {
+
 #ifdef ONEDAL_DATA_PARALLEL
     if (!queue.is(py::none()) && !queue.attr("sycl_device").attr("has_aspect_fp64").cast<bool>()) {
         // If the queue exists, doesn't have the fp64 aspect, and the data is float64
@@ -172,13 +180,7 @@ dal::table convert_to_table(py::object inp_obj, py::object queue) {
         }
     }
 #endif // ONEDAL_DATA_PARALLEL
-
-    PyObject *obj = inp_obj.ptr();
-
-    if (obj == nullptr || obj == Py_None) {
-        return res;
-    }
-    if (is_array(obj)) {
+        
         PyArrayObject *ary = reinterpret_cast<PyArrayObject *>(obj);
 
         if (!PyArray_ISCARRAY_RO(ary) && !PyArray_ISFARRAY_RO(ary)) {

--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -161,26 +161,26 @@ dal::table convert_to_table(py::object inp_obj, py::object queue) {
         return res;
     }
     if (is_array(obj)) {
-
 #ifdef ONEDAL_DATA_PARALLEL
-    if (!queue.is(py::none()) && !queue.attr("sycl_device").attr("has_aspect_fp64").cast<bool>()) {
-        // If the queue exists, doesn't have the fp64 aspect, and the data is float64
-        // then cast it to float32
-        int type = reinterpret_cast<PyArray_Descr *>(inp_obj.attr("dtype").ptr())->type_num;
-        if (type == NPY_DOUBLE || type == NPY_DOUBLELTR) {
-            PyErr_WarnEx(
-                PyExc_RuntimeWarning,
-                "Data will be converted into float32 from float64 because device does not support it",
-                1);
-            // use astype instead of PyArray_Cast in order to support scipy sparse inputs
-            inp_obj = inp_obj.attr("astype")(py::dtype::of<float>());
-            res = convert_to_table(
-                inp_obj); // queue will be set to none, as this check is no longer necessary
-            return res;
+        if (!queue.is(py::none()) &&
+            !queue.attr("sycl_device").attr("has_aspect_fp64").cast<bool>()) {
+            // If the queue exists, doesn't have the fp64 aspect, and the data is float64
+            // then cast it to float32
+            int type = reinterpret_cast<PyArray_Descr *>(inp_obj.attr("dtype").ptr())->type_num;
+            if (type == NPY_DOUBLE || type == NPY_DOUBLELTR) {
+                PyErr_WarnEx(
+                    PyExc_RuntimeWarning,
+                    "Data will be converted into float32 from float64 because device does not support it",
+                    1);
+                // use astype instead of PyArray_Cast in order to support scipy sparse inputs
+                inp_obj = inp_obj.attr("astype")(py::dtype::of<float>());
+                res = convert_to_table(
+                    inp_obj); // queue will be set to none, as this check is no longer necessary
+                return res;
+            }
         }
-    }
 #endif // ONEDAL_DATA_PARALLEL
-        
+
         PyArrayObject *ary = reinterpret_cast<PyArrayObject *>(obj);
 
         if (!PyArray_ISCARRAY_RO(ary) && !PyArray_ISFARRAY_RO(ary)) {

--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -399,8 +399,7 @@ PyObject *convert_to_pyobject(const dal::table &input) {
     }
     if (input.get_kind() == dal::homogen_table::kind()) {
         const auto &homogen_input = static_cast<const dal::homogen_table &>(input);
-        if (homogen_input.get_data_layout() == dal::data_layout::row_major) {
-            const dal::data_type dtype = homogen_input.get_metadata().get_data_type(0);
+        const dal::data_type dtype = homogen_input.get_metadata().get_data_type(0);
 
 #define MAKE_NYMPY_FROM_HOMOGEN(NpType)                                        \
     {                                                                          \
@@ -409,16 +408,10 @@ PyObject *convert_to_pyobject(const dal::table &input) {
                                             homogen_input.get_row_count(),     \
                                             homogen_input.get_column_count()); \
     }
-            SET_CTYPE_NPY_FROM_DAL_TYPE(
-                dtype,
-                MAKE_NYMPY_FROM_HOMOGEN,
-                throw std::invalid_argument("Not avalible to convert a numpy"));
+        SET_CTYPE_NPY_FROM_DAL_TYPE(dtype,
+                                    MAKE_NYMPY_FROM_HOMOGEN,
+                                    throw std::invalid_argument("Unable to convert numpy object"));
 #undef MAKE_NYMPY_FROM_HOMOGEN
-        }
-        else {
-            throw std::invalid_argument(
-                "Output oneDAL table doesn't have row major format for homogen table");
-        }
     }
     else if (input.get_kind() == csr_table_t::kind()) {
         const auto &csr_input = static_cast<const csr_table_t &>(input);
@@ -428,7 +421,7 @@ PyObject *convert_to_pyobject(const dal::table &input) {
         SET_CTYPES_NPY_FROM_DAL_TYPE(
             dtype,
             MAKE_PY_FROM_CSR,
-            throw std::invalid_argument("Not avalible to convert a scipy.csr"));
+            throw std::invalid_argument("Unable to convert scipy csr object"));
 #undef MAKE_PY_FROM_CSR
     }
     else {

--- a/onedal/datatypes/data_conversion.cpp
+++ b/onedal/datatypes/data_conversion.cpp
@@ -154,6 +154,13 @@ inline csr_table_t convert_to_csr_impl(PyObject *py_data,
 
 dal::table convert_to_table(py::object inp_obj, py::object queue) {
     dal::table res;
+
+    PyObject *obj = inp_obj.ptr();
+
+    if (obj == nullptr || obj == Py_None) {
+        return res;
+    }
+
 #ifdef ONEDAL_DATA_PARALLEL
     if (!queue.is(py::none()) && !queue.attr("sycl_device").attr("has_aspect_fp64").cast<bool>() &&
         hasattr(inp_obj, "dtype")) {
@@ -174,11 +181,6 @@ dal::table convert_to_table(py::object inp_obj, py::object queue) {
     }
 #endif // ONEDAL_DATA_PARALLEL
 
-    PyObject *obj = inp_obj.ptr();
-
-    if (obj == nullptr || obj == Py_None) {
-        return res;
-    }
     if (is_array(obj)) {
         PyArrayObject *ary = reinterpret_cast<PyArrayObject *>(obj);
 

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -452,7 +452,7 @@ def test_non_array(X, queue):
     err_str = ""
 
     if np.isscalar(X):
-        if np.atleast_2d(X).dtype not in [np.float64, np.float32, np.int64]:
+        if np.atleast_2d(X).dtype not in [np.float64, np.float32, np.ulong, np.long]:
             err_str = "Found unsupported array type"
     elif not (X is None or isinstance(X, np.ndarray)):
         err_str = r"\[convert_to_table\] Not available input format for convert Python object to onedal table."

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -451,9 +451,13 @@ def test_non_array(X, queue):
     # no guarantee is made about type or content
     err_str = ""
 
-    if np.isscalar(X) and np.atleast2d(X).dtype not in [np.float64, np.float32, np.int64]:
+    if np.isscalar(X) and np.atleast_2d(X).dtype not in [
+        np.float64,
+        np.float32,
+        np.int64,
+    ]:
         err_str = "[convert_to_table] Not available input format for convert Python object to onedal table."
-    elif not (X is None or isinstance(X, np.array)):
+    elif not (X is None or isinstance(X, np.ndarray)):
         err_str = "Found unsupported array type"
 
     if err_str:

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -470,8 +470,7 @@ def test_non_array(X, queue):
     not _is_dpc_backend, reason="Requires DPC backend for dtype conversion"
 )
 @pytest.mark.parametrize("X", [None, 5, "test", True, [], np.pi, lambda: None])
-@pytest.mark.parametrize("sparse", [True, False])
-def test_low_precision_non_array(X, sparse):
+def test_low_precision_non_array(X):
     # Use a dummy queue as fp32 hardware is not in public testing
 
     class DummySyclQueue:

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -451,12 +451,9 @@ def test_non_array(X, queue):
     # no guarantee is made about type or content
     err_str = ""
 
-    if np.isscalar(X) and np.atleast_2d(X).dtype not in [
-        np.float64,
-        np.float32,
-        np.int64,
-    ]:
-        err_str = "[convert_to_table] Not available input format for convert Python object to onedal table."
+    if np.isscalar(X):
+        if np.atleast_2d(X).dtype not in [np.float64, np.float32, np.int64]:
+            err_str = "[convert_to_table] Not available input format for convert Python object to onedal table."
     elif not (X is None or isinstance(X, np.ndarray)):
         err_str = "Found unsupported array type"
 

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -455,7 +455,7 @@ def test_non_array(X, queue):
         if np.atleast_2d(X).dtype not in [np.float64, np.float32, np.int64]:
             err_str = "Found unsupported array type"
     elif not (X is None or isinstance(X, np.ndarray)):
-        err_str = "[convert_to_table] Not available input format for convert Python object to onedal table."
+        err_str = r"\[convert_to_table\] Not available input format for convert Python object to onedal table."
 
     if err_str:
         with pytest.raises(ValueError, match=err_str):

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -450,12 +450,10 @@ def test_non_array(X, queue):
     # Verify that to and from table doesn't raise errors
     # no guarantee is made about type or content
     err_str = ""
-    if np.isscalar(X) or X is None:
-        temp = np.atleast_2d(X)
-        if temp.dtype not in [np.float64, np.float32, np.int64]:
-            err_str = "[convert_to_table] Not available input format for convert Python object to onedal table."
 
-    else:
+    if np.isscalar(X) and np.atleast2d(X).dtype not in [np.float64, np.float32, np.int64]:
+        err_str = "[convert_to_table] Not available input format for convert Python object to onedal table."
+    elif not (X is None or isinstance(X, np.array)):
         err_str = "Found unsupported array type"
 
     if err_str:

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -453,9 +453,9 @@ def test_non_array(X, queue):
 
     if np.isscalar(X):
         if np.atleast_2d(X).dtype not in [np.float64, np.float32, np.int64]:
-            err_str = "[convert_to_table] Not available input format for convert Python object to onedal table."
+            err_str = "Found unsupported array type"
     elif not (X is None or isinstance(X, np.ndarray)):
-        err_str = "Found unsupported array type"
+        err_str = "[convert_to_table] Not available input format for convert Python object to onedal table."
 
     if err_str:
         with pytest.raises(ValueError, match=err_str):

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -452,7 +452,7 @@ def test_non_array(X, queue):
     err_str = ""
 
     if np.isscalar(X):
-        if np.atleast_2d(X).dtype not in [np.float64, np.float32, np.ulong, np.long]:
+        if np.atleast_2d(X).dtype not in [np.float64, np.float32, np.int64, np.int32]:
             err_str = "Found unsupported array type"
     elif not (X is None or isinstance(X, np.ndarray)):
         err_str = r"\[convert_to_table\] Not available input format for convert Python object to onedal table."


### PR DESCRIPTION
## Description

This fixes an issue discovered in #2253 where it would try to query the dtype of a ```None``` object. First must be checked if it is an array, then the necessary dtype verification should occur.  This error only arises for SYCL GPUs which do not have the ```fp64_aspect```.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
