### PR TITLE
[testing] remove pytest skips associated with GPUs from ```test_data.py```

### DIFF
--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -128,8 +128,6 @@ def _test_input_format_f_contiguous_numpy(queue, dtype):
 @pytest.mark.parametrize("queue", get_queues())
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_input_format_f_contiguous_numpy(queue, dtype):
-    if queue and queue.sycl_device.is_gpu:
-        pytest.skip("Sporadic failures on GPU sycl_queue.")
     _test_input_format_f_contiguous_numpy(queue, dtype)
 
 

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -108,8 +108,6 @@ def _test_input_format_c_contiguous_numpy(queue, dtype):
 @pytest.mark.parametrize("queue", get_queues())
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_input_format_c_contiguous_numpy(queue, dtype):
-    if queue and queue.sycl_device.is_gpu:
-        pytest.skip("Sporadic failures on GPU sycl_queue.")
     _test_input_format_c_contiguous_numpy(queue, dtype)
 
 
@@ -156,8 +154,6 @@ def _test_input_format_c_not_contiguous_numpy(queue, dtype):
 @pytest.mark.parametrize("queue", get_queues())
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_input_format_c_not_contiguous_numpy(queue, dtype):
-    if queue and queue.sycl_device.is_gpu:
-        pytest.skip("Sporadic failures on GPU sycl_queue.")
     _test_input_format_c_not_contiguous_numpy(queue, dtype)
 
 
@@ -180,8 +176,6 @@ def _test_input_format_c_contiguous_pandas(queue, dtype):
 @pytest.mark.parametrize("queue", get_queues())
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_input_format_c_contiguous_pandas(queue, dtype):
-    if queue and queue.sycl_device.is_gpu:
-        pytest.skip("Sporadic failures on GPU sycl_queue.")
     _test_input_format_c_contiguous_pandas(queue, dtype)
 
 
@@ -204,8 +198,6 @@ def _test_input_format_f_contiguous_pandas(queue, dtype):
 @pytest.mark.parametrize("queue", get_queues())
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_input_format_f_contiguous_pandas(queue, dtype):
-    if queue and queue.sycl_device.is_gpu:
-        pytest.skip("Sporadic failures on GPU sycl_queue.")
     _test_input_format_f_contiguous_pandas(queue, dtype)
 
 


### PR DESCRIPTION
## Description

Looks to be that there are some very old test skips from ```onedal/datatypes/test_data.py``` introduced in #772 that can be removed. This has no impact on performance.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
