### PR TITLE
DOC: Add incremental ridge to docs

### DIFF
--- a/doc/sources/non-scikit-algorithms.rst
+++ b/doc/sources/non-scikit-algorithms.rst
@@ -40,3 +40,10 @@ IncrementalLinearRegression
 .. automethod:: sklearnex.linear_model.IncrementalLinearRegression.fit
 .. automethod:: sklearnex.linear_model.IncrementalLinearRegression.partial_fit
 .. automethod:: sklearnex.linear_model.IncrementalLinearRegression.predict
+
+IncrementalRidge
+----------------
+.. autoclass:: sklearnex.linear_model.IncrementalRidge
+.. automethod:: sklearnex.linear_model.IncrementalRidge.fit
+.. automethod:: sklearnex.linear_model.IncrementalRidge.partial_fit
+.. automethod:: sklearnex.linear_model.IncrementalRidge.predict

--- a/sklearnex/linear_model/incremental_ridge.py
+++ b/sklearnex/linear_model/incremental_ridge.py
@@ -32,7 +32,7 @@ if sklearn_check_version("1.2"):
 from onedal.linear_model import IncrementalRidge as onedal_IncrementalRidge
 
 from .._device_offload import dispatch, wrap_output_data
-from .._utils import PatchingConditionsChain
+from .._utils import IntelEstimator, PatchingConditionsChain
 
 if sklearn_check_version("1.6"):
     from sklearn.utils.validation import validate_data
@@ -43,7 +43,7 @@ else:
 @control_n_jobs(
     decorated_methods=["fit", "partial_fit", "predict", "score", "_onedal_finalize_fit"]
 )
-class IncrementalRidge(MultiOutputMixin, RegressorMixin, BaseEstimator):
+class IncrementalRidge(IntelEstimator, MultiOutputMixin, RegressorMixin, BaseEstimator):
     """
     Incremental estimator for Ridge Regression.
     Allows to train Ridge Regression if data is splitted into batches.
@@ -51,14 +51,14 @@ class IncrementalRidge(MultiOutputMixin, RegressorMixin, BaseEstimator):
     Parameters
     ----------
     fit_intercept : bool, default=True
-    Whether to calculate the intercept for this model. If set
-    to False, no intercept will be used in calculations
-    (i.e. data is expected to be centered).
+        Whether to calculate the intercept for this model. If set
+        to False, no intercept will be used in calculations
+        (i.e. data is expected to be centered).
 
     alpha : float, default=1.0
-    Regularization strength; must be a positive float. Regularization
-    improves the conditioning of the problem and reduces the variance of
-    the estimates. Larger values specify stronger regularization.
+        Regularization strength; must be a positive float. Regularization
+        improves the conditioning of the problem and reduces the variance of
+        the estimates. Larger values specify stronger regularization.
 
     copy_X : bool, default=True
         If True, X will be copied; else, it may be overwritten.


### PR DESCRIPTION
## Description

_Add a comprehensive description of proposed changes_

_List associated issue number(s) if exist(s): #6 (for example)_

_Documentation PR (if needed): #1340 (for example)_

_Benchmarks PR (if needed): https://github.com/IntelPython/scikit-learn_bench/pull/155 (for example)_

---

This PR adds the non-sklearn `IncrementalRidge` estimator to the docs. Along the way, it also fixes the docstrings to keep to numpy format in order to render correctly.

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
