### PR TITLE
ENH: Accept `I_MPI_ROOT` as fallback to `MPIROOT`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -162,7 +162,7 @@ The build-process (using setup.py) happens in 4 stages:
 ### Configure the Build with Environment Variables
 * ``SKLEARNEX_VERSION``: sets the package version
 * ``DALROOT``: sets the oneAPI Data Analytics Library path
-* ``MPIROOT``: sets the path to the MPI library that will be used for distributed mode support. Not used when using `NO_DIST=1`
+* ``MPIROOT``: sets the path to the MPI library that will be used for distributed mode support. If this variable is not set but `I_MPI_ROOT` is found, will use `I_MPI_ROOT` instead. Not used when using `NO_DIST=1`
 * ``NO_DIST``: set to '1', 'yes' or alike to build without support for distributed mode
 * ``NO_STREAM``: set to '1', 'yes' or alike to build without support for streaming mode
 * ``NO_DPC``: set to '1', 'yes' or alike to build without support of oneDAL DPC++ interfaces

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,12 @@ no_dpc = True if "NO_DPC" in os.environ and os.environ["NO_DPC"] in trues else F
 no_stream = "NO_STREAM" in os.environ and os.environ["NO_STREAM"] in trues
 use_gcov = "SKLEARNEX_GCOV" in os.environ and os.environ["SKLEARNEX_GCOV"] in trues
 debug_build = os.getenv("DEBUG_BUILD") == "1"
-mpi_root = None if no_dist else os.environ["MPIROOT"]
+mpi_root = None if no_dist else os.environ.get("MPIROOT", os.environ.get("I_MPI_ROOT"))
+if (not no_dist) and (mpi_root is None):
+    raise ValueError(
+        "'MPIROOT' is not set, cannot build with distributed mode."
+        " Use 'NO_DIST=1' to build without distributed mode."
+    )
 dpcpp = (
     shutil.which("icpx") is not None
     and "onedal_dpc" in get_onedal_shared_libs(dal_root)


### PR DESCRIPTION
## Description

_Add a comprehensive description of proposed changes_

_List associated issue number(s) if exist(s): #6 (for example)_

_Documentation PR (if needed): #1340 (for example)_

_Benchmarks PR (if needed): https://github.com/IntelPython/scikit-learn_bench/pull/155 (for example)_

---

Intel's MPI activation script sets an environment variable `${I_MPI_ROOT}`. This variable gets added automatically by e.g. the oneAPI env. sourcing script, whereas `${MPIROOT}` requires manual definition and it's not an obvious step.

This PR modifies the setup script to use `${I_MPI_ROOT}` when that variable is set but `${MPIROOT}` isn't.

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
