### PR TITLE
DOC: Removed unused `dpctl` import in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Intel(R) Extension for Scikit-learn is also a part of [Intel(R) AI Tools](https:
 
     ```py
     import numpy as np
-    import dpctl
     from sklearnex import patch_sklearn, config_context
     patch_sklearn()
 

--- a/doc/sources/index.rst
+++ b/doc/sources/index.rst
@@ -75,7 +75,6 @@ Note: executing on GPU has `additional system software requirements <https://www
 ::
 
    import numpy as np
-   import dpctl
    from sklearnex import patch_sklearn, config_context
    patch_sklearn()
 


### PR DESCRIPTION
## Description

There is an example for how to use sklearnex that is shown in both the readme and the root of the docs.

The example snippet imports `dpctl`, but does not use it for anything. This PR removed this unused import.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

Not applicable.

**Performance**

Not applicable.
