### PR TITLE
[enhancement] array_api acceleration for sklearnex's ```validate_data``` and ```_check_sample_weight```

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -65,7 +65,8 @@ header:
     # Specific files
     - 'setup.cfg'
     - 'LICENSE'
-
+    # External copies of copyrighted work
+    - 'onedal/datatypes/dlpack/dlpack.h'
   comment: never
 
   license-location-threshold: 80 # specifies the index threshold where the license header can be located.

--- a/doc/third-party-programs-sklearnex.txt
+++ b/doc/third-party-programs-sklearnex.txt
@@ -242,7 +242,7 @@ DAMAGE.
 -------------------------------------------------------------
 
 3. Cython
-Apache License
+                                 Apache License
                            Version 2.0, January 2004
                         https://www.apache.org/licenses/
 
@@ -418,6 +418,211 @@ Apache License
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+-------------------------------------------------------------
+
+3. DLPack
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 by Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
 -------------------------------------------------------------
 

--- a/onedal/datatypes/dlpack/data_conversion.cpp
+++ b/onedal/datatypes/dlpack/data_conversion.cpp
@@ -181,7 +181,7 @@ dal::table convert_to_table(py::object obj, py::object q_obj) {
     return res;
 }
 
-py::object dlpack_memory_order(py::capsule dlpack){
+py::object dlpack_memory_order(py::capsule dlpack) {
     DLManagedTensor* dlm;
     DLManagedTensorVersioned* dlmv;
     DLTensor tensor;
@@ -202,19 +202,11 @@ py::object dlpack_memory_order(py::capsule dlpack){
         throw std::runtime_error("unable to extract dltensor");
     }
 
-    switch(convert_dlpack_to_dal_type(tensor.dtype)) {
-        case dal::data_layout::row_major:
-            return py::str("C")
-        break;
-        case dal::data_layout::column_major:
-            return py::str("F");
-        break;
-        default:
-            return py::none();
-}
-
+    switch (convert_dlpack_to_dal_type(tensor.dtype)) {
+        case dal::data_layout::row_major: return py::str("C") break;
+        case dal::data_layout::column_major: return py::str("F"); break;
+        default: return py::none();
+    }
 };
-
-
 
 } // namespace oneapi::dal::python::dlpack

--- a/onedal/datatypes/dlpack/data_conversion.cpp
+++ b/onedal/datatypes/dlpack/data_conversion.cpp
@@ -1,0 +1,183 @@
+/*******************************************************************************
+* Copyright Contributors to the oneDAL project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/table/homogen.hpp"
+#include "oneapi/dal/table/detail/homogen_utils.hpp"
+
+#include "onedal/datatypes/dlpack/data_conversion.hpp"
+
+#ifdef ONEDAL_DATA_PARALLEL
+#include "onedal/common/sycl_interfaces.hpp"
+#endif // ONEDAL_DATA_PARALLEL
+
+namespace oneapi::dal::python::dlpack {
+
+template <typename T, typename managed_t>
+inline dal::homogen_table convert_to_homogen_impl(managed_t* dlm_tensor,
+                                                  bool readonly,
+                                                  py::object q_obj) {
+    dal::homogen_table res{};
+
+    DLTensor tensor = dlm_tensor->dl_tensor;
+
+    // if a nullptr, return an empty.
+    if (!tensor.data) {
+        return res;
+    }
+
+    // Get pointer to the data following dlpack.h conventions.
+    // use static cast because data is known to be void*, and reintrepret_cast
+    // since we know that T* is of a set specific types that we will guarantee
+    // for the compiler.
+    const auto* const ptr =
+        reinterpret_cast<const T*>(static_cast<char*>(tensor.data) + tensor.byte_offset);
+
+    // get shape, if 1 dimensional, force col count to 1
+    std::int64_t row_count, col_count;
+    row_count = tensor.shape[0];
+    col_count = get_ndim(tensor) == 1 ? 1l : tensor.shape[1];
+
+    // get data layout for homogeneous check
+    const dal::data_layout layout = get_dlpack_layout(tensor);
+
+    // create the dlpack deleter, which requires calling the deleter from the managed DL tensor.
+    // This must be done instead of a decref, as the data doesn't necessarily come from python,
+    // It is expected that deleter handles memory cleanup (including possible python decrefs)
+    const auto deleter = [dlm_tensor](const T* data) {
+        if (dlm_tensor->deleter != nullptr) {
+            dlm_tensor->deleter(dlm_tensor);
+        }
+    };
+
+    // check_dlpack_oneAPI_device will check if data is on a oneAPI device. If it is on an
+    // unsupported device it will throw an error.
+    if (check_dlpack_oneAPI_device(tensor.device.device_type)) {
+#ifdef ONEDAL_DATA_PARALLEL
+        // if located on a SYCL device, use the queue.
+#define MAKE_QUEUED_HOMOGEN(pointer)                     \
+    res = dal::homogen_table(queue,                      \
+                             pointer,                    \
+                             row_count,                  \
+                             col_count,                  \
+                             deleter,                    \
+                             std::vector<sycl::event>{}, \
+                             layout);
+        // generate queue from dlpack device information
+        // If a queue is given, it will override the general queue that would be generated
+        // from get_queue_by_device_id. Note, this behavior only occurs if on a oneAPI device.
+        sycl::queue queue;
+        queue = !q_obj.is(py::none()) ? get_queue_from_python(q_obj)
+                                      : get_queue_by_device_id(tensor.device.device_id);
+
+        if (readonly) {
+            MAKE_QUEUED_HOMOGEN(ptr);
+        }
+        else {
+            auto* const mut_ptr = const_cast<T*>(ptr);
+            MAKE_QUEUED_HOMOGEN(mut_ptr);
+        }
+        return res;
+#else
+        throw std::invalid_argument(
+            "Input array located on a oneAPI device, but sklearnex installation does not have SYCL support.");
+#endif
+    }
+
+    if (readonly) {
+        res = dal::homogen_table(ptr, row_count, col_count, deleter, layout);
+    }
+    else {
+        auto* const mut_ptr = const_cast<T*>(ptr);
+        res = dal::homogen_table(mut_ptr, row_count, col_count, deleter, layout);
+    }
+
+    return res;
+}
+
+dal::table convert_to_table(py::object obj, py::object q_obj) {
+    dal::table res;
+    bool versioned = false;
+    // Versioned has a readonly flag that can be used to block modification
+    bool readonly = false;
+    DLManagedTensor* dlm;
+    DLManagedTensorVersioned* dlmv;
+    DLTensor tensor;
+    dal::data_type dtype;
+
+    // extract __dlpack__ attribute from the input obj. This function should
+    // only be called if the attribute has been checked.
+    py::capsule caps = obj.attr("__dlpack__")();
+
+    // two different types of dlpack managed tensors are possible, with
+    // DLManagedTensor likely to be removed from future versions of dlpack.
+    // collect important aspects necessary for the macro offloading.
+    PyObject* capsule = caps.ptr();
+    if (PyCapsule_IsValid(capsule, "dltensor")) {
+        dlm = caps.get_pointer<DLManagedTensor>();
+        tensor = dlm->dl_tensor;
+    }
+    else if (PyCapsule_IsValid(capsule, "dltensor_versioned")) {
+        dlmv = caps.get_pointer<DLManagedTensorVersioned>();
+        if (dlmv->version.major > DLPACK_MAJOR_VERSION) {
+            throw std::runtime_error("dlpack tensor version newer than supported");
+        }
+        tensor = dlmv->dl_tensor;
+        versioned = true;
+        readonly = (dlmv->flags & DLPACK_FLAG_BITMASK_READ_ONLY) != 0;
+    }
+    else {
+        throw std::runtime_error("unable to extract dltensor");
+    }
+
+    // Extract and convert a DLpack data type into a oneDAL dtype.
+    dtype = convert_dlpack_to_dal_type(tensor.dtype);
+
+    // if there is a queue, check that the data matches the necessary precision.
+#ifdef ONEDAL_DATA_PARALLEL
+    if (!q_obj.is(py::none()) && !q_obj.attr("sycl_device").attr("has_aspect_fp64").cast<bool>() &&
+        dtype == dal::data_type::float64) {
+        // If the queue exists, doesn't have the fp64 aspect, and the data is float64
+        // then cast it to float32 (using reduce_precision)
+        py::object copy = reduce_precision(obj);
+        res = convert_to_table(copy, q_obj);
+        return res;
+    }
+#endif // ONEDAL_DATA_PARALLEL
+
+    // unusual data format found, try to make contiguous, otherwise throw error
+    // error throw located in regenerate_layout
+    if (get_dlpack_layout(tensor) == dal::data_layout::unknown) {
+        // NOTE: this attempts to make a contiguous deep copy of the data
+        // if possible, this is expected to be a special case
+        py::object copy = regenerate_layout(obj);
+        res = convert_to_table(copy, q_obj);
+        return res;
+    }
+
+#define MAKE_HOMOGEN_TABLE(CType)                                                               \
+    res = versioned                                                                             \
+              ? convert_to_homogen_impl<CType, DLManagedTensorVersioned>(dlmv, readonly, q_obj) \
+              : convert_to_homogen_impl<CType, DLManagedTensor>(dlm, readonly, q_obj);
+    SET_CTYPE_FROM_DAL_TYPE(dtype,
+                            MAKE_HOMOGEN_TABLE,
+                            throw std::invalid_argument("Found unsupported array type"));
+#undef MAKE_HOMOGEN_TABLE
+
+    // take ownership of the capsule, this is important to prevent data deletion
+    dlpack_take_ownership(caps);
+    return res;
+}
+} // namespace oneapi::dal::python::dlpack

--- a/onedal/datatypes/dlpack/data_conversion.hpp
+++ b/onedal/datatypes/dlpack/data_conversion.hpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+* Copyright Contributors to the oneDAL project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#ifdef ONEDAL_DATA_PARALLEL
+#include <sycl/sycl.hpp>
+#endif // ONEDAL_DATA_PARALLEL
+
+#include <pybind11/pybind11.h>
+
+#include "onedal/datatypes/dlpack/dlpack_utils.hpp"
+
+#include "oneapi/dal/table/common.hpp"
+
+namespace oneapi::dal::python::dlpack {
+
+namespace py = pybind11;
+
+dal::table convert_to_table(py::object obj, py::object q_obj = py::none());
+
+} // namespace oneapi::dal::python::dlpack

--- a/onedal/datatypes/dlpack/data_conversion.hpp
+++ b/onedal/datatypes/dlpack/data_conversion.hpp
@@ -35,4 +35,6 @@ namespace py = pybind11;
 
 dal::table convert_to_table(py::object obj, py::object q_obj = py::none());
 
+py::object dlpack_memory_order(py::capsule dlpack);
+
 } // namespace oneapi::dal::python::dlpack

--- a/onedal/datatypes/dlpack/dlpack.h
+++ b/onedal/datatypes/dlpack/dlpack.h
@@ -1,0 +1,332 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file dlpack.h
+ * \brief The common header of DLPack.
+ */
+#ifndef DLPACK_DLPACK_H_
+#define DLPACK_DLPACK_H_
+
+/**
+ * \brief Compatibility with C++
+ */
+#ifdef __cplusplus
+#define DLPACK_EXTERN_C extern "C"
+#else
+#define DLPACK_EXTERN_C
+#endif
+
+/*! \brief The current major version of dlpack */
+#define DLPACK_MAJOR_VERSION 1
+
+/*! \brief The current minor version of dlpack */
+#define DLPACK_MINOR_VERSION 0
+
+/*! \brief DLPACK_DLL prefix for windows */
+#ifdef _WIN32
+#ifdef DLPACK_EXPORTS
+#define DLPACK_DLL __declspec(dllexport)
+#else
+#define DLPACK_DLL __declspec(dllimport)
+#endif
+#else
+#define DLPACK_DLL
+#endif
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * \brief The DLPack version.
+ *
+ * A change in major version indicates that we have changed the
+ * data layout of the ABI - DLManagedTensorVersioned.
+ *
+ * A change in minor version indicates that we have added new
+ * code, such as a new device type, but the ABI is kept the same.
+ *
+ * If an obtained DLPack tensor has a major version that disagrees
+ * with the version number specified in this header file
+ * (i.e. major != DLPACK_MAJOR_VERSION), the consumer must call the deleter
+ * (and it is safe to do so). It is not safe to access any other fields
+ * as the memory layout will have changed.
+ *
+ * In the case of a minor version mismatch, the tensor can be safely used as
+ * long as the consumer knows how to interpret all fields. Minor version
+ * updates indicate the addition of enumeration values.
+ */
+typedef struct {
+    /*! \brief DLPack major version. */
+    uint32_t major;
+    /*! \brief DLPack minor version. */
+    uint32_t minor;
+} DLPackVersion;
+
+/*!
+ * \brief The device type in DLDevice.
+ */
+#ifdef __cplusplus
+typedef enum : int32_t {
+#else
+typedef enum {
+#endif
+    /*! \brief CPU device */
+    kDLCPU = 1,
+    /*! \brief CUDA GPU device */
+    kDLCUDA = 2,
+    /*!
+   * \brief Pinned CUDA CPU memory by cudaMallocHost
+   */
+    kDLCUDAHost = 3,
+    /*! \brief OpenCL devices. */
+    kDLOpenCL = 4,
+    /*! \brief Vulkan buffer for next generation graphics. */
+    kDLVulkan = 7,
+    /*! \brief Metal for Apple GPU. */
+    kDLMetal = 8,
+    /*! \brief Verilog simulator buffer */
+    kDLVPI = 9,
+    /*! \brief ROCm GPUs for AMD GPUs */
+    kDLROCM = 10,
+    /*!
+   * \brief Pinned ROCm CPU memory allocated by hipMallocHost
+   */
+    kDLROCMHost = 11,
+    /*!
+   * \brief Reserved extension device type,
+   * used for quickly test extension device
+   * The semantics can differ depending on the implementation.
+   */
+    kDLExtDev = 12,
+    /*!
+   * \brief CUDA managed/unified memory allocated by cudaMallocManaged
+   */
+    kDLCUDAManaged = 13,
+    /*!
+   * \brief Unified shared memory allocated on a oneAPI non-partititioned
+   * device. Call to oneAPI runtime is required to determine the device
+   * type, the USM allocation type and the sycl context it is bound to.
+   *
+   */
+    kDLOneAPI = 14,
+    /*! \brief GPU support for next generation WebGPU standard. */
+    kDLWebGPU = 15,
+    /*! \brief Qualcomm Hexagon DSP */
+    kDLHexagon = 16,
+    /*! \brief Microsoft MAIA devices */
+    kDLMAIA = 17,
+} DLDeviceType;
+
+/*!
+ * \brief A Device for Tensor and operator.
+ */
+typedef struct {
+    /*! \brief The device type used in the device. */
+    DLDeviceType device_type;
+    /*!
+   * \brief The device index.
+   * For vanilla CPU memory, pinned memory, or managed memory, this is set to 0.
+   */
+    int32_t device_id;
+} DLDevice;
+
+/*!
+ * \brief The type code options DLDataType.
+ */
+typedef enum {
+    /*! \brief signed integer */
+    kDLInt = 0U,
+    /*! \brief unsigned integer */
+    kDLUInt = 1U,
+    /*! \brief IEEE floating point */
+    kDLFloat = 2U,
+    /*!
+   * \brief Opaque handle type, reserved for testing purposes.
+   * Frameworks need to agree on the handle data type for the exchange to be well-defined.
+   */
+    kDLOpaqueHandle = 3U,
+    /*! \brief bfloat16 */
+    kDLBfloat = 4U,
+    /*!
+   * \brief complex number
+   * (C/C++/Python layout: compact struct per complex number)
+   */
+    kDLComplex = 5U,
+    /*! \brief boolean */
+    kDLBool = 6U,
+} DLDataTypeCode;
+
+/*!
+ * \brief The data type the tensor can hold. The data type is assumed to follow the
+ * native endian-ness. An explicit error message should be raised when attempting to
+ * export an array with non-native endianness
+ *
+ *  Examples
+ *   - float: type_code = 2, bits = 32, lanes = 1
+ *   - float4(vectorized 4 float): type_code = 2, bits = 32, lanes = 4
+ *   - int8: type_code = 0, bits = 8, lanes = 1
+ *   - std::complex<float>: type_code = 5, bits = 64, lanes = 1
+ *   - bool: type_code = 6, bits = 8, lanes = 1 (as per common array library convention, the underlying storage size of bool is 8 bits)
+ */
+typedef struct {
+    /*!
+   * \brief Type code of base types.
+   * We keep it uint8_t instead of DLDataTypeCode for minimal memory
+   * footprint, but the value should be one of DLDataTypeCode enum values.
+   * */
+    uint8_t code;
+    /*!
+   * \brief Number of bits, common choices are 8, 16, 32.
+   */
+    uint8_t bits;
+    /*! \brief Number of lanes in the type, used for vector types. */
+    uint16_t lanes;
+} DLDataType;
+
+/*!
+ * \brief Plain C Tensor object, does not manage memory.
+ */
+typedef struct {
+    /*!
+   * \brief The data pointer points to the allocated data. This will be CUDA
+   * device pointer or cl_mem handle in OpenCL. It may be opaque on some device
+   * types. This pointer is always aligned to 256 bytes as in CUDA. The
+   * `byte_offset` field should be used to point to the beginning of the data.
+   *
+   * Note that as of Nov 2021, multiply libraries (CuPy, PyTorch, TensorFlow,
+   * TVM, perhaps others) do not adhere to this 256 byte aligment requirement
+   * on CPU/CUDA/ROCm, and always use `byte_offset=0`.  This must be fixed
+   * (after which this note will be updated); at the moment it is recommended
+   * to not rely on the data pointer being correctly aligned.
+   *
+   * For given DLTensor, the size of memory required to store the contents of
+   * data is calculated as follows:
+   *
+   * \code{.c}
+   * static inline size_t GetDataSize(const DLTensor* t) {
+   *   size_t size = 1;
+   *   for (tvm_index_t i = 0; i < t->ndim; ++i) {
+   *     size *= t->shape[i];
+   *   }
+   *   size *= (t->dtype.bits * t->dtype.lanes + 7) / 8;
+   *   return size;
+   * }
+   * \endcode
+   *
+   * Note that if the tensor is of size zero, then the data pointer should be
+   * set to `NULL`.
+   */
+    void* data;
+    /*! \brief The device of the tensor */
+    DLDevice device;
+    /*! \brief Number of dimensions */
+    int32_t ndim;
+    /*! \brief The data type of the pointer*/
+    DLDataType dtype;
+    /*! \brief The shape of the tensor */
+    int64_t* shape;
+    /*!
+   * \brief strides of the tensor (in number of elements, not bytes)
+   *  can be NULL, indicating tensor is compact and row-majored.
+   */
+    int64_t* strides;
+    /*! \brief The offset in bytes to the beginning pointer to data */
+    uint64_t byte_offset;
+} DLTensor;
+
+/*!
+ * \brief C Tensor object, manage memory of DLTensor. This data structure is
+ *  intended to facilitate the borrowing of DLTensor by another framework. It is
+ *  not meant to transfer the tensor. When the borrowing framework doesn't need
+ *  the tensor, it should call the deleter to notify the host that the resource
+ *  is no longer needed.
+ *
+ * \note This data structure is used as Legacy DLManagedTensor
+ *       in DLPack exchange and is deprecated after DLPack v0.8
+ *       Use DLManagedTensorVersioned instead.
+ *       This data structure may get renamed or deleted in future versions.
+ *
+ * \sa DLManagedTensorVersioned
+ */
+typedef struct DLManagedTensor {
+    /*! \brief DLTensor which is being memory managed */
+    DLTensor dl_tensor;
+    /*! \brief the context of the original host framework of DLManagedTensor in
+   *   which DLManagedTensor is used in the framework. It can also be NULL.
+   */
+    void* manager_ctx;
+    /*!
+   * \brief Destructor - this should be called
+   * to destruct the manager_ctx  which backs the DLManagedTensor. It can be
+   * NULL if there is no way for the caller to provide a reasonable destructor.
+   * The destructor deletes the argument self as well.
+   */
+    void (*deleter)(struct DLManagedTensor* self);
+} DLManagedTensor;
+
+// bit masks used in in the DLManagedTensorVersioned
+
+/*! \brief bit mask to indicate that the tensor is read only. */
+#define DLPACK_FLAG_BITMASK_READ_ONLY (1UL << 0UL)
+
+/*!
+ * \brief bit mask to indicate that the tensor is a copy made by the producer.
+ *
+ * If set, the tensor is considered solely owned throughout its lifetime by the
+ * consumer, until the producer-provided deleter is invoked.
+ */
+#define DLPACK_FLAG_BITMASK_IS_COPIED (1UL << 1UL)
+
+/*!
+ * \brief A versioned and managed C Tensor object, manage memory of DLTensor.
+ *
+ * This data structure is intended to facilitate the borrowing of DLTensor by
+ * another framework. It is not meant to transfer the tensor. When the borrowing
+ * framework doesn't need the tensor, it should call the deleter to notify the
+ * host that the resource is no longer needed.
+ *
+ * \note This is the current standard DLPack exchange data structure.
+ */
+struct DLManagedTensorVersioned {
+    /*!
+   * \brief The API and ABI version of the current managed Tensor
+   */
+    DLPackVersion version;
+    /*!
+   * \brief the context of the original host framework.
+   *
+   * Stores DLManagedTensorVersioned is used in the
+   * framework. It can also be NULL.
+   */
+    void* manager_ctx;
+    /*!
+   * \brief Destructor.
+   *
+   * This should be called to destruct manager_ctx which holds the DLManagedTensorVersioned.
+   * It can be NULL if there is no way for the caller to provide a reasonable
+   * destructor. The destructor deletes the argument self as well.
+   */
+    void (*deleter)(struct DLManagedTensorVersioned* self);
+    /*!
+   * \brief Additional bitmask flags information about the tensor.
+   *
+   * By default the flags should be set to 0.
+   *
+   * \note Future ABI changes should keep everything until this field
+   *       stable, to ensure that deleter can be correctly called.
+   *
+   * \sa DLPACK_FLAG_BITMASK_READ_ONLY
+   * \sa DLPACK_FLAG_BITMASK_IS_COPIED
+   */
+    uint64_t flags;
+    /*! \brief DLTensor which is being memory managed */
+    DLTensor dl_tensor;
+};
+
+#ifdef __cplusplus
+} // DLPACK_EXTERN_C
+#endif
+#endif // DLPACK_DLPACK_H_

--- a/onedal/datatypes/dlpack/dlpack_utils.cpp
+++ b/onedal/datatypes/dlpack/dlpack_utils.cpp
@@ -1,0 +1,127 @@
+/*******************************************************************************
+* Copyright Contributors to the oneDAL project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <pybind11/pybind11.h>
+
+#include "oneapi/dal/common.hpp"
+#include "oneapi/dal/detail/common.hpp"
+
+#include "onedal/datatypes/dlpack/dlpack.h"
+#include "onedal/datatypes/dlpack/dlpack_utils.hpp"
+#include "onedal/datatypes/dlpack/dtype_conversion.hpp"
+
+namespace py = pybind11;
+
+namespace oneapi::dal::python::dlpack {
+
+using namespace pybind11::literals;
+
+void dlpack_take_ownership(py::capsule& caps) {
+    // take a dlpack tensor and claim ownership by changing its name
+    // this will block the destructor of the managed dlpack tensor
+    // unless the dal table calls it.
+    PyObject* capsule = caps.ptr();
+    if (PyCapsule_IsValid(capsule, "dltensor")) {
+        caps.set_name("used_dltensor");
+    }
+    else if (PyCapsule_IsValid(capsule, "dltensor_versioned")) {
+        caps.set_name("used_dltensor_versioned");
+    }
+    else {
+        throw std::runtime_error("unable to extract dltensor");
+    }
+}
+
+std::int32_t get_ndim(const DLTensor& tensor) {
+    // check if 1 or 2 dimensional, and return the number of dimensions
+    const std::int32_t ndim = tensor.ndim;
+    if (ndim != 2 && ndim != 1) {
+        throw std::length_error("Input array has wrong dimensionality (must be 2d).");
+    }
+    return ndim;
+}
+
+dal::data_layout get_dlpack_layout(const DLTensor& tensor) {
+    // determine the layout of a dlpack tensor
+    // get shape, if 1 dimensional, force col count to 1
+    std::int64_t r_count, c_count;
+    c_count = get_ndim(tensor) == 1 ? 1l : tensor.shape[1];
+    r_count = tensor.shape[0];
+    const std::int64_t* strides = tensor.strides;
+    // if NULL then row major contiguous (see dlpack.h)
+    // if 1 column array, also row major
+    // if strides of rows = c_count elements, and columns = 1, also row major
+    if (strides == NULL || c_count == 1 || (strides[0] == c_count && strides[1] == 1)) {
+        return dal::data_layout::row_major;
+    }
+    else if (strides[0] == 1 && strides[1] == r_count) {
+        return dal::data_layout::column_major;
+    }
+    else {
+        return dal::data_layout::unknown;
+    }
+}
+
+bool check_dlpack_oneAPI_device(const DLDeviceType& device) {
+    // check if dlpack tensor is 1) supported and 2) on a SYCL device
+
+    if (device == DLDeviceType::kDLOneAPI) {
+        return true;
+    }
+    else if (device != DLDeviceType::kDLCPU) {
+#if ONEDAL_DATA_PARALLEL
+        throw std::invalid_argument("Input array not located on a supported device or CPU");
+#else
+        throw std::invalid_argument("Input array not located on CPU");
+#endif
+    }
+    return false;
+}
+
+py::object regenerate_layout(const py::object& obj) {
+    // attempt to use native python commands to get a C- or F-contiguous array
+    py::object copy;
+    if (py::hasattr(obj, "copy")) {
+        copy = obj.attr("copy")();
+    }
+    else if (py::hasattr(obj, "__array_namespace__")) {
+        const auto space = obj.attr("__array_namespace__")();
+        copy = space.attr("asarray")(obj, "copy"_a = true);
+    }
+    else {
+        throw std::runtime_error("Wrong strides");
+    }
+    return copy;
+}
+
+py::object reduce_precision(const py::object& obj) {
+    // attempt to use native python commands to down convert fp64 data to fp32
+    py::object copy;
+    if (hasattr(obj, "__array_namespace__")) {
+        PyErr_WarnEx(
+            PyExc_RuntimeWarning,
+            "Data will be converted into float32 from float64 because device does not support it",
+            1);
+        const auto space = obj.attr("__array_namespace__")();
+        copy = space.attr("astype")(obj, space.attr("float32"));
+    }
+    else {
+        throw std::invalid_argument("Data has higher precision than the supported device");
+    }
+    return copy;
+}
+
+} // namespace oneapi::dal::python::dlpack

--- a/onedal/datatypes/dlpack/dlpack_utils.hpp
+++ b/onedal/datatypes/dlpack/dlpack_utils.hpp
@@ -1,0 +1,35 @@
+/*******************************************************************************
+* Copyright Contributors to the oneDAL project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include <Python.h>
+#include <pybind11/pybind11.h>
+
+#include "onedal/datatypes/dlpack/dtype_conversion.hpp"
+
+namespace py = pybind11;
+
+namespace oneapi::dal::python::dlpack {
+
+void dlpack_take_ownership(py::capsule& caps);
+std::int32_t get_ndim(const DLTensor& caps);
+dal::data_layout get_dlpack_layout(const DLTensor& tensor);
+bool check_dlpack_oneAPI_device(const DLDeviceType& device);
+py::object regenerate_layout(const py::object& obj);
+py::object reduce_precision(const py::object& obj);
+
+} // namespace oneapi::dal::python::dlpack

--- a/onedal/datatypes/dlpack/dtype_conversion.cpp
+++ b/onedal/datatypes/dlpack/dtype_conversion.cpp
@@ -1,0 +1,150 @@
+/*******************************************************************************
+* Copyright Contributors to the oneDAL project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <type_traits>
+#include <unordered_map>
+
+#include "onedal/datatypes/dlpack/dtype_conversion.hpp"
+
+namespace oneapi::dal::python::dlpack {
+
+union type_hash_union {
+    std::uint8_t bytes[4];
+    std::uint16_t halfs[2];
+    std::uint32_t full = 0u;
+
+    constexpr type_hash_union(const DLDataType& t) {
+        bytes[0] = t.code;
+        bytes[1] = t.bits;
+        halfs[1] = t.lanes;
+    }
+};
+
+struct dlpack_type_hash {
+    using type_t = DLDataType;
+    constexpr std::uint32_t operator()(const type_t& type) const {
+        return type_hash_union(type).full;
+    }
+};
+
+struct dlpack_type_equal {
+    using type_t = DLDataType;
+    constexpr bool operator()(const type_t& lhs, const type_t& rhs) const {
+        const auto l = type_hash_union(lhs).full;
+        const auto r = type_hash_union(rhs).full;
+        return l == r;
+    }
+};
+
+using fwd_map_t = std::unordered_map<DLDataType,
+                                     dal::data_type, //
+                                     dlpack_type_hash,
+                                     dlpack_type_equal>;
+using inv_map_t = std::unordered_map<dal::data_type,
+                                     DLDataType, //
+                                     std::hash<dal::data_type>,
+                                     std::equal_to<dal::data_type>>;
+
+template <typename Type>
+constexpr inline DLDataTypeCode make_dlpack_type_code() {
+    if constexpr (std::is_integral_v<Type>) {
+        if constexpr (std::is_unsigned_v<Type>) {
+            return DLDataTypeCode::kDLUInt;
+        }
+        else {
+            return DLDataTypeCode::kDLInt;
+        }
+    }
+    else {
+        if constexpr (std::is_floating_point_v<Type>) {
+            return DLDataTypeCode::kDLFloat;
+        }
+        else {
+            throw std::runtime_error("Unsupported");
+            return static_cast<DLDataTypeCode>(-1);
+        }
+    }
+}
+
+template <typename Type>
+constexpr inline DLDataType make_dlpack_type(std::uint16_t lanes = 0) {
+    constexpr auto code = make_dlpack_type_code<Type>();
+    constexpr auto size = std::size_t(8) * sizeof(Type);
+    return DLDataType{ code, size, lanes };
+}
+
+template <typename... Types>
+inline auto make_inv_map(const std::tuple<Types...>* const = nullptr) {
+    inv_map_t result(1ul * sizeof...(Types));
+
+    dal::detail::apply(
+        [&](auto type_tag) -> void {
+            using type_t = std::decay_t<decltype(type_tag)>;
+            constexpr auto dal_v = detail::make_data_type<type_t>();
+            result.emplace(dal_v, make_dlpack_type<type_t>(1));
+        },
+        Types{}...);
+
+    return result;
+}
+
+template <typename... Types>
+inline auto make_fwd_map(const std::tuple<Types...>* const = nullptr) {
+    fwd_map_t result(2ul * sizeof...(Types));
+
+    dal::detail::apply(
+        [&](auto type_tag) -> void {
+            using type_t = std::decay_t<decltype(type_tag)>;
+            constexpr auto dal_v = detail::make_data_type<type_t>();
+            result.emplace(make_dlpack_type<type_t>(0), dal_v);
+            result.emplace(make_dlpack_type<type_t>(1), dal_v);
+        },
+        Types{}...);
+
+    return result;
+}
+
+static const inv_map_t& get_inv_map() {
+    constexpr const supported_types_t* types = nullptr;
+    static const inv_map_t body = make_inv_map(types);
+    return body;
+}
+
+static const fwd_map_t& get_fwd_map() {
+    constexpr const supported_types_t* types = nullptr;
+    static const fwd_map_t body = make_fwd_map(types);
+    return body;
+}
+
+dal::data_type convert_dlpack_to_dal_type(DLDataType dtype) {
+    if (get_fwd_map().count(dtype)) {
+        return get_fwd_map().at(dtype);
+    }
+    else {
+        throw std::runtime_error("Not a known \"dlpack\" type");
+    }
+}
+
+DLDataType convert_dal_to_dlpack_type(dal::data_type dtype) {
+    if (get_inv_map().count(dtype)) {
+        return get_inv_map().at(dtype);
+    }
+    else {
+        throw std::runtime_error("Not a known \"dal\" type");
+    }
+}
+
+} // namespace oneapi::dal::python::dlpack

--- a/onedal/datatypes/dlpack/dtype_conversion.hpp
+++ b/onedal/datatypes/dlpack/dtype_conversion.hpp
@@ -1,0 +1,42 @@
+/*******************************************************************************
+* Copyright Contributors to the oneDAL project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include <string>
+
+#include <pybind11/pybind11.h>
+
+#include "oneapi/dal/table/common.hpp"
+#include "onedal/datatypes/dtype_dispatcher.hpp"
+
+#include "onedal/datatypes/dlpack/dlpack.h"
+
+namespace py = pybind11;
+
+namespace oneapi::dal::python::dlpack {
+
+// DLDataType is only 64 bits in size. Not expensive
+dal::data_type convert_dlpack_to_dal_type(DLDataType dt);
+DLDataType convert_dal_to_dlpack_type(dal::data_type dt);
+
+template <typename Type>
+inline DLDataType make_data_type(Type tag = {}) {
+    constexpr auto dt = detail::make_data_type<Type>();
+    return convert_dlpack_to_dal_type(dt);
+}
+
+} // namespace oneapi::dal::python::dlpack

--- a/onedal/datatypes/numpy/data_conversion.cpp
+++ b/onedal/datatypes/numpy/data_conversion.cpp
@@ -71,7 +71,7 @@ inline dal::homogen_table convert_to_homogen_impl(PyArrayObject *np_data) {
     std::int64_t column_count = 1;
 
     if (array_numdims(np_data) > 2) {
-        throw std::runtime_error("Input array has wrong dimensionality (must be 2d).");
+        throw std::length_error("Input array has wrong dimensionality (must be 2d).");
     }
     T *const data_pointer = reinterpret_cast<T *const>(array_data(np_data));
     // TODO: check safe cast from int to std::int64_t

--- a/onedal/datatypes/table.cpp
+++ b/onedal/datatypes/table.cpp
@@ -102,6 +102,7 @@ ONEDAL_PY_INIT_MODULE(table) {
         auto* obj_ptr = numpy::convert_to_pyobject(t);
         return obj_ptr;
     });
+    m.def("dlpack_memory_order", &dlpack::dlpack_memory_order);
 }
 
 } // namespace oneapi::dal::python

--- a/onedal/datatypes/table.cpp
+++ b/onedal/datatypes/table.cpp
@@ -22,6 +22,7 @@
 #endif // ONEDAL_DATA_PARALLEL
 
 #include "onedal/datatypes/numpy/data_conversion.hpp"
+#include "onedal/datatypes/dlpack/data_conversion.hpp"
 #include "onedal/datatypes/numpy/numpy_utils.hpp"
 #include "onedal/common/pybind11_helpers.hpp"
 #include "onedal/version.hpp"
@@ -82,12 +83,18 @@ ONEDAL_PY_INIT_MODULE(table) {
 #endif // ONEDAL_DATA_PARALLEL
 
     m.def("to_table", [](py::object obj, py::object queue) {
+        if (py::isinstance<py::array>(obj)) {
+            return numpy::convert_to_table(obj, queue);
+        }
 #ifdef ONEDAL_DATA_PARALLEL
         if (py::hasattr(obj, "__sycl_usm_array_interface__")) {
             return sycl_usm::convert_to_table(obj);
         }
 #endif // ONEDAL_DATA_PARALLEL
-
+        if (py::hasattr(obj, "__dlpack__")) {
+            return dlpack::convert_to_table(obj, queue);
+        }
+        // assume to be sparse (handled in numpy)
         return numpy::convert_to_table(obj, queue);
     });
 

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -32,6 +32,7 @@ if dpctl_available:
 from onedal.primitives import linear_kernel
 from onedal.tests.utils._dataframes_support import (
     _convert_to_dataframe,
+    array_api_modules,
     get_dataframes_and_queues,
 )
 from onedal.tests.utils._device_selection import get_queues
@@ -89,6 +90,20 @@ else:
 
     class DummyEstimatorWithTableConversions:
         pass
+
+
+class _OnlyDLTensor:
+    """This is a temporary class to force use of the '__dlpack__' logic branch
+    in `to_table` as `__dlpack__` conversion is lower priority by design.
+    dpctl data with CPU SyclQueues are shown as on KDLOneAPI devices, which serve
+    to test the SYCL device support in `__dlpack__` logic without GPU hardware.
+    This takes inspiration from sklearn's `_NotAnArray`."""
+
+    def __init__(self, data):
+        self.data = data
+
+    def __dlpack__(self):
+        return self.data.__dlpack__()
 
 
 def _test_input_format_c_contiguous_numpy(queue, dtype):
@@ -229,7 +244,7 @@ def test_conversion_to_table(dtype):
 )
 @pytest.mark.parametrize("order", ["C", "F"])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
-def test_input_sua_iface_zero_copy(dataframe, queue, order, dtype):
+def test_input_zero_copy_sycl_usm(dataframe, queue, order, dtype):
     """Checking that values ​​representing USM allocations `__sycl_usm_array_interface__`
     are preserved during conversion to onedal table.
     """
@@ -266,7 +281,7 @@ def test_input_sua_iface_zero_copy(dataframe, queue, order, dtype):
 @pytest.mark.parametrize("order", ["F", "C"])
 @pytest.mark.parametrize("data_shape", data_shapes)
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_table_conversions(dataframe, queue, order, data_shape, dtype):
+def test_table_conversions_sycl_usm(dataframe, queue, order, data_shape, dtype):
     """Checking that values ​​representing USM allocations `__sycl_usm_array_interface__`
     are preserved during conversion to onedal table and from onedal table to
     sycl usm array dataformat.
@@ -313,32 +328,25 @@ def test_table_conversions(dataframe, queue, order, data_shape, dtype):
     )
 
 
-@pytest.mark.skipif(
-    not _is_dpc_backend,
-    reason="__sycl_usm_array_interface__ support requires DPC backend.",
-)
 @pytest.mark.parametrize(
-    "dataframe,queue", get_dataframes_and_queues("dpctl,dpnp", "cpu,gpu")
+    "dataframe,queue", get_dataframes_and_queues("numpy,dpctl,dpnp,array_api", "cpu,gpu")
 )
 @pytest.mark.parametrize("data_shape", unsupported_data_shapes)
-def test_sua_iface_interop_invalid_shape(dataframe, queue, data_shape):
+def test_interop_invalid_shape(dataframe, queue, data_shape):
     X = np.zeros(data_shape)
     X = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
-    sua_iface, _, _ = _get_sycl_namespace(X)
 
-    expected_err_msg = (
-        "Unable to convert from SUA interface: only 1D & 2D tensors are allowed"
-    )
+    expected_err_msg = r"Input array has wrong dimensionality \(must be 2d\)."
+    if dataframe in "dpctl,dpnp":
+        expected_err_msg = (
+            "Unable to convert from SUA interface: only 1D & 2D tensors are allowed"
+        )
     with pytest.raises(ValueError, match=expected_err_msg):
         to_table(X)
 
 
-@pytest.mark.skipif(
-    not _is_dpc_backend,
-    reason="__sycl_usm_array_interface__ support requires DPC backend.",
-)
 @pytest.mark.parametrize(
-    "dataframe,queue", get_dataframes_and_queues("dpctl,dpnp", "cpu,gpu")
+    "dataframe,queue", get_dataframes_and_queues("dpctl,dpnp,array_api", "cpu,gpu")
 )
 @pytest.mark.parametrize(
     "dtype",
@@ -348,16 +356,17 @@ def test_sua_iface_interop_invalid_shape(dataframe, queue, data_shape):
         pytest.param(np.uint64, id=np.dtype(np.uint64).name),
     ],
 )
-def test_sua_iface_interop_unsupported_dtypes(dataframe, queue, dtype):
+def test_interop_unsupported_dtypes(dataframe, queue, dtype):
     # sua iface interobility supported only for oneDAL supported dtypes
     # for input data: int32, int64, float32, float64.
     # Checking some common dtypes supported by dpctl, dpnp for exception
     # raise.
     X = np.zeros((10, 20), dtype=dtype)
     X = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
-    sua_iface, _, _ = _get_sycl_namespace(X)
-
     expected_err_msg = "Unable to convert from SUA interface: unknown data type"
+    if dataframe in "array_api":
+        expected_err_msg = "Found unsupported array type"
+
     with pytest.raises(ValueError, match=expected_err_msg):
         to_table(X)
 
@@ -371,8 +380,6 @@ def test_to_table_non_contiguous_input(dataframe, queue):
     X, _ = np.mgrid[:10, :10]
     X = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
     X = X[:, :3]
-    sua_iface, _, _ = _get_sycl_namespace(X)
-    # X expected to be non-contiguous.
     assert not X.flags.c_contiguous and not X.flags.f_contiguous
     X_t = to_table(X)
     assert X_t and X_t.shape == (10, 3) and X_t.has_data
@@ -386,7 +393,7 @@ def test_to_table_non_contiguous_input(dataframe, queue):
     "dataframe,queue", get_dataframes_and_queues("dpctl,dpnp", "cpu,gpu")
 )
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_sua_iface_interop_if_no_dpc_backend(dataframe, queue, dtype):
+def test_interop_if_no_dpc_backend_sycl_usm(dataframe, queue, dtype):
     X = np.zeros((10, 20), dtype=dtype)
     X = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
     sua_iface, _, _ = _get_sycl_namespace(X)
@@ -396,12 +403,7 @@ def test_sua_iface_interop_if_no_dpc_backend(dataframe, queue, dtype):
         to_table(X)
 
 
-@pytest.mark.skipif(
-    not _is_dpc_backend, reason="Requires DPC backend for dtype conversion"
-)
-@pytest.mark.parametrize("dtype", [np.float32, np.float64])
-@pytest.mark.parametrize("sparse", [True, False])
-def test_low_precision_gpu_conversion(dtype, sparse):
+def _test_low_precision_gpu_conversion(dtype, sparse, dataframe):
     # Use a dummy queue as fp32 hardware is not in public testing
 
     class DummySyclQueue:
@@ -418,7 +420,9 @@ def test_low_precision_gpu_conversion(dtype, sparse):
     if sparse:
         X = sp.random(100, 100, format="csr", dtype=dtype)
     else:
-        X = np.random.rand(100, 100).astype(dtype)
+        X = _convert_to_dataframe(
+            np.random.rand(100, 100).astype(dtype), target_df=dataframe
+        )
 
     if dtype == np.float64:
         with pytest.warns(
@@ -432,6 +436,24 @@ def test_low_precision_gpu_conversion(dtype, sparse):
     assert X_table.dtype == np.float32
     if dtype == np.float32 and not sparse:
         assert_allclose(X, from_table(X_table))
+
+
+@pytest.mark.skipif(
+    not _is_dpc_backend, reason="Requires DPC backend for dtype conversion"
+)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("sparse", [True, False])
+def test_low_precision_gpu_conversion_numpy(dtype, sparse):
+    _test_low_precision_gpu_conversion(dtype, sparse, "numpy")
+
+
+@pytest.mark.skipif(
+    not _is_dpc_backend or "array_api" not in array_api_modules,
+    reason="Requires DPC backend and array_api_strict for the test",
+)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_low_precision_gpu_conversion_array_api(dtype):
+    _test_low_precision_gpu_conversion(dtype, False, "array_api")
 
 
 @pytest.mark.parametrize("X", [None, 5, "test", True, [], np.pi, lambda: None])
@@ -473,3 +495,45 @@ def test_low_precision_non_array(X):
 
     queue = DummySyclQueue()
     test_non_array(X, queue)
+
+
+@pytest.mark.parametrize(
+    "dataframe,queue", get_dataframes_and_queues("dpctl,numpy", "cpu,gpu")
+)
+@pytest.mark.parametrize("can_copy", [True, False])
+def test_to_table_non_contiguous_input_dlpack(dataframe, queue, can_copy):
+    X, _ = np.mgrid[:10, :10]
+    X = _convert_to_dataframe(X, sycl_queue=queue, dataframe=dataframe)
+    if not hasattr(X, "__dlpack__"):
+        pytest.skip("underlying array doesn't support dlpack")
+
+    X_tens = _OnlyDLTensor(X[:, :3])
+
+    # give the _OnlyDLTensor the ability to copy
+    if can_copy:
+        X_tens.copy = lambda: _OnlyDLTensor(X.copy())
+        to_table(X_tens)
+    else:
+        with pytest.raises(RuntimeError, match="Wrong strides"):
+            to_table(X_tens)
+
+
+@pytest.mark.parametrize(
+    "dataframe,queue", get_dataframes_and_queues("dpctl,numpy", "cpu,gpu")
+)
+@pytest.mark.parametrize("order", ["F", "C"])
+@pytest.mark.parametrize("data_shape", data_shapes)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_table_conversions_dlpack(dataframe, queue, order, data_shape, dtype):
+    """Test if __dlpack__ data can be properly consumed when only __dlpack__ attribute is exposed.
+    This tests kDLOneAPI devices as well as kDLCPU devices
+    """
+    rng = np.random.RandomState(0)
+    X = np.array(5 * rng.random_sample(data_shape), dtype=dtype)
+
+    X = ORDER_DICT[order](X)
+
+    X = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
+    X = _OnlyDLTensor(X)
+
+    to_table(X)

--- a/onedal/utils/tests/test_validation.py
+++ b/onedal/utils/tests/test_validation.py
@@ -40,7 +40,7 @@ from onedal.utils.validation import assert_all_finite
 )
 @pytest.mark.parametrize("allow_nan", [False, True])
 @pytest.mark.parametrize(
-    "dataframe, queue", get_dataframes_and_queues("numpy,dpnp,dpctl")
+    "dataframe, queue", get_dataframes_and_queues("numpy,dpnp,dpctl,array_api")
 )
 def test_sum_infinite_actually_finite(dtype, shape, allow_nan, dataframe, queue):
     X = np.empty(shape, dtype=dtype)
@@ -65,7 +65,7 @@ def test_sum_infinite_actually_finite(dtype, shape, allow_nan, dataframe, queue)
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
 @pytest.mark.parametrize("seed", [0, 123456])
 @pytest.mark.parametrize(
-    "dataframe, queue", get_dataframes_and_queues("numpy,dpnp,dpctl")
+    "dataframe, queue", get_dataframes_and_queues("numpy,dpnp,dpctl,array_api")
 )
 def test_assert_finite_random_location(
     dtype, shape, allow_nan, check, seed, dataframe, queue
@@ -92,7 +92,7 @@ def test_assert_finite_random_location(
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
 @pytest.mark.parametrize("seed", [0, 123456])
 @pytest.mark.parametrize(
-    "dataframe, queue", get_dataframes_and_queues("numpy,dpnp,dpctl")
+    "dataframe, queue", get_dataframes_and_queues("numpy,dpnp,dpctl,array_api")
 )
 def test_assert_finite_random_shape_and_location(
     dtype, allow_nan, check, seed, dataframe, queue

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -462,3 +462,12 @@ def assert_all_finite(
         allow_nan=allow_nan,
         input_name=input_name,
     )
+
+
+def is_contiguous(X):
+    if hasattr(X, "flags"):
+        return X.flags["C_CONTIGUOUS"] or X.flags["F_CONTIGUOUS"]
+    elif hasattr(X, "__dlpack__"):
+        return _backend.dlpack_memory_order(X.__dlpack__()) is not None
+    else:
+        raise TypeError(f"layout of {type(X)} object cannot be checked")

--- a/sklearnex/tests/utils/base.py
+++ b/sklearnex/tests/utils/base.py
@@ -415,8 +415,8 @@ class DummyEstimator(BaseEstimator):
                 xp=xp,
             )
         else:
-            self.x_attr = from_table(X_table)
-            self.y_attr = from_table(y_table)
+            self.x_attr_ = from_table(X_table)
+            self.y_attr_ = from_table(y_table)
 
         return self
 

--- a/sklearnex/utils/validation.py
+++ b/sklearnex/utils/validation.py
@@ -23,6 +23,7 @@ from sklearn.utils.validation import _num_samples, check_array, check_non_negati
 from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
 
 from ._array_api import get_namespace
+from onedal.utils.validation import is_contiguous
 
 if sklearn_check_version("1.6"):
     from sklearn.utils.validation import validate_data as _sklearn_validate_data
@@ -48,11 +49,7 @@ if daal_check_version((2024, "P", 700)):
         # used for array_api inputs but will allow dpnp ndarrays and dpctl tensors.
         # only check contiguous arrays to prevent unnecessary copying of data, even if
         # non-contiguous arrays can now be converted to oneDAL tables.
-        return (
-            X.dtype in [xp.float32, xp.float64]
-            and hasattr(X, "flags")
-            and (X.flags["C_CONTIGUOUS"] or X.flags["F_CONTIGUOUS"])
-        )
+        return X.dtype in [xp.float32, xp.float64] and is_contiguous(X)
 
 else:
     from daal4py.utils.validation import _assert_all_finite as _onedal_assert_all_finite


### PR DESCRIPTION
## Description

Continues dlpack work from #2275. ```validate_data``` and ```_check_sample_weight``` do not follow standard sklearnex offloading practice, namely they compute always wherever the data is (as the data movement could ruin any speedup provided by oneDAL, the algorithm is extraordinarily simple).  Therefore, they must be enabled separately for array_api support. Since they are to be included in every zero-copy array_api supported algorithm, it is a prerequisite for enabling every other estimator.

Previously this aspect was controlled by the looking for the ```flags``` attribute, which is not in the array_api standard. The array api standard does not include python-facing attributes or methods which can show if C-contiguous or F-contiguous. However, the array_api standard requires dlpack support. The attributes of from a DLPack tensor can be checked for the memory layout instead. This PR introduces a special onedal backend function which extracts and checks the necessary memory layout (without taking ownership of the tensor).  A python function is created which first checks and queries the ```flags``` or ```__dlpack__``` attributes. If neither are available, it will return False triggering the sklearn ```_assert_all_finite```.  This is done as ```to_table``` will attempt to convert to a contiguous memory layout, which again will ruin the performance gain.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
