### PR TITLE
chore: update documentation on config parameters

### DIFF
--- a/onedal/_config.py
+++ b/onedal/_config.py
@@ -37,7 +37,7 @@ allow_sklearn_after_onedal:
     backend in case of runtime error on onedal backend computations.
     Global default: True.
 use_raw_input:
-    If True, uses the raw input data in the onedal backend computations
+    If True, uses the raw input data in some SPMD onedal backend computations
     without any checks on data consistency or validity.
     Note: This option is not recommended for general use.
     Global default: False.

--- a/onedal/_config.py
+++ b/onedal/_config.py
@@ -23,20 +23,20 @@ Default values for global configuration parameters.
 These values are typically managed through the sklearnex.set_config() interface.
 Here we only define the defaults.
 
-target_offload : string or dpctl.SyclQueue, default=None
+target_offload:
     The device primarily used to perform computations.
     If string, expected to be "auto" (the execution context
     is deduced from input data location), or SYCL* filter selector string.
     Global default: "auto".
-allow_fallback_to_host : bool, default=None
+allow_fallback_to_host:
     If True, allows to fallback computation to host device
     in case particular estimator does not support the selected one.
     Global default: False.
-allow_sklearn_after_onedal : bool, default=None
+allow_sklearn_after_onedal:
     If True, allows to fallback computation to sklearn after onedal
     backend in case of runtime error on onedal backend computations.
     Global default: True.
-use_raw_input : bool, default=None
+use_raw_input:
     If True, uses the raw input data in the onedal backend computations
     without any checks on data consistency or validity.
     Note: This option is not recommended for general use.

--- a/onedal/_config.py
+++ b/onedal/_config.py
@@ -18,6 +18,30 @@
 
 import threading
 
+"""
+Default values for global configuration parameters.
+These values are typically managed through the sklearnex.set_config() interface.
+Here we only define the defaults.
+
+target_offload : string or dpctl.SyclQueue, default=None
+    The device primarily used to perform computations.
+    If string, expected to be "auto" (the execution context
+    is deduced from input data location), or SYCL* filter selector string.
+    Global default: "auto".
+allow_fallback_to_host : bool, default=None
+    If True, allows to fallback computation to host device
+    in case particular estimator does not support the selected one.
+    Global default: False.
+allow_sklearn_after_onedal : bool, default=None
+    If True, allows to fallback computation to sklearn after onedal
+    backend in case of runtime error on onedal backend computations.
+    Global default: True.
+use_raw_input : bool, default=None
+    If True, uses the raw input data in the onedal backend computations
+    without any checks on data consistency or validity.
+    Note: This option is not recommended for general use.
+    Global default: False.
+"""
 _default_global_config = {
     "target_offload": "auto",
     "allow_fallback_to_host": False,
@@ -40,8 +64,8 @@ def _get_config(copy=True):
     Parameters
     ----------
     copy : bool, default=True
-        If False, the values ​​of the global config are returned,
-        which can further be overwritten.
+        If False, a mutable view of the configuration is returned. Each thread
+        has a separate copy of the configuration.
     Returns
     -------
     config : dict

--- a/sklearnex/_config.py
+++ b/sklearnex/_config.py
@@ -88,7 +88,7 @@ def set_config(
 
     Warnings
     --------
-    Using `use_raw_input=True` is not recommended for general use as it
+    Using ``use_raw_input=True`` is not recommended for general use as it
     bypasses data consistency checks, which may lead to unexpected behavior.
     """
 

--- a/sklearnex/_config.py
+++ b/sklearnex/_config.py
@@ -151,7 +151,7 @@ def config_context(**new_config):
 
     Warnings
     --------
-    Using `use_raw_input=True` is not recommended for general use as it
+    Using ``use_raw_input=True`` is not recommended for general use as it
     bypasses data consistency checks, which may lead to unexpected behavior.
     """
     old_config = get_config()

--- a/sklearnex/_config.py
+++ b/sklearnex/_config.py
@@ -26,10 +26,12 @@ from onedal._config import _get_config as onedal_get_config
 
 def get_config():
     """Retrieve current values for configuration set by :func:`set_config`
+
     Returns
     -------
     config : dict
         Keys are parameter names that can be passed to :func:`set_config`.
+
     See Also
     --------
     config_context : Context manager for global configuration.
@@ -48,6 +50,7 @@ def set_config(
     **sklearn_configs,
 ):
     """Set global configuration
+
     Parameters
     ----------
     target_offload : string or dpctl.SyclQueue, default=None
@@ -55,24 +58,38 @@ def set_config(
         If string, expected to be "auto" (the execution context
         is deduced from input data location),
         or SYCL* filter selector string. Global default: "auto".
+
     allow_fallback_to_host : bool, default=None
         If True, allows to fallback computation to host device
         in case particular estimator does not support the selected one.
         Global default: False.
+
     allow_sklearn_after_onedal : bool, default=None
         If True, allows to fallback computation to sklearn after onedal
         backend in case of runtime error on onedal backend computations.
         Global default: True.
+
     use_raw_input : bool, default=None
+        .. deprecated:: 2026.0
         If True, uses the raw input data in some SPMD onedal backend computations
         without any checks on data consistency or validity.
         Note: This option is not recommended for general use.
         Global default: False.
 
+    Notes
+    -----
+    All settings, not just those presently modified, will be returned to
+    their previous values when the context manager is exited.
+
     See Also
     --------
-    config_context : Context manager for global configuration.
+    set_config : Set global scikit-learn configuration.
     get_config : Retrieve current values of the global configuration.
+
+    Warnings
+    --------
+    Using `use_raw_input=True` is not recommended for general use as it
+    bypasses data consistency checks, which may lead to unexpected behavior.
     """
 
     array_api_dispatch = sklearn_configs.get("array_api_dispatch", False)
@@ -96,6 +113,7 @@ def set_config(
 @contextmanager
 def config_context(**new_config):
     """Context manager for global scikit-learn configuration
+
     Parameters
     ----------
     target_offload : string or dpctl.SyclQueue, default=None
@@ -103,15 +121,19 @@ def config_context(**new_config):
         If string, expected to be "auto" (the execution context
         is deduced from input data location),
         or SYCL* filter selector string. Global default: "auto".
+
     allow_fallback_to_host : bool, default=None
         If True, allows to fallback computation to host device
         in case particular estimator does not support the selected one.
         Global default: False.
+
     allow_sklearn_after_onedal : bool, default=None
         If True, allows to fallback computation to sklearn after onedal
         backend in case of runtime error on onedal backend computations.
         Global default: True.
+
     use_raw_input : bool, default=None
+        .. deprecated:: 2026.0
         If True, uses the raw input data in some SPMD onedal backend computations
         without any checks on data consistency or validity.
         Note: This option is not recommended for general use.
@@ -121,10 +143,16 @@ def config_context(**new_config):
     -----
     All settings, not just those presently modified, will be returned to
     their previous values when the context manager is exited.
+
     See Also
     --------
     set_config : Set global scikit-learn configuration.
     get_config : Retrieve current values of the global configuration.
+
+    Warnings
+    --------
+    Using `use_raw_input=True` is not recommended for general use as it
+    bypasses data consistency checks, which may lead to unexpected behavior.
     """
     old_config = get_config()
     set_config(**new_config)

--- a/sklearnex/_config.py
+++ b/sklearnex/_config.py
@@ -63,6 +63,11 @@ def set_config(
         If True, allows to fallback computation to sklearn after onedal
         backend in case of runtime error on onedal backend computations.
         Global default: True.
+    use_raw_input : bool, default=None
+        If True, uses the raw input data in the onedal backend computations
+        without any checks on data consistency or validity.
+        Note: This option is not recommended for general use.
+        Global default: False.
     See Also
     --------
     config_context : Context manager for global configuration.
@@ -100,6 +105,15 @@ def config_context(**new_config):
     allow_fallback_to_host : bool, default=None
         If True, allows to fallback computation to host device
         in case particular estimator does not support the selected one.
+        Global default: False.
+    allow_sklearn_after_onedal : bool, default=None
+        If True, allows to fallback computation to sklearn after onedal
+        backend in case of runtime error on onedal backend computations.
+        Global default: True.
+    use_raw_input : bool, default=None
+        If True, uses the raw input data in the onedal backend computations
+        without any checks on data consistency or validity.
+        Note: This option is not recommended for general use.
         Global default: False.
     Notes
     -----

--- a/sklearnex/_config.py
+++ b/sklearnex/_config.py
@@ -53,33 +53,28 @@ def set_config(
 
     Parameters
     ----------
-    target_offload : string or dpctl.SyclQueue, default=None
+    target_offload : string or dpctl.SyclQueue or None, default=None
         The device primarily used to perform computations.
         If string, expected to be "auto" (the execution context
         is deduced from input data location),
         or SYCL* filter selector string. Global default: "auto".
 
-    allow_fallback_to_host : bool, default=None
+    allow_fallback_to_host : bool or None, default=None
         If True, allows to fallback computation to host device
         in case particular estimator does not support the selected one.
         Global default: False.
 
-    allow_sklearn_after_onedal : bool, default=None
+    allow_sklearn_after_onedal : bool or None, default=None
         If True, allows to fallback computation to sklearn after onedal
         backend in case of runtime error on onedal backend computations.
         Global default: True.
 
-    use_raw_input : bool, default=None
+    use_raw_input : bool or None, default=None
         .. deprecated:: 2026.0
         If True, uses the raw input data in some SPMD onedal backend computations
         without any checks on data consistency or validity.
-        Note: This option is not recommended for general use.
+        Not recommended for general use.
         Global default: False.
-
-    Notes
-    -----
-    All settings, not just those presently modified, will be returned to
-    their previous values when the context manager is exited.
 
     See Also
     --------
@@ -116,30 +111,30 @@ def config_context(**new_config):
 
     Parameters
     ----------
-    target_offload : string or dpctl.SyclQueue, default=None
+    target_offload : string or dpctl.SyclQueue or None, default=None
         The device primarily used to perform computations.
         If string, expected to be "auto" (the execution context
         is deduced from input data location),
         or SYCL* filter selector string. Global default: "auto".
 
-    allow_fallback_to_host : bool, default=None
+    allow_fallback_to_host : bool or None, default=None
         If True, allows to fallback computation to host device
         in case particular estimator does not support the selected one.
         Global default: False.
 
-    allow_sklearn_after_onedal : bool, default=None
+    allow_sklearn_after_onedal : bool or None, default=None
         If True, allows to fallback computation to sklearn after onedal
         backend in case of runtime error on onedal backend computations.
         Global default: True.
 
-    use_raw_input : bool, default=None
+    use_raw_input : bool or None, default=None
         .. deprecated:: 2026.0
         If True, uses the raw input data in some SPMD onedal backend computations
         without any checks on data consistency or validity.
-        Note: This option is not recommended for general use.
+        Not recommended for general use.
         Global default: False.
 
-    Notes
+    Note
     -----
     All settings, not just those presently modified, will be returned to
     their previous values when the context manager is exited.

--- a/sklearnex/_config.py
+++ b/sklearnex/_config.py
@@ -83,7 +83,7 @@ def set_config(
 
     See Also
     --------
-    set_config : Set global scikit-learn configuration.
+    config_context : Context manager for global configuration.
     get_config : Retrieve current values of the global configuration.
 
     Warnings

--- a/sklearnex/_config.py
+++ b/sklearnex/_config.py
@@ -64,10 +64,11 @@ def set_config(
         backend in case of runtime error on onedal backend computations.
         Global default: True.
     use_raw_input : bool, default=None
-        If True, uses the raw input data in the onedal backend computations
+        If True, uses the raw input data in some SPMD onedal backend computations
         without any checks on data consistency or validity.
         Note: This option is not recommended for general use.
         Global default: False.
+
     See Also
     --------
     config_context : Context manager for global configuration.
@@ -111,10 +112,11 @@ def config_context(**new_config):
         backend in case of runtime error on onedal backend computations.
         Global default: True.
     use_raw_input : bool, default=None
-        If True, uses the raw input data in the onedal backend computations
+        If True, uses the raw input data in some SPMD onedal backend computations
         without any checks on data consistency or validity.
         Note: This option is not recommended for general use.
         Global default: False.
+
     Notes
     -----
     All settings, not just those presently modified, will be returned to


### PR DESCRIPTION
## Description

Add documentation about `use_raw_input` parameter. Also adds a missing explanation of `allow_sklearn_after_onedal` in one function, and the doc of all config parameters in the dictionary of default values in `onedal/_config.py`.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
