### PR TITLE
[testing] re-enable some GPU sklearn conformance tests

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -384,6 +384,18 @@ public:
 gpu:
   # Segfaults
   - ensemble/tests/test_weight_boosting.py
+  # Fails
+  - cluster/tests/test_dbscan.py::test_weighted_dbscan
+  - model_selection/tests/test_search.py::test_unsupervised_grid_search
+  - ensemble/tests/test_voting.py::test_sample_weight[42]
+  - model_selection/tests/test_search.py::test_search_default_iid
+  - neighbors/tests/test_neighbors.py::test_unsupervised_kneighbors
+  - neighbors/tests/test_neighbors.py::test_neighbors_metrics[float64-l2]
+  - svm/tests/test_svm.py::test_svm_classifier_sided_sample_weight[estimator0]
+  - svm/tests/test_svm.py::test_svm_equivalence_sample_weight_C
+  - svm/tests/test_svm.py::test_negative_weights_svc_leave_two_labels[partial-mask-label-1-SVC]
+  - svm/tests/test_svm.py::test_negative_weights_svc_leave_two_labels[partial-mask-label-2-SVC]
+  
   # sparse input is not implemented for DBSCAN.
   - tests/test_common.py::test_estimators[RandomForestClassifier()-check_class_weight_classifiers]
   - tests/test_common.py::test_estimators[SVC()-check_sample_weights_not_an_array]
@@ -400,6 +412,23 @@ gpu:
   - neighbors/tests/test_neighbors.py::test_neigh_predictions_algorithm_agnosticity[float64-KNeighborsClassifier-100-1000-l2-1000-5-100]
   - neighbors/tests/test_neighbors.py::test_neigh_predictions_algorithm_agnosticity[float64-KNeighborsRegressor-50-500-l2-1000-5-100]
   - neighbors/tests/test_neighbors.py::test_neigh_predictions_algorithm_agnosticity[float64-KNeighborsRegressor-100-1000-l2-1000-5-100]
+  # GPU Forest algorithm implementation does not follow certain Scikit-learn standards
+  - ensemble/tests/test_forest.py::test_max_leaf_nodes_max_depth
+  - ensemble/tests/test_forest.py::test_min_samples_split[ExtraTreesClassifier]
+  - ensemble/tests/test_forest.py::test_min_samples_split[RandomForestClassifier]
+  - ensemble/tests/test_forest.py::test_min_samples_split[ExtraTreesRegressor]
+  - ensemble/tests/test_forest.py::test_max_samples_boundary_regressors
+
+  # numerical issues in GPU Forest algorithms which require further investigation
+  - ensemble/tests/test_voting.py::test_predict_on_toy_problem[42]
+  - tests/test_common.py::test_estimators[ExtraTreesClassifier()-check_class_weight_classifiers]
+  - tests/test_common.py::test_estimators[ExtraTreesRegressor()-check_sample_weights_invariance(kind=zeros)]
+  - tests/test_common.py::test_estimators[RandomForestRegressor()-check_regressor_data_not_an_array]
+
+  # GPU implementation of Extra Trees doesn't support sample_weights
+  # comparisons to GPU with sample weights will use different algorithms
+  - tests/test_common.py::test_estimators[ExtraTreesClassifier()-check_sample_weights_invariance(kind=zeros)]
+  - tests/test_common.py::test_estimators[ExtraTreesRegressor()-check_sample_weights_invariance(kind=ones)]
 
   # RuntimeError: Device support is not implemented, failing as result of fallback to cpu false
   - svm/tests/test_svm.py::test_unfitted

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -395,7 +395,6 @@ gpu:
   - svm/tests/test_svm.py::test_svm_equivalence_sample_weight_C
   - svm/tests/test_svm.py::test_negative_weights_svc_leave_two_labels[partial-mask-label-1-SVC]
   - svm/tests/test_svm.py::test_negative_weights_svc_leave_two_labels[partial-mask-label-2-SVC]
-  
   # sparse input is not implemented for DBSCAN.
   - tests/test_common.py::test_estimators[RandomForestClassifier()-check_class_weight_classifiers]
   - tests/test_common.py::test_estimators[SVC()-check_sample_weights_not_an_array]
@@ -427,6 +426,7 @@ gpu:
 
   # GPU implementation of Extra Trees doesn't support sample_weights
   # comparisons to GPU with sample weights will use different algorithms
+  - tests/test_common.py::test_estimators[ExtraTreesClassifier()-check_sample_weights_invariance(kind=ones)]
   - tests/test_common.py::test_estimators[ExtraTreesClassifier()-check_sample_weights_invariance(kind=zeros)]
   - tests/test_common.py::test_estimators[ExtraTreesRegressor()-check_sample_weights_invariance(kind=ones)]
 

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -384,26 +384,6 @@ public:
 gpu:
   # Segfaults
   - ensemble/tests/test_weight_boosting.py
-  # Fails
-  - cluster/tests/test_dbscan.py::test_weighted_dbscan
-  - cluster/tests/test_k_means.py::test_kmeans_elkan_results[42-1e-100-sparse-normal]
-  - model_selection/tests/test_search.py::test_unsupervised_grid_search
-  - ensemble/tests/test_bagging.py::test_estimators_samples
-  - ensemble/tests/test_voting.py::test_sample_weight
-  - metrics/tests/test_score_objects.py::test_average_precision_pos_label
-  - model_selection/tests/test_search.py::test_search_default_iid
-  - neighbors/tests/test_neighbors.py::test_unsupervised_kneighbors
-  - neighbors/tests/test_neighbors.py::test_neighbors_metrics
-  - svm/tests/test_sparse.py::test_svc
-  - svm/tests/test_sparse.py::test_svc_iris
-  - svm/tests/test_sparse.py::test_sparse_realdata
-  - svm/tests/test_svm.py::test_precomputed
-  - svm/tests/test_svm.py::test_tweak_params
-  - svm/tests/test_svm.py::test_svm_classifier_sided_sample_weight[estimator0]
-  - svm/tests/test_svm.py::test_svm_equivalence_sample_weight_C
-  - svm/tests/test_svm.py::test_negative_weights_svc_leave_two_labels[partial-mask-label-1-SVC]
-  - svm/tests/test_svm.py::test_negative_weights_svc_leave_two_labels[partial-mask-label-2-SVC]
-  - svm/tests/test_svm.py::test_svc_clone_with_callable_kernel
   # sparse input is not implemented for DBSCAN.
   - tests/test_common.py::test_estimators[RandomForestClassifier()-check_class_weight_classifiers]
   - tests/test_common.py::test_estimators[SVC()-check_sample_weights_not_an_array]
@@ -415,53 +395,11 @@ gpu:
   # Segmentation faults on GPU
   - tests/test_common.py::test_search_cv
 
-  # Other device issues
-  - tests/test_multioutput.py::test_classifier_chain_tuple_order[list]
-  - tests/test_multioutput.py::test_classifier_chain_tuple_order[tuple]
   # KD Tree (not implemented for GPU)
   - neighbors/tests/test_neighbors.py::test_neigh_predictions_algorithm_agnosticity[float64-KNeighborsClassifier-50-500-l2-1000-5-100]
   - neighbors/tests/test_neighbors.py::test_neigh_predictions_algorithm_agnosticity[float64-KNeighborsClassifier-100-1000-l2-1000-5-100]
   - neighbors/tests/test_neighbors.py::test_neigh_predictions_algorithm_agnosticity[float64-KNeighborsRegressor-50-500-l2-1000-5-100]
   - neighbors/tests/test_neighbors.py::test_neigh_predictions_algorithm_agnosticity[float64-KNeighborsRegressor-100-1000-l2-1000-5-100]
-  # failing due to numeric/code error
-  - linear_model/tests/test_common.py::test_balance_property[42-False-LogisticRegressionCV]
-  - sklearn/manifold/tests/test_t_sne.py::test_n_iter_without_progress
-  - model_selection/tests/test_search.py::test_searchcv_raise_warning_with_non_finite_score[RandomizedSearchCV-specialized_params1-False]
-  - model_selection/tests/test_search.py::test_searchcv_raise_warning_with_non_finite_score[RandomizedSearchCV-specialized_params1-True]
-  - tests/test_calibration.py::test_calibrated_classifier_cv_double_sample_weights_equivalence
-  - tests/test_calibration.py::test_calibrated_classifier_cv_zeros_sample_weights_equivalence
-  - tests/test_common.py::test_estimators[FeatureAgglomeration()-check_parameters_default_constructible]
-  - neighbors/tests/test_lof.py::test_novelty_true_common_tests[LocalOutlierFactor(novelty=True)-check_methods_subset_invariance]
-  - tests/test_common.py::test_transformers_get_feature_names_out[StackingRegressor(estimators=[('est1',Ridge(alpha=0.1)),('est2',Ridge(alpha=1))])]
-  - tests/test_common.py::test_transformers_get_feature_names_out[VotingRegressor(estimators=[('est1',Ridge(alpha=0.1)),('est2',Ridge(alpha=1))])]
-  - tests/test_common.py::test_f_contiguous_array_estimator[TSNE]
-  - manifold/tests/test_t_sne.py::test_tsne_works_with_pandas_output
-
-  # GPU Forest algorithm implementation does not follow certain Scikit-learn standards
-  - ensemble/tests/test_forest.py::test_max_leaf_nodes_max_depth
-  - ensemble/tests/test_forest.py::test_min_samples_split[ExtraTreesClassifier]
-  - ensemble/tests/test_forest.py::test_min_samples_split[RandomForestClassifier]
-  - ensemble/tests/test_forest.py::test_min_samples_split[ExtraTreesRegressor]
-  - ensemble/tests/test_forest.py::test_max_samples_boundary_regressors
-
-  # numerical issues in GPU Forest algorithms which require further investigation
-  - ensemble/tests/test_voting.py::test_predict_on_toy_problem[42]
-  - tests/test_common.py::test_estimators[ExtraTreesClassifier()-check_class_weight_classifiers]
-  - tests/test_common.py::test_estimators[ExtraTreesRegressor()-check_sample_weights_invariance(kind=zeros)]
-  - tests/test_common.py::test_estimators[RandomForestRegressor()-check_regressor_data_not_an_array]
-  - ensemble/tests/test_forest.py::test_max_samples_boundary_classifiers[ExtraTreesClassifier]
-  - tests/test_common.py::test_estimators[ExtraTreesClassifier()-check_classifier_data_not_an_array]
-  - tests/test_common.py::test_estimators[ExtraTreesClassifier()-check_classifiers_train]
-  - tests/test_common.py::test_estimators[ExtraTreesClassifier()-check_classifiers_train(readonly_memmap=True)]
-  - tests/test_common.py::test_estimators[ExtraTreesClassifier()-check_fit_idempotent]
-  - tests/test_common.py::test_estimators[ExtraTreesRegressor()-check_fit_idempotent]
-  - tests/test_common.py::test_estimators[ExtraTreesRegressor()-check_regressor_data_not_an_array]
-
-  # GPU implementation of Extra Trees doesn't support sample_weights
-  # comparisons to GPU with sample weights will use different algorithms
-  - tests/test_common.py::test_estimators[ExtraTreesClassifier()-check_sample_weights_invariance(kind=ones)]
-  - tests/test_common.py::test_estimators[ExtraTreesClassifier()-check_sample_weights_invariance(kind=zeros)]
-  - tests/test_common.py::test_estimators[ExtraTreesRegressor()-check_sample_weights_invariance(kind=ones)]
 
   # RuntimeError: Device support is not implemented, failing as result of fallback to cpu false
   - svm/tests/test_svm.py::test_unfitted


### PR DESCRIPTION
## Description

Intel CI runs GPU sklearn conformance testing. Previously, it ran without dpctl, meaning that the DummySyclQueue was forcing computation with sklearn to float32, causing some test failures.  With changes in the Intel CI using dpctl, and with the removal of the DummySyclQueue in #2152, sklearn conformance testing with fp64 hardware can pass these tests either with or without dpctl.  Therefore, these tests can now be re-enabled. Approximately 30 tests are now re-enabled.

No performance benchmarks necessary.

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
