### PR TITLE
MAINT: Add a warning not to modify auto-generated files

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -45,6 +45,11 @@ header:
     # All .csv and .ipynb files
     - '**/*.csv'
     - '**/*.ipynb'
+   # Auto-generated files
+    - doc/Makefile
+    - doc/make.bat
+    - doc/daal4py/Makefile
+    - doc/daal4py/make.bat
    # Something in doc/
     - 'doc/daal4py/_static/style.css'
     - 'doc/daal4py/_templates/layout.html'

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,18 +1,5 @@
-#===============================================================================
-# Copyright 2014 Intel Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#===============================================================================
+# IMPORTANT!! this file is auto-generated through 'sphinx-quickstart'.
+# Do NOT modify it manually - if needed, modify 'build_docs.sh' instead.
 
 # Minimal makefile for Sphinx documentation
 #

--- a/doc/daal4py/Makefile
+++ b/doc/daal4py/Makefile
@@ -1,18 +1,5 @@
-#===============================================================================
-# Copyright 2014 Intel Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#===============================================================================
+# IMPORTANT!! this file is auto-generated through 'sphinx-quickstart'.
+# Do NOT modify it manually.
 
 # Minimal makefile for Sphinx documentation
 #

--- a/doc/daal4py/make.bat
+++ b/doc/daal4py/make.bat
@@ -1,19 +1,6 @@
 @echo off
-rem ============================================================================
-rem Copyright 2018 Intel Corporation
-rem
-rem Licensed under the Apache License, Version 2.0 (the "License");
-rem you may not use this file except in compliance with the License.
-rem You may obtain a copy of the License at
-rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
-rem
-rem Unless required by applicable law or agreed to in writing, software
-rem distributed under the License is distributed on an "AS IS" BASIS,
-rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-rem See the License for the specific language governing permissions and
-rem limitations under the License.
-rem ============================================================================
+rem IMPORTANT!! this file is auto-generated through 'sphinx-quickstart'.
+rem Do NOT modify it manually.
 
 pushd %~dp0
 

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,19 +1,6 @@
 @echo off
-rem ============================================================================
-rem Copyright 2018 Intel Corporation
-rem
-rem Licensed under the Apache License, Version 2.0 (the "License");
-rem you may not use this file except in compliance with the License.
-rem You may obtain a copy of the License at
-rem
-rem     http://www.apache.org/licenses/LICENSE-2.0
-rem
-rem Unless required by applicable law or agreed to in writing, software
-rem distributed under the License is distributed on an "AS IS" BASIS,
-rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-rem See the License for the specific language governing permissions and
-rem limitations under the License.
-rem ============================================================================
+rem IMPORTANT!! this file is auto-generated through 'sphinx-quickstart'.
+rem Do NOT modify it manually - if needed, modify 'build_docs.sh' instead.
 
 pushd %~dp0
 


### PR DESCRIPTION
## Description

This PR adds a warning note on auto-generated makefiles to not modify them manually. It also removes the copyright headers from them since they are auto-generated.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

Not applicable.

**Performance**

Not applicable.
