### PR TITLE
fix: use utf-8 encoding

### DIFF
--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -246,7 +246,7 @@ def run(exdir, logdir, args):
                     )
                 else:
                     logfn = jp(logdir, script.replace(".py", ".res"))
-                    with open(logfn, "w") as logfile:
+                    with open(logfn, "w", encoding="utf-8") as logfile:
                         print("\n##### " + jp(dirpath, script))
                         execute_string = get_exe_cmd(jp(dirpath, script), args)
                         if execute_string:
@@ -267,7 +267,7 @@ def run(exdir, logdir, args):
                                 proc.kill()
                                 out = proc.communicate()[0]
                                 print("Process has timed out: " + str(execute_string))
-                            logfile.write(out.decode("ascii"))
+                            logfile.write(out.decode("utf-8"))
                             if proc.returncode:
                                 print(out)
                                 print(

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -246,7 +246,7 @@ def run(exdir, logdir, args):
                     )
                 else:
                     logfn = jp(logdir, script.replace(".py", ".res"))
-                    with open(logfn, "w", encoding="utf-8") as logfile:
+                    with open(logfn, "w") as logfile:
                         print("\n##### " + jp(dirpath, script))
                         execute_string = get_exe_cmd(jp(dirpath, script), args)
                         if execute_string:
@@ -267,7 +267,7 @@ def run(exdir, logdir, args):
                                 proc.kill()
                                 out = proc.communicate()[0]
                                 print("Process has timed out: " + str(execute_string))
-                            logfile.write(out.decode("utf-8"))
+                            logfile.write(out.decode())
                             if proc.returncode:
                                 print(out)
                                 print(


### PR DESCRIPTION
## Description

In some cases non-ASCII characters are used in logging (e.g. the trademark sign) which breaks the current write to file.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
