### PR TITLE
[bug] fix numpy fortran order support in ```from_table```, errors in ```to_table``` 

### DIFF
--- a/onedal/datatypes/numpy/data_conversion.cpp
+++ b/onedal/datatypes/numpy/data_conversion.cpp
@@ -289,7 +289,7 @@ static PyObject *convert_to_numpy_impl(
     host_array.need_mutable_data();
     auto *bytes = host_array.get_mutable_data();
     // assumes that the array has writeable data (not clear if that is the case in oneDAL)
-    int flags = layout == dal::data_layout::row_major : NPY_ARRAY_CARRAY : NPY_ARRAY_FARRAY;
+    int flags = layout == dal::data_layout::row_major ? NPY_ARRAY_CARRAY : NPY_ARRAY_FARRAY;
     PyObject *obj = PyArray_New(&PyArray_Type, size_dims, dims, NpType, NULL, static_cast<void *>(bytes), 0, flags, NULL);
     if (!obj)
         throw std::invalid_argument("Conversion to numpy array failed");

--- a/onedal/datatypes/numpy/data_conversion.cpp
+++ b/onedal/datatypes/numpy/data_conversion.cpp
@@ -285,24 +285,15 @@ static PyObject *convert_to_numpy_impl(
     const dal::data_layout &layout = dal::data_layout::row_major) {
     const int size_dims = column_count == 0 ? 1 : 2;
     npy_intp dims[2] = { static_cast<npy_intp>(row_count), static_cast<npy_intp>(column_count) };
-    // for column_major start with reversed indices, col major conversion seldomly occurs in sklearnex
-    if (layout == dal::data_layout::column_major) {
-        dims[0] = static_cast<npy_intp>(column_count);
-        dims[1] = static_cast<npy_intp>(row_count);
-    }
     auto host_array = transfer_to_host(array);
     host_array.need_mutable_data();
     auto *bytes = host_array.get_mutable_data();
-
-    PyObject *obj = PyArray_SimpleNewFromData(size_dims, dims, NpType, static_cast<void *>(bytes));
+    // assumes that the array has writeable data (not clear if that is the case in oneDAL)
+    int flags = layout == dal::data_layout::row_major : NPY_ARRAY_CARRAY : NPY_ARRAY_FARRAY;
+    PyObject *obj = PyArray_New(&PyArray_Type, size_dims, dims, NpType, NULL, static_cast<void *>(bytes), 0, flags, NULL);
     if (!obj)
         throw std::invalid_argument("Conversion to numpy array failed");
-    // set column major data to the proper format using transpose
-    if (layout == dal::data_layout::column_major) {
-        obj = PyArray_Transpose(reinterpret_cast<PyArrayObject *>(obj), NULL);
-        if (!obj)
-            throw std::invalid_argument("Conversion to numpy array failed");
-    }
+
     void *opaque_value = static_cast<void *>(new dal::array<T>(host_array));
     PyObject *cap = PyCapsule_New(opaque_value, NULL, free_capsule);
     PyArray_SetBaseObject(reinterpret_cast<PyArrayObject *>(obj), cap);

--- a/onedal/datatypes/numpy/data_conversion.cpp
+++ b/onedal/datatypes/numpy/data_conversion.cpp
@@ -69,14 +69,15 @@ static dal::array<T> transfer_to_host(const dal::array<T> &array) {
 template <typename T>
 inline dal::homogen_table convert_to_homogen_impl(PyArrayObject *np_data) {
     std::int64_t column_count = 1;
-
-    if (array_numdims(np_data) > 2) {
-        throw std::runtime_error("Input array has wrong dimensionality (must be 2d).");
+    const std::int32_t ndims = array_numdims(np_data);
+    if (ndims > 2) {
+        throw std::length_error("Input array has wrong dimensionality (must be 2d).");
     }
     T *const data_pointer = reinterpret_cast<T *const>(array_data(np_data));
     // TODO: check safe cast from int to std::int64_t
-    const std::int64_t row_count = static_cast<std::int64_t>(array_size(np_data, 0));
-    if (array_numdims(np_data) == 2) {
+    // if 0 dimensional numpy array, force to 2d
+    const std::int64_t row_count = ndims ? static_cast<std::int64_t>(array_size(np_data, 0)) : 1l;
+    if (ndims == 2) {
         // TODO: check safe cast from int to std::int64_t
         column_count = static_cast<std::int64_t>(array_size(np_data, 1));
     }
@@ -152,7 +153,7 @@ inline csr_table_t convert_to_csr_impl(PyObject *py_data,
     return res_table;
 }
 
-dal::table convert_to_table(py::object inp_obj, py::object queue) {
+dal::table convert_to_table(py::object inp_obj, py::object queue, bool recursed) {
     dal::table res;
 
     PyObject *obj = inp_obj.ptr();
@@ -168,14 +169,19 @@ dal::table convert_to_table(py::object inp_obj, py::object queue) {
         // then cast it to float32
         int type = reinterpret_cast<PyArray_Descr *>(inp_obj.attr("dtype").ptr())->type_num;
         if (type == NPY_DOUBLE || type == NPY_DOUBLELTR) {
-            PyErr_WarnEx(
-                PyExc_RuntimeWarning,
-                "Data will be converted into float32 from float64 because device does not support it",
-                1);
             // use astype instead of PyArray_Cast in order to support scipy sparse inputs
-            inp_obj = inp_obj.attr("astype")(py::dtype::of<float>());
-            res = convert_to_table(
-                inp_obj); // queue will be set to none, as this check is no longer necessary
+            if (!recursed) {
+                PyErr_WarnEx(
+                    PyExc_RuntimeWarning,
+                    "Data will be converted into float32 from float64 because device does not support it",
+                    1);
+                inp_obj = inp_obj.attr("astype")(py::dtype::of<float>());
+                res = convert_to_table(inp_obj, queue, true);
+            }
+            else {
+                throw std::invalid_argument(
+                    "[convert_to_table] Numpy input could not be converted into onedal table.");
+            }
             return res;
         }
     }
@@ -188,8 +194,8 @@ dal::table convert_to_table(py::object inp_obj, py::object queue) {
             // NOTE: this will make a C-contiguous deep copy of the data
             // this is expected to be a special case
             obj = reinterpret_cast<PyObject *>(PyArray_GETCONTIGUOUS(ary));
-            if (obj) {
-                res = convert_to_table(py::cast<py::object>(obj), queue);
+            if (obj && !recursed) {
+                res = convert_to_table(py::cast<py::object>(obj), queue, true);
                 Py_DECREF(obj);
                 return res;
             }
@@ -202,7 +208,7 @@ dal::table convert_to_table(py::object inp_obj, py::object queue) {
         SET_NPY_FEATURE(array_type(ary),
                         array_type_sizeof(ary),
                         MAKE_HOMOGEN_TABLE,
-                        throw std::invalid_argument("Found unsupported array type"));
+                        throw py::type_error("Found unsupported array type"));
 #undef MAKE_HOMOGEN_TABLE
     }
     else if (strcmp(Py_TYPE(obj)->tp_name, "csr_matrix") == 0 ||
@@ -251,7 +257,7 @@ dal::table convert_to_table(py::object inp_obj, py::object queue) {
         SET_NPY_FEATURE(array_type(np_data),
                         array_type_sizeof(np_data),
                         MAKE_CSR_TABLE,
-                        throw std::invalid_argument("Found unsupported data type in csr_matrix"));
+                        throw py::type_error("Found unsupported data type in csr_matrix"));
 #undef MAKE_CSR_TABLE
         Py_DECREF(np_column_indices);
         Py_DECREF(np_row_indices);
@@ -272,12 +278,18 @@ static void free_capsule(PyObject *cap) {
 }
 
 template <int NpType, typename T = byte_t>
-static PyObject *convert_to_numpy_impl(const dal::array<T> &array,
-                                       std::int64_t row_count,
-                                       std::int64_t column_count = 0) {
+static PyObject *convert_to_numpy_impl(
+    const dal::array<T> &array,
+    std::int64_t row_count,
+    std::int64_t column_count = 0,
+    const dal::data_layout &layout = dal::data_layout::row_major) {
     const int size_dims = column_count == 0 ? 1 : 2;
-
     npy_intp dims[2] = { static_cast<npy_intp>(row_count), static_cast<npy_intp>(column_count) };
+    // for column_major start with reversed indices, col major conversion seldomly occurs in sklearnex
+    if (layout == dal::data_layout::column_major) {
+        dims[0] = static_cast<npy_intp>(column_count);
+        dims[1] = static_cast<npy_intp>(row_count);
+    }
     auto host_array = transfer_to_host(array);
     host_array.need_mutable_data();
     auto *bytes = host_array.get_mutable_data();
@@ -285,7 +297,12 @@ static PyObject *convert_to_numpy_impl(const dal::array<T> &array,
     PyObject *obj = PyArray_SimpleNewFromData(size_dims, dims, NpType, static_cast<void *>(bytes));
     if (!obj)
         throw std::invalid_argument("Conversion to numpy array failed");
-
+    // set column major data to the proper format using transpose
+    if (layout == dal::data_layout::column_major) {
+        obj = PyArray_Transpose(reinterpret_cast<PyArrayObject *>(obj), NULL);
+        if (!obj)
+            throw std::invalid_argument("Conversion to numpy array failed");
+    }
     void *opaque_value = static_cast<void *>(new dal::array<T>(host_array));
     PyObject *cap = PyCapsule_New(opaque_value, NULL, free_capsule);
     PyArray_SetBaseObject(reinterpret_cast<PyArrayObject *>(obj), cap);
@@ -403,12 +420,13 @@ PyObject *convert_to_pyobject(const dal::table &input) {
         const auto &homogen_input = static_cast<const dal::homogen_table &>(input);
         const dal::data_type dtype = homogen_input.get_metadata().get_data_type(0);
 
-#define MAKE_NYMPY_FROM_HOMOGEN(NpType)                                        \
-    {                                                                          \
-        auto bytes_array = dal::detail::get_original_data(homogen_input);      \
-        res = convert_to_numpy_impl<NpType>(bytes_array,                       \
-                                            homogen_input.get_row_count(),     \
-                                            homogen_input.get_column_count()); \
+#define MAKE_NYMPY_FROM_HOMOGEN(NpType)                                       \
+    {                                                                         \
+        auto bytes_array = dal::detail::get_original_data(homogen_input);     \
+        res = convert_to_numpy_impl<NpType>(bytes_array,                      \
+                                            homogen_input.get_row_count(),    \
+                                            homogen_input.get_column_count(), \
+                                            homogen_input.get_data_layout()); \
     }
         SET_CTYPE_NPY_FROM_DAL_TYPE(dtype,
                                     MAKE_NYMPY_FROM_HOMOGEN,

--- a/onedal/datatypes/numpy/data_conversion.hpp
+++ b/onedal/datatypes/numpy/data_conversion.hpp
@@ -30,6 +30,8 @@ namespace oneapi::dal::python::numpy {
 namespace py = pybind11;
 
 PyObject *convert_to_pyobject(const dal::table &input);
-dal::table convert_to_table(py::object inp_obj, py::object queue = py::none());
+dal::table convert_to_table(py::object inp_obj,
+                            py::object queue = py::none(),
+                            bool recursed = false);
 
 } // namespace oneapi::dal::python::numpy

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -442,15 +442,16 @@ def test_non_array(X, queue):
     # Verify that to and from table doesn't raise errors
     # no guarantee is made about type or content
     err_str = ""
-
+    error = ValueError
     if np.isscalar(X):
         if np.atleast_2d(X).dtype not in [np.float64, np.float32, np.int64, np.int32]:
+            error = TypeError
             err_str = "Found unsupported array type"
     elif not (X is None or isinstance(X, np.ndarray)):
         err_str = r"\[convert_to_table\] Not available input format for convert Python object to onedal table."
 
     if err_str:
-        with pytest.raises(TypeError, match=err_str):
+        with pytest.raises(error, match=err_str):
             to_table(X)
     else:
         X_table = to_table(X, queue=queue)

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -199,21 +199,23 @@ def test_input_format_f_contiguous_pandas(queue, dtype):
     _test_input_format_f_contiguous_pandas(queue, dtype)
 
 
-def _test_conversion_to_table(dtype):
+def _test_conversion_to_table(dtype, order):
     np.random.seed()
     if dtype in [np.int32, np.int64]:
         x = np.random.randint(0, 10, (15, 3), dtype=dtype)
     else:
         x = np.random.uniform(-2, 2, (18, 6)).astype(dtype)
+    x = ORDER_DICT[order](x)
     x_table = to_table(x)
     x2 = from_table(x_table)
     assert x.dtype == x2.dtype
     assert np.array_equal(x, x2)
 
 
+@pytest.mark.parametrize("order", ["F", "C"])
 @pytest.mark.parametrize("dtype", [np.int32, np.int64, np.float32, np.float64])
-def test_conversion_to_table(dtype):
-    _test_conversion_to_table(dtype)
+def test_conversion_to_table(dtype, order):
+    _test_conversion_to_table(dtype, order)
 
 
 @pytest.mark.skipif(

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -450,7 +450,7 @@ def test_non_array(X, queue):
         err_str = r"\[convert_to_table\] Not available input format for convert Python object to onedal table."
 
     if err_str:
-        with pytest.raises(ValueError, match=err_str):
+        with pytest.raises(TypeError, match=err_str):
             to_table(X)
     else:
         X_table = to_table(X, queue=queue)


### PR DESCRIPTION
## Description

Contains corrections for numpy inputs from #2275

Column order oneDAL datatables are converted into C-contiguous numpy arrays, which is a false transpose of data. Recursion checks on data can lead to an infinite loop, a safety boolean is added to allow for it to occur once.  More informative errors are added, rather than a generic errors.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
