### PR TITLE
Enhance sklearn 1.7 support and remove sklearn<1.0 code

### DIFF
--- a/.ci/scripts/get_compatible_scipy_version.py
+++ b/.ci/scripts/get_compatible_scipy_version.py
@@ -45,11 +45,6 @@ elif sklearn_check_version("1.2") or python_version[1] > 10:
         print("scipy==1.9.*")
 elif sklearn_check_version("1.1"):
     print("scipy==1.8.*")
-elif sklearn_check_version("1.0"):
-    print("scipy==1.7.*")
-elif sklearn_check_version("0.24"):
-    # scipy 1.6 is compatible with pandas versions lower than 1.4
-    print("scipy==1.6.* pandas==1.3.*")
 else:
     print(
         "Scipy version defaults to not specified "

--- a/.ci/scripts/get_compatible_scipy_version.py
+++ b/.ci/scripts/get_compatible_scipy_version.py
@@ -45,6 +45,8 @@ elif sklearn_check_version("1.2") or python_version[1] > 10:
         print("scipy==1.9.*")
 elif sklearn_check_version("1.1"):
     print("scipy==1.8.*")
+elif sklearn_check_version("1.0"):
+    print("scipy==1.7.*")
 else:
     print(
         "Scipy version defaults to not specified "

--- a/daal4py/sklearn/cluster/dbscan.py
+++ b/daal4py/sklearn/cluster/dbscan.py
@@ -26,6 +26,7 @@ import daal4py
 
 from .._n_jobs_support import control_n_jobs
 from .._utils import PatchingConditionsChain, getFPType, make2d, sklearn_check_version
+from ..utils.validation import check_feature_names
 
 if sklearn_check_version("1.1") and not sklearn_check_version("1.2"):
     from sklearn.utils import check_scalar
@@ -121,8 +122,7 @@ class DBSCAN(DBSCAN_original):
             if self.eps <= 0.0:
                 raise ValueError(f"eps == {self.eps}, must be > 0.0.")
 
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=True)
+        check_feature_names(self, X, reset=True)
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X)

--- a/daal4py/sklearn/cluster/k_means.py
+++ b/daal4py/sklearn/cluster/k_means.py
@@ -36,6 +36,7 @@ import daal4py
 
 from .._n_jobs_support import control_n_jobs
 from .._utils import PatchingConditionsChain, getFPType, sklearn_check_version
+from ..utils.validation import check_feature_names, validate_data
 
 if sklearn_check_version("1.1"):
     from sklearn.utils.validation import _check_sample_weight, _is_arraylike_not_scalar
@@ -262,7 +263,8 @@ def _fit(self, X, y=None, sample_weight=None):
         if sklearn_check_version("1.2"):
             self._validate_params()
 
-        X = self._validate_data(
+        X = validate_data(
+            self,
             X,
             accept_sparse="csr",
             dtype=[np.float64, np.float32],
@@ -310,8 +312,7 @@ def _fit(self, X, y=None, sample_weight=None):
             raise ValueError(f"n_init should be > 0, got {self.n_init} instead.")
 
         random_state = check_random_state(self.random_state)
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=True)
+        check_feature_names(self, X, reset=True)
 
         if self.max_iter <= 0:
             raise ValueError(f"max_iter should be > 0, got {self.max_iter} instead.")
@@ -413,8 +414,7 @@ def _fit(self, X, y=None, sample_weight=None):
 
 
 def _daal4py_check_test_data(self, X):
-    if sklearn_check_version("1.0"):
-        self._check_feature_names(X, reset=False)
+    check_feature_names(self, X, reset=False)
     X = check_array(
         X, accept_sparse="csr", dtype=[np.float64, np.float32], accept_large_sparse=False
     )
@@ -514,7 +514,7 @@ class KMeans(KMeans_original):
                 algorithm=algorithm,
             )
 
-    elif sklearn_check_version("1.0"):
+    else:
 
         @_deprecate_positional_args
         def __init__(
@@ -539,38 +539,6 @@ class KMeans(KMeans_original):
                 verbose=verbose,
                 random_state=random_state,
                 copy_x=copy_x,
-                algorithm=algorithm,
-            )
-
-    else:
-
-        @_deprecate_positional_args
-        def __init__(
-            self,
-            n_clusters=8,
-            *,
-            init="k-means++",
-            n_init=10,
-            max_iter=300,
-            tol=1e-4,
-            precompute_distances="deprecated",
-            verbose=0,
-            random_state=None,
-            copy_x=True,
-            n_jobs="deprecated",
-            algorithm="auto",
-        ):
-            super(KMeans, self).__init__(
-                n_clusters=n_clusters,
-                init=init,
-                max_iter=max_iter,
-                tol=tol,
-                precompute_distances=precompute_distances,
-                n_init=n_init,
-                verbose=verbose,
-                random_state=random_state,
-                copy_x=copy_x,
-                n_jobs=n_jobs,
                 algorithm=algorithm,
             )
 

--- a/daal4py/sklearn/ensemble/AdaBoostClassifier.py
+++ b/daal4py/sklearn/ensemble/AdaBoostClassifier.py
@@ -29,11 +29,7 @@ from daal4py.sklearn._utils import sklearn_check_version
 
 from .._n_jobs_support import control_n_jobs
 from .._utils import getFPType
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = BaseEstimator._validate_data
+from ..utils.validation import validate_data
 
 
 @control_n_jobs(decorated_methods=["fit", "predict"])

--- a/daal4py/sklearn/ensemble/GBTDAAL.py
+++ b/daal4py/sklearn/ensemble/GBTDAAL.py
@@ -30,11 +30,7 @@ from daal4py.sklearn._utils import sklearn_check_version
 
 from .._n_jobs_support import control_n_jobs
 from .._utils import getFPType
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = BaseEstimator._validate_data
+from ..utils.validation import validate_data
 
 
 class GBTDAALBase(BaseEstimator, d4p.mb.GBTDAALBaseModel):
@@ -217,7 +213,7 @@ class GBTDAALClassifier(ClassifierMixin, GBTDAALBase):
             self,
             X,
             dtype=[np.float64, np.float32],
-            force_all_finite="allow-nan" if self.allow_nan_ else True,
+            ensure_all_finite="allow-nan" if self.allow_nan_ else True,
             reset=False,
         )
 
@@ -321,7 +317,7 @@ class GBTDAALRegressor(RegressorMixin, GBTDAALBase):
             self,
             X,
             dtype=[np.float64, np.float32],
-            force_all_finite="allow-nan" if self.allow_nan_ else True,
+            ensure_all_finite="allow-nan" if self.allow_nan_ else True,
             reset=False,
         )
 

--- a/daal4py/sklearn/ensemble/_forest.py
+++ b/daal4py/sklearn/ensemble/_forest.py
@@ -43,7 +43,7 @@ from daal4py.sklearn._utils import (
 )
 
 from .._n_jobs_support import control_n_jobs
-from ..utils.validation import _daal_num_features
+from ..utils.validation import _daal_num_features, check_feature_names, check_n_features
 
 if sklearn_check_version("1.2"):
     from sklearn.utils._param_validation import Interval, StrOptions
@@ -107,13 +107,9 @@ def _get_n_samples_bootstrap(n_samples, max_samples):
     if isinstance(max_samples, numbers.Real):
         if sklearn_check_version("1.2"):
             pass
-        elif sklearn_check_version("1.0"):
+        else:
             if not (0 < float(max_samples) <= 1):
                 msg = "`max_samples` must be in range (0.0, 1.0] but got value {}"
-                raise ValueError(msg.format(max_samples))
-        else:
-            if not (0 < float(max_samples) < 1):
-                msg = "`max_samples` must be in range (0, 1) but got value {}"
                 raise ValueError(msg.format(max_samples))
         return max(float(max_samples), 1 / n_samples)
 
@@ -295,7 +291,7 @@ class RandomForestClassifier(RandomForestClassifier_original, RandomForestBase):
             self.min_impurity_split = None
             self.binningStrategy = binningStrategy
 
-    elif sklearn_check_version("1.0"):
+    else:
 
         def __init__(
             self,
@@ -344,58 +340,6 @@ class RandomForestClassifier(RandomForestClassifier_original, RandomForestBase):
             self.maxBins = maxBins
             self.minBinSize = minBinSize
             self.min_impurity_split = None
-            self.binningStrategy = binningStrategy
-
-    else:
-
-        def __init__(
-            self,
-            n_estimators=100,
-            criterion="gini",
-            max_depth=None,
-            min_samples_split=2,
-            min_samples_leaf=1,
-            min_weight_fraction_leaf=0.0,
-            max_features="auto",
-            max_leaf_nodes=None,
-            min_impurity_decrease=0.0,
-            min_impurity_split=None,
-            bootstrap=True,
-            oob_score=False,
-            n_jobs=None,
-            random_state=None,
-            verbose=0,
-            warm_start=False,
-            class_weight=None,
-            ccp_alpha=0.0,
-            max_samples=None,
-            maxBins=256,
-            minBinSize=1,
-            binningStrategy="quantiles",
-        ):
-            super().__init__(
-                n_estimators=n_estimators,
-                criterion=criterion,
-                max_depth=max_depth,
-                min_samples_split=min_samples_split,
-                min_samples_leaf=min_samples_leaf,
-                min_weight_fraction_leaf=min_weight_fraction_leaf,
-                max_features=max_features,
-                max_leaf_nodes=max_leaf_nodes,
-                min_impurity_decrease=min_impurity_decrease,
-                min_impurity_split=min_impurity_split,
-                bootstrap=bootstrap,
-                oob_score=oob_score,
-                n_jobs=n_jobs,
-                random_state=random_state,
-                verbose=verbose,
-                warm_start=warm_start,
-                class_weight=class_weight,
-                ccp_alpha=ccp_alpha,
-                max_samples=max_samples,
-            )
-            self.maxBins = maxBins
-            self.minBinSize = minBinSize
             self.binningStrategy = binningStrategy
 
     def fit(self, X, y, sample_weight=None):
@@ -477,13 +421,19 @@ class RandomForestClassifier(RandomForestClassifier_original, RandomForestBase):
             )
 
         if _dal_ready:
-            if sklearn_check_version("1.0"):
-                self._check_feature_names(X, reset=True)
-            X = check_array(
-                X,
-                dtype=[np.float32, np.float64],
-                force_all_finite=not sklearn_check_version("1.4"),
-            )
+            check_feature_names(self, X, reset=True)
+            if sklearn_check_version("1.6"):
+                X = check_array(
+                    X,
+                    dtype=[np.float32, np.float64],
+                    ensure_all_finite=False,
+                )
+            else:
+                X = check_array(
+                    X,
+                    dtype=[np.float32, np.float64],
+                    force_all_finite=not sklearn_check_version("1.4"),
+                )
             y = np.asarray(y)
             y = np.atleast_1d(y)
 
@@ -571,8 +521,7 @@ class RandomForestClassifier(RandomForestClassifier_original, RandomForestBase):
         if not _dal_ready:
             return super().predict(X)
 
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=False)
+        check_feature_names(self, X, reset=False)
         X = check_array(
             X, accept_sparse=["csr", "csc", "coo"], dtype=[np.float64, np.float32]
         )
@@ -601,8 +550,7 @@ class RandomForestClassifier(RandomForestClassifier_original, RandomForestBase):
             The class probabilities of the input samples. The order of the
             classes corresponds to that in the attribute :term:`classes_`.
         """
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=False)
+        check_feature_names(self, X, reset=False)
         if hasattr(self, "n_features_in_"):
             try:
                 num_features = _daal_num_features(X)
@@ -645,10 +593,10 @@ class RandomForestClassifier(RandomForestClassifier_original, RandomForestBase):
             return super().predict_proba(X)
         X = check_array(X, dtype=[np.float64, np.float32])
         check_is_fitted(self)
-        self._check_n_features(X, reset=False)
+        check_n_features(self, X, reset=False)
         return self._daal_predict_proba(X)
 
-    if sklearn_check_version("1.0"):
+    if not sklearn_check_version("1.2"):
 
         @deprecated(
             "Attribute `n_features_` was deprecated in version 1.0 and will be "
@@ -679,8 +627,6 @@ class RandomForestClassifier(RandomForestClassifier_original, RandomForestBase):
             "min_impurity_decrease": self.min_impurity_decrease,
             "random_state": None,
         }
-        if not sklearn_check_version("1.0"):
-            params["min_impurity_split"] = self.min_impurity_split
         est = DecisionTreeClassifier(**params)
         # we need to set est.tree_ field with Trees constructed from
         # oneAPI Data Analytics Library solution
@@ -691,10 +637,7 @@ class RandomForestClassifier(RandomForestClassifier_original, RandomForestBase):
             est_i.set_params(
                 random_state=random_state_checked.randint(np.iinfo(np.int32).max)
             )
-            if sklearn_check_version("1.0"):
-                est_i.n_features_in_ = self.n_features_in_
-            else:
-                est_i.n_features_ = self.n_features_in_
+            est_i.n_features_in_ = self.n_features_in_
             est_i.n_outputs_ = self.n_outputs_
             est_i.classes_ = classes_
             est_i.n_classes_ = n_classes_
@@ -744,8 +687,6 @@ class RandomForestClassifier(RandomForestClassifier_original, RandomForestBase):
         y, expanded_class_weight = self._validate_y_class_weight(y)
         n_classes = self.n_classes_[0]
         self.n_features_in_ = X.shape[1]
-        if not sklearn_check_version("1.0"):
-            self.n_features_ = self.n_features_in_
 
         if expanded_class_weight is not None:
             if sample_weight is not None:
@@ -931,7 +872,7 @@ class RandomForestRegressor(RandomForestRegressor_original, RandomForestBase):
             self.min_impurity_split = None
             self.binningStrategy = binningStrategy
 
-    elif sklearn_check_version("1.0"):
+    else:
 
         def __init__(
             self,
@@ -981,57 +922,6 @@ class RandomForestRegressor(RandomForestRegressor_original, RandomForestBase):
             self.min_impurity_split = None
             self.binningStrategy = binningStrategy
 
-    else:
-
-        def __init__(
-            self,
-            n_estimators=100,
-            *,
-            criterion="mse",
-            max_depth=None,
-            min_samples_split=2,
-            min_samples_leaf=1,
-            min_weight_fraction_leaf=0.0,
-            max_features="auto",
-            max_leaf_nodes=None,
-            min_impurity_decrease=0.0,
-            min_impurity_split=None,
-            bootstrap=True,
-            oob_score=False,
-            n_jobs=None,
-            random_state=None,
-            verbose=0,
-            warm_start=False,
-            ccp_alpha=0.0,
-            max_samples=None,
-            maxBins=256,
-            minBinSize=1,
-            binningStrategy="quantiles",
-        ):
-            super().__init__(
-                n_estimators=n_estimators,
-                criterion=criterion,
-                max_depth=max_depth,
-                min_samples_split=min_samples_split,
-                min_samples_leaf=min_samples_leaf,
-                min_weight_fraction_leaf=min_weight_fraction_leaf,
-                max_features=max_features,
-                max_leaf_nodes=max_leaf_nodes,
-                min_impurity_decrease=min_impurity_decrease,
-                min_impurity_split=min_impurity_split,
-                bootstrap=bootstrap,
-                oob_score=oob_score,
-                n_jobs=n_jobs,
-                random_state=random_state,
-                verbose=verbose,
-                warm_start=warm_start,
-                ccp_alpha=ccp_alpha,
-                max_samples=max_samples,
-            )
-            self.maxBins = maxBins
-            self.minBinSize = minBinSize
-            self.binningStrategy = binningStrategy
-
     def fit(self, X, y, sample_weight=None):
         """
         Build a forest of trees from the training set (X, y).
@@ -1067,7 +957,7 @@ class RandomForestRegressor(RandomForestRegressor_original, RandomForestBase):
         if sample_weight is not None:
             sample_weight = check_sample_weight(sample_weight, X)
 
-        if sklearn_check_version("1.0") and self.criterion == "mse":
+        if not sklearn_check_version("1.2") and self.criterion == "mse":
             warnings.warn(
                 "Criterion 'mse' was deprecated in v1.0 and will be "
                 "removed in version 1.2. Use `criterion='squared_error'` "
@@ -1119,13 +1009,19 @@ class RandomForestRegressor(RandomForestRegressor_original, RandomForestBase):
             )
 
         if _dal_ready:
-            if sklearn_check_version("1.0"):
-                self._check_feature_names(X, reset=True)
-            X = check_array(
-                X,
-                dtype=[np.float64, np.float32],
-                force_all_finite=not sklearn_check_version("1.4"),
-            )
+            check_feature_names(self, X, reset=True)
+            if sklearn_check_version("1.6"):
+                X = check_array(
+                    X,
+                    dtype=[np.float64, np.float32],
+                    ensure_all_finite=False,
+                )
+            else:
+                X = check_array(
+                    X,
+                    dtype=[np.float64, np.float32],
+                    force_all_finite=not sklearn_check_version("1.4"),
+                )
             y = np.asarray(y)
             y = np.atleast_1d(y)
 
@@ -1210,14 +1106,13 @@ class RandomForestRegressor(RandomForestRegressor_original, RandomForestBase):
         if not _dal_ready:
             return super().predict(X)
 
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=False)
+        check_feature_names(self, X, reset=False)
         X = check_array(
             X, accept_sparse=["csr", "csc", "coo"], dtype=[np.float64, np.float32]
         )
         return self._daal_predict_regressor(X)
 
-    if sklearn_check_version("1.0"):
+    if not sklearn_check_version("1.2"):
 
         @deprecated(
             "Attribute `n_features_` was deprecated in version 1.0 and will be "
@@ -1245,8 +1140,6 @@ class RandomForestRegressor(RandomForestRegressor_original, RandomForestBase):
             "min_impurity_decrease": self.min_impurity_decrease,
             "random_state": None,
         }
-        if not sklearn_check_version("1.0"):
-            params["min_impurity_split"] = self.min_impurity_split
         est = DecisionTreeRegressor(**params)
 
         # we need to set est.tree_ field with Trees constructed from
@@ -1258,10 +1151,7 @@ class RandomForestRegressor(RandomForestRegressor_original, RandomForestBase):
             est_i.set_params(
                 random_state=random_state_checked.randint(np.iinfo(np.int32).max)
             )
-            if sklearn_check_version("1.0"):
-                est_i.n_features_in_ = self.n_features_in_
-            else:
-                est_i.n_features_ = self.n_features_in_
+            est_i.n_features_in_ = self.n_features_in_
             est_i.n_outputs_ = self.n_outputs_
 
             tree_i_state_class = daal4py.getTreeState(self.daal_model_, i)
@@ -1282,8 +1172,6 @@ class RandomForestRegressor(RandomForestRegressor_original, RandomForestBase):
 
     def _daal_fit_regressor(self, X, y, sample_weight=None):
         self.n_features_in_ = X.shape[1]
-        if not sklearn_check_version("1.0"):
-            self.n_features_ = self.n_features_in_
 
         rs_ = check_random_state(self.random_state)
 

--- a/daal4py/sklearn/linear_model/_coordinate_descent.py
+++ b/daal4py/sklearn/linear_model/_coordinate_descent.py
@@ -32,8 +32,9 @@ from daal4py.sklearn._utils import (
 )
 
 from .._n_jobs_support import control_n_jobs
+from ..utils.validation import check_feature_names
 
-if sklearn_check_version("1.0") and not sklearn_check_version("1.2"):
+if not sklearn_check_version("1.2"):
     from sklearn.linear_model._base import _deprecate_normalize
 if sklearn_check_version("1.1") and not sklearn_check_version("1.2"):
     from sklearn.utils import check_scalar
@@ -117,7 +118,7 @@ def _daal4py_fit_enet(self, X, y_, check_input):
     if sklearn_check_version("1.2"):
         _normalize = False
     else:
-        _normalize = self._normalize if sklearn_check_version("1.0") else self.normalize
+        _normalize = self._normalize
     if self.fit_intercept:
         X_offset = np.average(X, axis=0)
         if _normalize:
@@ -291,7 +292,7 @@ def _daal4py_fit_lasso(self, X, y_, check_input):
     if sklearn_check_version("1.2"):
         _normalize = False
     else:
-        _normalize = self._normalize if sklearn_check_version("1.0") else self.normalize
+        _normalize = self._normalize
     if self.fit_intercept:
         X_offset = np.average(X, axis=0)
         if _normalize:
@@ -434,8 +435,7 @@ def _daal4py_predict_lasso(self, X):
 
 
 def _fit(self, _X, _y, sample_weight=None, check_input=True):
-    if sklearn_check_version("1.0"):
-        self._check_feature_names(_X, reset=True)
+    check_feature_names(self, _X, reset=True)
     if sklearn_check_version("1.2"):
         self._validate_params()
     elif sklearn_check_version("1.1"):
@@ -534,7 +534,7 @@ def _fit(self, _X, _y, sample_weight=None, check_input=True):
             # print(X.flags)
             raise ValueError("ndarray is not Fortran contiguous")
 
-    if sklearn_check_version("1.0") and not sklearn_check_version("1.2"):
+    if not sklearn_check_version("1.2"):
         self._normalize = _deprecate_normalize(
             self.normalize, default=False, estimator_name=class_name
         )
@@ -661,7 +661,7 @@ class ElasticNet(ElasticNet_original):
             alpha=1.0,
             l1_ratio=0.5,
             fit_intercept=True,
-            normalize="deprecated" if sklearn_check_version("1.0") else False,
+            normalize="deprecated",
             precompute=False,
             max_iter=1000,
             copy_X=True,
@@ -690,8 +690,7 @@ class ElasticNet(ElasticNet_original):
         return _fit(self, X, y, sample_weight=sample_weight, check_input=check_input)
 
     def predict(self, X):
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=False)
+        check_feature_names(self, X, reset=False)
 
         _X = check_array(
             X, accept_sparse=["csr", "csc", "coo"], dtype=[np.float64, np.float32]
@@ -776,7 +775,7 @@ class Lasso(Lasso_original):
             self,
             alpha=1.0,
             fit_intercept=True,
-            normalize="deprecated" if sklearn_check_version("1.0") else False,
+            normalize="deprecated",
             precompute=False,
             copy_X=True,
             max_iter=1000,
@@ -805,8 +804,7 @@ class Lasso(Lasso_original):
         return _fit(self, X, y, sample_weight, check_input)
 
     def predict(self, X):
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=False)
+        check_feature_names(self, X, reset=False)
         _X = check_array(
             X, accept_sparse=["csr", "csc", "coo"], dtype=[np.float64, np.float32]
         )

--- a/daal4py/sklearn/linear_model/_linear.py
+++ b/daal4py/sklearn/linear_model/_linear.py
@@ -20,10 +20,9 @@ from sklearn.linear_model import LinearRegression as LinearRegression_original
 from sklearn.utils import check_array
 
 from .._utils import sklearn_check_version
-from ..utils.base import _daal_validate_data
-from ..utils.validation import _daal_check_array
+from ..utils.validation import _daal_check_array, check_feature_names, validate_data
 
-if sklearn_check_version("1.0") and not sklearn_check_version("1.2"):
+if not sklearn_check_version("1.2"):
     from sklearn.linear_model._base import _deprecate_normalize
 
 import logging
@@ -108,7 +107,7 @@ def _fit_linear(self, X, y, sample_weight=None):
         "y_numeric": True,
         "multi_output": True,
     }
-    X, y = _daal_validate_data(
+    X, y = validate_data(
         self,
         dtype=[np.float64, np.float32],
         **params,
@@ -152,8 +151,7 @@ def _fit_linear(self, X, y, sample_weight=None):
 
 
 def _predict_linear(self, X):
-    if sklearn_check_version("1.0"):
-        self._check_feature_names(X, reset=False)
+    check_feature_names(self, X, reset=False)
     is_df = is_DataFrame(X)
     X = check_array(X, accept_sparse="csr", dtype=[np.float64, np.float32])
     X = np.asarray(X) if not sp.issparse(X) and not is_df else X
@@ -224,7 +222,7 @@ class LinearRegression(LinearRegression_original):
         def __init__(
             self,
             fit_intercept=True,
-            normalize="deprecated" if sklearn_check_version("1.0") else False,
+            normalize="deprecated",
             copy_X=True,
             n_jobs=None,
             positive=False,
@@ -238,14 +236,13 @@ class LinearRegression(LinearRegression_original):
             )
 
     def fit(self, X, y, sample_weight=None):
-        if sklearn_check_version("1.0") and not sklearn_check_version("1.2"):
+        if not sklearn_check_version("1.2"):
             self._normalize = _deprecate_normalize(
                 self.normalize,
                 default=False,
                 estimator_name=self.__class__.__name__,
             )
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=True)
+        check_feature_names(self, X, reset=True)
         if sklearn_check_version("1.2"):
             self._validate_params()
 

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -34,6 +34,7 @@ import daal4py as d4p
 
 from .._n_jobs_support import control_n_jobs
 from .._utils import PatchingConditionsChain, getFPType, sklearn_check_version
+from ..utils.validation import check_feature_names
 from .logistic_loss import (
     _daal4py_cross_entropy_loss_extra_args,
     _daal4py_grad_,
@@ -793,8 +794,7 @@ def daal4py_fit(self, X, y, sample_weight=None):
 
 def daal4py_predict(self, X, resultsToEvaluate):
     check_is_fitted(self)
-    if sklearn_check_version("1.0"):
-        self._check_feature_names(X, reset=False)
+    check_feature_names(self, X, reset=False)
     X = check_array(X, accept_sparse="csr", dtype=[np.float64, np.float32])
     try:
         fptype = getFPType(X)
@@ -1005,8 +1005,7 @@ class LogisticRegression(LogisticRegression_original):
         self.l1_ratio = l1_ratio
 
     def fit(self, X, y, sample_weight=None):
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=True)
+        check_feature_names(self, X, reset=True)
         if sklearn_check_version("1.2"):
             self._validate_params()
         return daal4py_fit(self, X, y, sample_weight)

--- a/daal4py/sklearn/manifold/_t_sne.py
+++ b/daal4py/sklearn/manifold/_t_sne.py
@@ -37,6 +37,7 @@ from daal4py.sklearn._utils import (
 
 from .._n_jobs_support import control_n_jobs
 from ..neighbors import NearestNeighbors
+from ..utils.validation import validate_data
 
 
 @control_n_jobs(decorated_methods=["fit"])
@@ -183,15 +184,19 @@ class TSNE(BaseTSNE):
                     )
 
         if self.method == "barnes_hut":
-            X = self._validate_data(
+            X = validate_data(
+                self,
                 X,
                 accept_sparse=["csr"],
                 ensure_min_samples=2,
                 dtype=[np.float32, np.float64],
             )
         else:
-            X = self._validate_data(
-                X, accept_sparse=["csr", "csc", "coo"], dtype=[np.float32, np.float64]
+            X = validate_data(
+                self,
+                X,
+                accept_sparse=["csr", "csc", "coo"],
+                dtype=[np.float32, np.float64],
             )
 
         if self.metric == "precomputed":

--- a/daal4py/sklearn/metrics/_pairwise.py
+++ b/daal4py/sklearn/metrics/_pairwise.py
@@ -107,9 +107,14 @@ def _pairwise_distances(
             return _daal4py_correlation_distance_dense(X)
         raise ValueError(f"'{metric}' distance is wrong for daal4py.")
     if metric == "precomputed":
-        X, _ = check_pairwise_arrays(
-            X, Y, precomputed=True, force_all_finite=force_all_finite
-        )
+        if sklearn_check_version("1.6"):
+            X, _ = check_pairwise_arrays(
+                X, Y, precomputed=True, ensure_all_finite=force_all_finite
+            )
+        else:
+            X, _ = check_pairwise_arrays(
+                X, Y, precomputed=True, force_all_finite=force_all_finite
+            )
         whom = (
             "`pairwise_distances`. Precomputed distance "
             " need to have non-negative values."
@@ -119,9 +124,20 @@ def _pairwise_distances(
     if metric in PAIRWISE_DISTANCE_FUNCTIONS:
         func = PAIRWISE_DISTANCE_FUNCTIONS[metric]
     elif callable(metric):
-        func = partial(
-            _pairwise_callable, metric=metric, force_all_finite=force_all_finite, **kwds
-        )
+        if sklearn_check_version("1.6"):
+            func = partial(
+                _pairwise_callable,
+                metric=metric,
+                ensure_all_finite=force_all_finite,
+                **kwds,
+            )
+        else:
+            func = partial(
+                _pairwise_callable,
+                metric=metric,
+                force_all_finite=force_all_finite,
+                **kwds,
+            )
     else:
         if issparse(X) or issparse(Y):
             raise TypeError("scipy distance metrics do not" " support sparse matrices.")
@@ -132,7 +148,14 @@ def _pairwise_distances(
             msg = "Data was converted to boolean for metric %s" % metric
             warnings.warn(msg, DataConversionWarning)
 
-        X, Y = check_pairwise_arrays(X, Y, dtype=dtype, force_all_finite=force_all_finite)
+        if sklearn_check_version("1.6"):
+            X, Y = check_pairwise_arrays(
+                X, Y, dtype=dtype, ensure_all_finite=force_all_finite
+            )
+        else:
+            X, Y = check_pairwise_arrays(
+                X, Y, dtype=dtype, force_all_finite=force_all_finite
+            )
 
         # precompute data-derived metric params
         params = _precompute_metric_params(X, Y, metric=metric, **kwds)

--- a/daal4py/sklearn/neighbors/_classification.py
+++ b/daal4py/sklearn/neighbors/_classification.py
@@ -25,6 +25,7 @@ from sklearn.neighbors._classification import (
 from sklearn.utils.validation import check_array
 
 from .._utils import PatchingConditionsChain, getFPType, sklearn_check_version
+from ..utils.validation import check_feature_names
 from ._base import KNeighborsMixin, NeighborsBase, parse_auto_method, prediction_algorithm
 
 if not sklearn_check_version("1.2"):
@@ -34,8 +35,7 @@ from sklearn.utils.validation import _deprecate_positional_args
 
 
 def daal4py_classifier_predict(estimator, X, base_predict):
-    if sklearn_check_version("1.0"):
-        estimator._check_feature_names(X, reset=False)
+    check_feature_names(estimator, X, reset=False)
     X = check_array(X, accept_sparse="csr", dtype=[np.float64, np.float32])
     daal_model = getattr(estimator, "_daal_model", None)
     n_features = getattr(estimator, "n_features_in_", None)
@@ -119,9 +119,7 @@ class KNeighborsClassifier(KNeighborsMixin, BaseClassifierMixin, NeighborsBase):
             n_jobs=n_jobs,
             **kwargs,
         )
-        self.weights = (
-            weights if sklearn_check_version("1.0") else _check_weights(weights)
-        )
+        self.weights = weights
 
     def fit(self, X, y):
         return NeighborsBase._fit(self, X, y)
@@ -130,8 +128,7 @@ class KNeighborsClassifier(KNeighborsMixin, BaseClassifierMixin, NeighborsBase):
         return daal4py_classifier_predict(self, X, BaseKNeighborsClassifier.predict)
 
     def predict_proba(self, X):
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=False)
+        check_feature_names(self, X, reset=False)
         return BaseKNeighborsClassifier.predict_proba(self, X)
 
     fit.__doc__ = BaseKNeighborsClassifier.fit.__doc__

--- a/daal4py/sklearn/neighbors/_regression.py
+++ b/daal4py/sklearn/neighbors/_regression.py
@@ -20,6 +20,7 @@ from sklearn.base import RegressorMixin
 from sklearn.neighbors._regression import KNeighborsRegressor as BaseKNeighborsRegressor
 
 from .._utils import sklearn_check_version
+from ..utils.validation import check_feature_names
 from ._base import KNeighborsMixin, NeighborsBase
 
 if not sklearn_check_version("1.2"):
@@ -55,9 +56,7 @@ class KNeighborsRegressor(KNeighborsMixin, RegressorMixin, NeighborsBase):
             n_jobs=n_jobs,
             **kwargs,
         )
-        self.weights = (
-            weights if sklearn_check_version("1.0") else _check_weights(weights)
-        )
+        self.weights = weights
 
     def _more_tags(self):
         return BaseKNeighborsRegressor._more_tags(self)
@@ -66,8 +65,7 @@ class KNeighborsRegressor(KNeighborsMixin, RegressorMixin, NeighborsBase):
         return NeighborsBase._fit(self, X, y)
 
     def predict(self, X):
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=False)
+        check_feature_names(self, X, reset=False)
         return BaseKNeighborsRegressor.predict(self, X)
 
     fit.__doc__ = BaseKNeighborsRegressor.fit.__doc__

--- a/daal4py/sklearn/svm/svm.py
+++ b/daal4py/sklearn/svm/svm.py
@@ -35,6 +35,7 @@ from sklearn.utils.validation import (
 import daal4py
 
 from .._utils import PatchingConditionsChain, getFPType, make2d
+from ..utils.validation import validate_data
 
 
 def _get_libsvm_impl():
@@ -421,7 +422,8 @@ def fit(self, X, y, sample_weight=None):
     if callable(self.kernel):
         check_consistent_length(X, y)
     else:
-        X, y = self._validate_data(
+        X, y = validate_data(
+            self,
             X,
             y,
             dtype=np.float64,

--- a/daal4py/sklearn/utils/base.py
+++ b/daal4py/sklearn/utils/base.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 # ==============================================================================
 
-from .validation import _daal_check_array, _daal_check_X_y
+from .validation import (
+    _daal_check_array,
+    _daal_check_X_y,
+    check_n_features,
+    get_requires_y_tag,
+)
 
 
 def _daal_validate_data(
@@ -50,7 +55,7 @@ def _daal_validate_data(
     """
 
     if y is None:
-        if self._get_tags()["requires_y"]:
+        if get_requires_y_tag(self):
             raise ValueError(
                 f"This {self.__class__.__name__} estimator "
                 f"requires y to be passed, but the target y is None."
@@ -71,5 +76,5 @@ def _daal_validate_data(
         out = X, y
 
     if check_params.get("ensure_2d", True):
-        self._check_n_features(X, reset=reset)
+        check_n_features(self, X, reset=reset)
     return out

--- a/daal4py/sklearn/utils/validation.py
+++ b/daal4py/sklearn/utils/validation.py
@@ -717,6 +717,8 @@ def _daal_num_features(X):
 
 
 def get_requires_y_tag(estimator):
+    """Gets the value of the 'requires_y' tag from the estimator
+    using correct code path depending on the scikit-learn version."""
     if sklearn_check_version("1.6"):
         requires_y = estimator.__sklearn_tags__().target_tags.required
     else:

--- a/onedal/linear_model/linear_model.py
+++ b/onedal/linear_model/linear_model.py
@@ -344,8 +344,9 @@ class Ridge(BaseLinearRegression):
             packed_coefficients[:, 0],
         )
 
-        if self.coef_.shape[0] == 1 and y.ndim == 1:
+        if self.coef_.shape[0] == 1:
             self.coef_ = self.coef_.ravel()
-            self.intercept_ = self.intercept_[0]
+            if y.ndim == 1:
+                self.intercept_ = self.intercept_[0]
 
         return self

--- a/onedal/linear_model/linear_model.py
+++ b/onedal/linear_model/linear_model.py
@@ -344,9 +344,8 @@ class Ridge(BaseLinearRegression):
             packed_coefficients[:, 0],
         )
 
-        if self.coef_.shape[0] == 1:
+        if self.coef_.shape[0] == 1 and y.ndim == 1:
             self.coef_ = self.coef_.ravel()
-            if y.ndim == 1:
-                self.intercept_ = self.intercept_[0]
+            self.intercept_ = self.intercept_[0]
 
         return self

--- a/onedal/utils/_dpep_helpers.py
+++ b/onedal/utils/_dpep_helpers.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
-""" Utilities for Data Parallel Extensions libs, such as DPNP, DPCtl.
+"""Utilities for Data Parallel Extensions libs, such as DPNP, DPCtl.
 See `Data Parallel Extensions for Python <https://github.com/IntelPython/DPEP>`__
 """
 

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -131,6 +131,10 @@ def _validate_targets(y, class_weight, dtype):
 
 
 def get_finite_keyword():
+    """Gets the argument name for scikit-learn's validation functions compatible with
+    the current version of scikit-learn and using function inspection instead of
+    `sklearn_check_version` due to `onedal` design rule: sklearn versioning should occur
+    in `sklearnex` module."""
     if "ensure_all_finite" in inspect.signature(check_array).parameters:
         return "ensure_all_finite"
     return "force_all_finite"

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -133,7 +133,7 @@ def _validate_targets(y, class_weight, dtype):
 def get_finite_keyword():
     """Gets the argument name for scikit-learn's validation functions compatible with
     the current version of scikit-learn and using function inspection instead of
-    `sklearn_check_version` due to `onedal` design rule: sklearn versioning should occur
+    version check due to `onedal` design rule: sklearn versioning should occur
     in `sklearnex` module."""
     if "ensure_all_finite" in inspect.signature(check_array).parameters:
         return "ensure_all_finite"

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
+import inspect
 import warnings
 from collections.abc import Sequence
 from numbers import Integral
@@ -129,6 +130,12 @@ def _validate_targets(y, class_weight, dtype):
     return np.asarray(y, dtype=dtype, order="C"), class_weight_res, classes
 
 
+def get_finite_keyword():
+    if "ensure_all_finite" in inspect.signature(check_array).parameters:
+        return "ensure_all_finite"
+    return "force_all_finite"
+
+
 def _check_array(
     array,
     dtype="numeric",
@@ -138,6 +145,7 @@ def _check_array(
     force_all_finite=True,
     ensure_2d=True,
     accept_large_sparse=True,
+    _finite_keyword=get_finite_keyword(),
 ):
     if force_all_finite:
         if sp.issparse(array):
@@ -147,15 +155,19 @@ def _check_array(
         else:
             _daal4py_assert_all_finite(array)
             force_all_finite = False
+    check_kwargs = {
+        "array": array,
+        "dtype": dtype,
+        "accept_sparse": accept_sparse,
+        "order": order,
+        "copy": copy,
+        "ensure_2d": ensure_2d,
+        "accept_large_sparse": accept_large_sparse,
+    }
+    check_kwargs[_finite_keyword] = force_all_finite
+
     array = check_array(
-        array=array,
-        dtype=dtype,
-        accept_sparse=accept_sparse,
-        order=order,
-        copy=copy,
-        force_all_finite=force_all_finite,
-        ensure_2d=ensure_2d,
-        accept_large_sparse=accept_large_sparse,
+        **check_kwargs,
     )
 
     if sp.issparse(array):

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -60,6 +60,16 @@ def _get_backend(obj, queue, method_name, *data):
     raise RuntimeError("Device support is not implemented")
 
 
+def get_array_api_support_tag(estimator):
+    if hasattr(estimator, "__sklearn_tags__"):
+        return estimator.__sklearn_tags__().array_api_support
+    elif hasattr(estimator, "_get_tags"):
+        tags = estimator._get_tags()
+        if "array_api_support" in tags:
+            return tags["array_api_support"]
+    return False
+
+
 def dispatch(obj, method_name, branches, *args, **kwargs):
     if get_config()["use_raw_input"] is False:
         with QM.manage_global_queue(None, *args) as queue:
@@ -78,8 +88,7 @@ def dispatch(obj, method_name, branches, *args, **kwargs):
                 if (
                     "array_api_dispatch" in get_config()
                     and get_config()["array_api_dispatch"]
-                    and "array_api_support" in obj._get_tags()
-                    and obj._get_tags()["array_api_support"]
+                    and get_array_api_support_tag(obj)
                     and not has_usm_data
                 ):
                     # USM ndarrays are also excluded for the fallback Array API. Currently, DPNP.ndarray is

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -61,6 +61,8 @@ def _get_backend(obj, queue, method_name, *data):
 
 
 def get_array_api_support_tag(estimator):
+    """Gets the value of the 'array_api_support' tag from the estimator
+    using correct code path depending on the scikit-learn version."""
     if hasattr(estimator, "__sklearn_tags__"):
         return estimator.__sklearn_tags__().array_api_support
     elif hasattr(estimator, "_get_tags"):

--- a/sklearnex/basic_statistics/basic_statistics.py
+++ b/sklearnex/basic_statistics/basic_statistics.py
@@ -29,11 +29,7 @@ from onedal.utils.validation import _is_csr
 
 from .._device_offload import dispatch
 from .._utils import ExtensionEstimator, PatchingConditionsChain
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = BaseEstimator._validate_data
+from ..utils.validation import validate_data
 
 if sklearn_check_version("1.2"):
     from sklearn.utils._param_validation import StrOptions
@@ -204,16 +200,13 @@ class BasicStatistics(ExtensionEstimator, BaseEstimator):
         if sklearn_check_version("1.2"):
             self._validate_params()
 
-        if sklearn_check_version("1.0"):
-            X = validate_data(
-                self,
-                X,
-                dtype=[np.float64, np.float32],
-                ensure_2d=False,
-                accept_sparse="csr",
-            )
-        else:
-            X = check_array(X, dtype=[np.float64, np.float32])
+        X = validate_data(
+            self,
+            X,
+            dtype=[np.float64, np.float32],
+            ensure_2d=False,
+            accept_sparse="csr",
+        )
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X)

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -32,17 +32,13 @@ from .._utils import (
     PatchingConditionsChain,
     _add_inc_serialization_note,
 )
+from ..utils.validation import validate_data
 
 if sklearn_check_version("1.2"):
     from sklearn.utils._param_validation import Interval, StrOptions
 
 import numbers
 import warnings
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = BaseEstimator._validate_data
 
 
 @control_n_jobs(decorated_methods=["partial_fit", "_onedal_finalize_fit"])
@@ -200,18 +196,12 @@ class IncrementalBasicStatistics(ExtensionEstimator, BaseEstimator):
         # never check input when using raw input
         check_input &= use_raw_input is False
         if check_input:
-            if sklearn_check_version("1.0"):
-                X = validate_data(
-                    self,
-                    X,
-                    dtype=[np.float64, np.float32],
-                    reset=first_pass,
-                )
-            else:
-                X = check_array(
-                    X,
-                    dtype=[np.float64, np.float32],
-                )
+            X = validate_data(
+                self,
+                X,
+                dtype=[np.float64, np.float32],
+                reset=first_pass,
+            )
 
         if not use_raw_input and sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X)
@@ -238,10 +228,7 @@ class IncrementalBasicStatistics(ExtensionEstimator, BaseEstimator):
             if sklearn_check_version("1.2"):
                 self._validate_params()
 
-            if sklearn_check_version("1.0"):
-                X = validate_data(self, X, dtype=[np.float64, np.float32])
-            else:
-                X = check_array(X, dtype=[np.float64, np.float32])
+            X = validate_data(self, X, dtype=[np.float64, np.float32])
 
             if sample_weight is not None:
                 sample_weight = _check_sample_weight(sample_weight, X)

--- a/sklearnex/cluster/dbscan.py
+++ b/sklearnex/cluster/dbscan.py
@@ -28,14 +28,10 @@ from onedal.cluster import DBSCAN as onedal_DBSCAN
 from .._config import get_config
 from .._device_offload import dispatch
 from .._utils import PatchableEstimator, PatchingConditionsChain
+from ..utils.validation import validate_data
 
 if sklearn_check_version("1.1") and not sklearn_check_version("1.2"):
     from sklearn.utils import check_scalar
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = _sklearn_DBSCAN._validate_data
 
 
 class BaseDBSCAN(ABC):
@@ -91,8 +87,7 @@ class DBSCAN(PatchableEstimator, _sklearn_DBSCAN, BaseDBSCAN):
 
     def _onedal_fit(self, X, y, sample_weight=None, queue=None):
         if get_config()["use_raw_input"] is False:
-            if sklearn_check_version("1.0"):
-                X = validate_data(self, X, force_all_finite=False)
+            X = validate_data(self, X, ensure_all_finite=False)
 
         onedal_params = {
             "eps": self.eps,

--- a/sklearnex/cluster/k_means.py
+++ b/sklearnex/cluster/k_means.py
@@ -40,11 +40,7 @@ if daal_check_version((2023, "P", 200)):
 
     from .._device_offload import dispatch, wrap_output_data
     from .._utils import PatchableEstimator, PatchingConditionsChain
-
-    if sklearn_check_version("1.6"):
-        from sklearn.utils.validation import validate_data
-    else:
-        validate_data = _sklearn_KMeans._validate_data
+    from ..utils.validation import validate_data
 
     @control_n_jobs(decorated_methods=["fit", "fit_transform", "predict", "score"])
     class KMeans(PatchableEstimator, _sklearn_KMeans):

--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -35,6 +35,7 @@ if daal_check_version((2024, "P", 100)):
     from .._device_offload import dispatch, wrap_output_data
     from .._utils import PatchingConditionsChain
     from ..utils._array_api import get_namespace
+    from ..utils.validation import validate_data
 
     if sklearn_check_version("1.1") and not sklearn_check_version("1.2"):
         from sklearn.utils import check_scalar
@@ -45,11 +46,6 @@ if daal_check_version((2024, "P", 100)):
     from sklearn.decomposition import PCA as _sklearn_PCA
 
     from onedal.decomposition import PCA as onedal_PCA
-
-    if sklearn_check_version("1.6"):
-        from sklearn.utils.validation import validate_data
-    else:
-        validate_data = _sklearn_PCA._validate_data
 
     @control_n_jobs(decorated_methods=["fit", "transform", "fit_transform"])
     class PCA(PatchableEstimator, _sklearn_PCA):
@@ -184,18 +180,12 @@ if daal_check_version((2024, "P", 100)):
             )
 
         def _onedal_transform(self, X, queue=None):
-            if sklearn_check_version("1.0"):
-                X = validate_data(
-                    self,
-                    X,
-                    dtype=[np.float64, np.float32],
-                    reset=False,
-                )
-            else:
-                X = check_array(
-                    X,
-                    dtype=[np.float64, np.float32],
-                )
+            X = validate_data(
+                self,
+                X,
+                dtype=[np.float64, np.float32],
+                reset=False,
+            )
             self._validate_n_features_in_after_fitting(X)
 
             return self._onedal_estimator.predict(X, queue=queue)

--- a/sklearnex/dispatcher.py
+++ b/sklearnex/dispatcher.py
@@ -454,10 +454,10 @@ def get_patch_names():
 def patch_sklearn(name=None, verbose=True, global_patch=False, preview=False):
     if preview:
         os.environ["SKLEARNEX_PREVIEW"] = "enabled_via_patch_sklearn"
-    if not sklearn_check_version("0.24"):
+    if not sklearn_check_version("1.0"):
         raise NotImplementedError(
             "Extension for Scikit-learn* patches apply "
-            "for scikit-learn >= 0.24 only ..."
+            "for scikit-learn >= 1.0 only ..."
         )
 
     if global_patch:

--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -90,7 +90,6 @@ class BaseForest(PatchableEstimator, ABC):
                 dtype=[np.float64, np.float32],
                 ensure_all_finite=False,
                 ensure_2d=True,
-                skip_y_conversion=True,
             )
 
             if sample_weight is not None:
@@ -815,7 +814,6 @@ class ForestClassifier(_sklearn_ForestClassifier, BaseForest):
                 ensure_all_finite=False,
                 reset=False,
                 ensure_2d=True,
-                skip_y_conversion=True,
             )
             if hasattr(self, "n_features_in_"):
                 try:
@@ -850,7 +848,6 @@ class ForestClassifier(_sklearn_ForestClassifier, BaseForest):
                 ensure_all_finite=False,
                 reset=False,
                 ensure_2d=True,
-                skip_y_conversion=True,
             )
 
         return self._onedal_estimator.predict_proba(X, queue=queue)
@@ -1160,7 +1157,6 @@ class ForestRegressor(_sklearn_ForestRegressor, BaseForest):
                 ensure_all_finite=False,
                 reset=False,
                 ensure_2d=True,
-                skip_y_conversion=True,
             )  # Warning, order of dtype matters
 
         return self._onedal_estimator.predict(X, queue=queue)

--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -66,16 +66,12 @@ from .._config import get_config
 from .._device_offload import dispatch, wrap_output_data
 from .._utils import PatchableEstimator, PatchingConditionsChain
 from ..utils._array_api import get_namespace
+from ..utils.validation import check_n_features, validate_data
 
 if sklearn_check_version("1.2"):
     from sklearn.utils._param_validation import Interval
 if sklearn_check_version("1.4"):
     from daal4py.sklearn.utils import _assert_all_finite
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = BaseEstimator._validate_data
 
 
 class BaseForest(PatchableEstimator, ABC):
@@ -92,7 +88,7 @@ class BaseForest(PatchableEstimator, ABC):
                 multi_output=True,
                 accept_sparse=False,
                 dtype=[np.float64, np.float32],
-                force_all_finite=False,
+                ensure_all_finite=False,
                 ensure_2d=True,
             )
 
@@ -156,10 +152,7 @@ class BaseForest(PatchableEstimator, ABC):
             "max_samples": self.max_samples,
         }
 
-        if not sklearn_check_version("1.0"):
-            onedal_params["min_impurity_split"] = self.min_impurity_split
-        else:
-            onedal_params["min_impurity_split"] = None
+        onedal_params["min_impurity_split"] = None
 
         # Lazy evaluation of estimators_
         self._cached_estimators_ = None
@@ -361,8 +354,6 @@ class BaseForest(PatchableEstimator, ABC):
             "min_impurity_decrease": self._onedal_estimator.min_impurity_decrease,
             "random_state": None,
         }
-        if not sklearn_check_version("1.0"):
-            params["min_impurity_split"] = self._onedal_estimator.min_impurity_split
         est = self.estimator.__class__(**params)
         # we need to set est.tree_ field with Trees constructed from
         # oneAPI Data Analytics Library solution
@@ -375,10 +366,7 @@ class BaseForest(PatchableEstimator, ABC):
             est_i.set_params(
                 random_state=random_state_checked.randint(np.iinfo(np.int32).max)
             )
-            if sklearn_check_version("1.0"):
-                est_i.n_features_in_ = self.n_features_in_
-            else:
-                est_i.n_features_ = self.n_features_in_
+            est_i.n_features_in_ = self.n_features_in_
             est_i.n_outputs_ = self.n_outputs_
             est_i.n_classes_ = n_classes_
             tree_i_state_class = self._get_tree_state(
@@ -401,7 +389,7 @@ class BaseForest(PatchableEstimator, ABC):
 
         self._cached_estimators_ = estimators_
 
-    if sklearn_check_version("1.0"):
+    if not sklearn_check_version("1.2"):
 
         @deprecated(
             "Attribute `n_features_` was deprecated in version 1.0 and will be "
@@ -410,8 +398,6 @@ class BaseForest(PatchableEstimator, ABC):
         @property
         def n_features_(self):
             return self.n_features_in_
-
-    if not sklearn_check_version("1.2"):
 
         @property
         def base_estimator(self):
@@ -558,14 +544,24 @@ class ForestClassifier(_sklearn_ForestClassifier, BaseForest):
             )
 
         if patching_status.get_status():
-            X, y = check_X_y(
-                X,
-                y,
-                multi_output=True,
-                accept_sparse=True,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-            )
+            if sklearn_check_version("1.6"):
+                X, y = check_X_y(
+                    X,
+                    y,
+                    multi_output=True,
+                    accept_sparse=True,
+                    dtype=[np.float64, np.float32],
+                    ensure_all_finite=False,
+                )
+            else:
+                X, y = check_X_y(
+                    X,
+                    y,
+                    multi_output=True,
+                    accept_sparse=True,
+                    dtype=[np.float64, np.float32],
+                    force_all_finite=False,
+                )
 
             if y.ndim == 2 and y.shape[1] == 1:
                 warnings.warn(
@@ -811,21 +807,14 @@ class ForestClassifier(_sklearn_ForestClassifier, BaseForest):
     def _onedal_predict(self, X, queue=None):
         xp, _ = get_namespace(X)
         if not get_config()["use_raw_input"]:
-            if sklearn_check_version("1.0"):
-                X = validate_data(
-                    self,
-                    X,
-                    dtype=[np.float64, np.float32],
-                    force_all_finite=False,
-                    reset=False,
-                    ensure_2d=True,
-                )
-            else:
-                X = check_array(
-                    X,
-                    dtype=[np.float64, np.float32],
-                    force_all_finite=False,
-                )  # Warning, order of dtype matters
+            X = validate_data(
+                self,
+                X,
+                dtype=[np.float64, np.float32],
+                ensure_all_finite=False,
+                reset=False,
+                ensure_2d=True,
+            )
             if hasattr(self, "n_features_in_"):
                 try:
                     num_features = _num_features(X)
@@ -839,7 +828,7 @@ class ForestClassifier(_sklearn_ForestClassifier, BaseForest):
                             f"{self.n_features_in_} features as input"
                         )
                     )
-            self._check_n_features(X, reset=False)
+            check_n_features(self, X, reset=False)
 
         res = self._onedal_estimator.predict(X, queue=queue)
         try:
@@ -852,22 +841,14 @@ class ForestClassifier(_sklearn_ForestClassifier, BaseForest):
     def _onedal_predict_proba(self, X, queue=None):
         use_raw_input = get_config().get("use_raw_input", False) is True
         if not use_raw_input:
-            if sklearn_check_version("1.0"):
-                X = validate_data(
-                    self,
-                    X,
-                    dtype=[np.float64, np.float32],
-                    force_all_finite=False,
-                    reset=False,
-                    ensure_2d=True,
-                )
-            else:
-                X = check_array(
-                    X,
-                    dtype=[np.float64, np.float32],
-                    force_all_finite=False,
-                )  # Warning, order of dtype matters
-                self._check_n_features(X, reset=False)
+            X = validate_data(
+                self,
+                X,
+                dtype=[np.float64, np.float32],
+                ensure_all_finite=False,
+                reset=False,
+                ensure_2d=True,
+            )
 
         return self._onedal_estimator.predict_proba(X, queue=queue)
 
@@ -934,7 +915,7 @@ class ForestRegressor(_sklearn_ForestRegressor, BaseForest):
         if not self.bootstrap and self.oob_score:
             raise ValueError("Out of bag estimation only available" " if bootstrap=True")
 
-        if sklearn_check_version("1.0") and self.criterion == "mse":
+        if not sklearn_check_version("1.2") and self.criterion == "mse":
             warnings.warn(
                 "Criterion 'mse' was deprecated in v1.0 and will be "
                 "removed in version 1.2. Use `criterion='squared_error'` "
@@ -985,14 +966,24 @@ class ForestRegressor(_sklearn_ForestRegressor, BaseForest):
             )
 
         if patching_status.get_status():
-            X, y = check_X_y(
-                X,
-                y,
-                multi_output=True,
-                accept_sparse=True,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-            )
+            if sklearn_check_version("1.6"):
+                X, y = check_X_y(
+                    X,
+                    y,
+                    multi_output=True,
+                    accept_sparse=True,
+                    dtype=[np.float64, np.float32],
+                    ensure_all_finite=False,
+                )
+            else:
+                X, y = check_X_y(
+                    X,
+                    y,
+                    multi_output=True,
+                    accept_sparse=True,
+                    dtype=[np.float64, np.float32],
+                    force_all_finite=False,
+                )
 
             if y.ndim == 2 and y.shape[1] == 1:
                 warnings.warn(
@@ -1159,19 +1150,14 @@ class ForestRegressor(_sklearn_ForestRegressor, BaseForest):
         use_raw_input = get_config().get("use_raw_input", False) is True
 
         if not use_raw_input:
-            if sklearn_check_version("1.0"):
-                X = validate_data(
-                    self,
-                    X,
-                    dtype=[np.float64, np.float32],
-                    force_all_finite=False,
-                    reset=False,
-                    ensure_2d=True,
-                )  # Warning, order of dtype matters
-            else:
-                X = check_array(
-                    X, dtype=[np.float64, np.float32], force_all_finite=False
-                )  # Warning, order of dtype matters
+            X = validate_data(
+                self,
+                X,
+                dtype=[np.float64, np.float32],
+                ensure_all_finite=False,
+                reset=False,
+                ensure_2d=True,
+            )  # Warning, order of dtype matters
 
         return self._onedal_estimator.predict(X, queue=queue)
 
@@ -1306,7 +1292,7 @@ class RandomForestClassifier(ForestClassifier):
             self.min_bin_size = min_bin_size
             self.monotonic_cst = monotonic_cst
 
-    elif sklearn_check_version("1.0"):
+    else:
 
         def __init__(
             self,
@@ -1366,74 +1352,6 @@ class RandomForestClassifier(ForestClassifier):
             self.max_leaf_nodes = max_leaf_nodes
             self.min_impurity_decrease = min_impurity_decrease
             self.ccp_alpha = ccp_alpha
-            self.max_bins = max_bins
-            self.min_bin_size = min_bin_size
-
-    else:
-
-        def __init__(
-            self,
-            n_estimators=100,
-            *,
-            criterion="gini",
-            max_depth=None,
-            min_samples_split=2,
-            min_samples_leaf=1,
-            min_weight_fraction_leaf=0.0,
-            max_features="auto",
-            max_leaf_nodes=None,
-            min_impurity_decrease=0.0,
-            min_impurity_split=None,
-            bootstrap=True,
-            oob_score=False,
-            n_jobs=None,
-            random_state=None,
-            verbose=0,
-            warm_start=False,
-            class_weight=None,
-            ccp_alpha=0.0,
-            max_samples=None,
-            max_bins=256,
-            min_bin_size=1,
-        ):
-            super().__init__(
-                DecisionTreeClassifier(),
-                n_estimators,
-                estimator_params=(
-                    "criterion",
-                    "max_depth",
-                    "min_samples_split",
-                    "min_samples_leaf",
-                    "min_weight_fraction_leaf",
-                    "max_features",
-                    "max_leaf_nodes",
-                    "min_impurity_decrease",
-                    "min_impurity_split",
-                    "random_state",
-                    "ccp_alpha",
-                ),
-                bootstrap=bootstrap,
-                oob_score=oob_score,
-                n_jobs=n_jobs,
-                random_state=random_state,
-                verbose=verbose,
-                warm_start=warm_start,
-                class_weight=class_weight,
-                max_samples=max_samples,
-            )
-
-            self.criterion = criterion
-            self.max_depth = max_depth
-            self.min_samples_split = min_samples_split
-            self.min_samples_leaf = min_samples_leaf
-            self.min_weight_fraction_leaf = min_weight_fraction_leaf
-            self.max_features = max_features
-            self.max_leaf_nodes = max_leaf_nodes
-            self.min_impurity_decrease = min_impurity_decrease
-            self.min_impurity_split = min_impurity_split
-            self.ccp_alpha = ccp_alpha
-            self.max_bins = max_bins
-            self.min_bin_size = min_bin_size
             self.max_bins = max_bins
             self.min_bin_size = min_bin_size
 
@@ -1514,7 +1432,7 @@ class RandomForestRegressor(ForestRegressor):
             self.min_bin_size = min_bin_size
             self.monotonic_cst = monotonic_cst
 
-    elif sklearn_check_version("1.0"):
+    else:
 
         def __init__(
             self,
@@ -1571,69 +1489,6 @@ class RandomForestRegressor(ForestRegressor):
             self.max_features = max_features
             self.max_leaf_nodes = max_leaf_nodes
             self.min_impurity_decrease = min_impurity_decrease
-            self.ccp_alpha = ccp_alpha
-            self.max_bins = max_bins
-            self.min_bin_size = min_bin_size
-
-    else:
-
-        def __init__(
-            self,
-            n_estimators=100,
-            *,
-            criterion="mse",
-            max_depth=None,
-            min_samples_split=2,
-            min_samples_leaf=1,
-            min_weight_fraction_leaf=0.0,
-            max_features="auto",
-            max_leaf_nodes=None,
-            min_impurity_decrease=0.0,
-            min_impurity_split=None,
-            bootstrap=True,
-            oob_score=False,
-            n_jobs=None,
-            random_state=None,
-            verbose=0,
-            warm_start=False,
-            ccp_alpha=0.0,
-            max_samples=None,
-            max_bins=256,
-            min_bin_size=1,
-        ):
-            super().__init__(
-                DecisionTreeRegressor(),
-                n_estimators=n_estimators,
-                estimator_params=(
-                    "criterion",
-                    "max_depth",
-                    "min_samples_split",
-                    "min_samples_leaf",
-                    "min_weight_fraction_leaf",
-                    "max_features",
-                    "max_leaf_nodes",
-                    "min_impurity_decrease",
-                    "min_impurity_split" "random_state",
-                    "ccp_alpha",
-                ),
-                bootstrap=bootstrap,
-                oob_score=oob_score,
-                n_jobs=n_jobs,
-                random_state=random_state,
-                verbose=verbose,
-                warm_start=warm_start,
-                max_samples=max_samples,
-            )
-
-            self.criterion = criterion
-            self.max_depth = max_depth
-            self.min_samples_split = min_samples_split
-            self.min_samples_leaf = min_samples_leaf
-            self.min_weight_fraction_leaf = min_weight_fraction_leaf
-            self.max_features = max_features
-            self.max_leaf_nodes = max_leaf_nodes
-            self.min_impurity_decrease = min_impurity_decrease
-            self.min_impurity_split = min_impurity_split
             self.ccp_alpha = ccp_alpha
             self.max_bins = max_bins
             self.min_bin_size = min_bin_size
@@ -1717,7 +1572,7 @@ class ExtraTreesClassifier(ForestClassifier):
             self.min_bin_size = min_bin_size
             self.monotonic_cst = monotonic_cst
 
-    elif sklearn_check_version("1.0"):
+    else:
 
         def __init__(
             self,
@@ -1777,74 +1632,6 @@ class ExtraTreesClassifier(ForestClassifier):
             self.max_leaf_nodes = max_leaf_nodes
             self.min_impurity_decrease = min_impurity_decrease
             self.ccp_alpha = ccp_alpha
-            self.max_bins = max_bins
-            self.min_bin_size = min_bin_size
-
-    else:
-
-        def __init__(
-            self,
-            n_estimators=100,
-            *,
-            criterion="gini",
-            max_depth=None,
-            min_samples_split=2,
-            min_samples_leaf=1,
-            min_weight_fraction_leaf=0.0,
-            max_features="auto",
-            max_leaf_nodes=None,
-            min_impurity_decrease=0.0,
-            min_impurity_split=None,
-            bootstrap=False,
-            oob_score=False,
-            n_jobs=None,
-            random_state=None,
-            verbose=0,
-            warm_start=False,
-            class_weight=None,
-            ccp_alpha=0.0,
-            max_samples=None,
-            max_bins=256,
-            min_bin_size=1,
-        ):
-            super().__init__(
-                ExtraTreeClassifier(),
-                n_estimators,
-                estimator_params=(
-                    "criterion",
-                    "max_depth",
-                    "min_samples_split",
-                    "min_samples_leaf",
-                    "min_weight_fraction_leaf",
-                    "max_features",
-                    "max_leaf_nodes",
-                    "min_impurity_decrease",
-                    "min_impurity_split",
-                    "random_state",
-                    "ccp_alpha",
-                ),
-                bootstrap=bootstrap,
-                oob_score=oob_score,
-                n_jobs=n_jobs,
-                random_state=random_state,
-                verbose=verbose,
-                warm_start=warm_start,
-                class_weight=class_weight,
-                max_samples=max_samples,
-            )
-
-            self.criterion = criterion
-            self.max_depth = max_depth
-            self.min_samples_split = min_samples_split
-            self.min_samples_leaf = min_samples_leaf
-            self.min_weight_fraction_leaf = min_weight_fraction_leaf
-            self.max_features = max_features
-            self.max_leaf_nodes = max_leaf_nodes
-            self.min_impurity_decrease = min_impurity_decrease
-            self.min_impurity_split = min_impurity_split
-            self.ccp_alpha = ccp_alpha
-            self.max_bins = max_bins
-            self.min_bin_size = min_bin_size
             self.max_bins = max_bins
             self.min_bin_size = min_bin_size
 
@@ -1925,7 +1712,7 @@ class ExtraTreesRegressor(ForestRegressor):
             self.min_bin_size = min_bin_size
             self.monotonic_cst = monotonic_cst
 
-    elif sklearn_check_version("1.0"):
+    else:
 
         def __init__(
             self,
@@ -1982,69 +1769,6 @@ class ExtraTreesRegressor(ForestRegressor):
             self.max_features = max_features
             self.max_leaf_nodes = max_leaf_nodes
             self.min_impurity_decrease = min_impurity_decrease
-            self.ccp_alpha = ccp_alpha
-            self.max_bins = max_bins
-            self.min_bin_size = min_bin_size
-
-    else:
-
-        def __init__(
-            self,
-            n_estimators=100,
-            *,
-            criterion="mse",
-            max_depth=None,
-            min_samples_split=2,
-            min_samples_leaf=1,
-            min_weight_fraction_leaf=0.0,
-            max_features="auto",
-            max_leaf_nodes=None,
-            min_impurity_decrease=0.0,
-            min_impurity_split=None,
-            bootstrap=False,
-            oob_score=False,
-            n_jobs=None,
-            random_state=None,
-            verbose=0,
-            warm_start=False,
-            ccp_alpha=0.0,
-            max_samples=None,
-            max_bins=256,
-            min_bin_size=1,
-        ):
-            super().__init__(
-                ExtraTreeRegressor(),
-                n_estimators=n_estimators,
-                estimator_params=(
-                    "criterion",
-                    "max_depth",
-                    "min_samples_split",
-                    "min_samples_leaf",
-                    "min_weight_fraction_leaf",
-                    "max_features",
-                    "max_leaf_nodes",
-                    "min_impurity_decrease",
-                    "min_impurity_split" "random_state",
-                    "ccp_alpha",
-                ),
-                bootstrap=bootstrap,
-                oob_score=oob_score,
-                n_jobs=n_jobs,
-                random_state=random_state,
-                verbose=verbose,
-                warm_start=warm_start,
-                max_samples=max_samples,
-            )
-
-            self.criterion = criterion
-            self.max_depth = max_depth
-            self.min_samples_split = min_samples_split
-            self.min_samples_leaf = min_samples_leaf
-            self.min_weight_fraction_leaf = min_weight_fraction_leaf
-            self.max_features = max_features
-            self.max_leaf_nodes = max_leaf_nodes
-            self.min_impurity_decrease = min_impurity_decrease
-            self.min_impurity_split = min_impurity_split
             self.ccp_alpha = ccp_alpha
             self.max_bins = max_bins
             self.min_bin_size = min_bin_size

--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -391,14 +391,6 @@ class BaseForest(PatchableEstimator, ABC):
 
     if not sklearn_check_version("1.2"):
 
-        @deprecated(
-            "Attribute `n_features_` was deprecated in version 1.0 and will be "
-            "removed in 1.2. Use `n_features_in_` instead."
-        )
-        @property
-        def n_features_(self):
-            return self.n_features_in_
-
         @property
         def base_estimator(self):
             return self.estimator

--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -90,6 +90,7 @@ class BaseForest(PatchableEstimator, ABC):
                 dtype=[np.float64, np.float32],
                 ensure_all_finite=False,
                 ensure_2d=True,
+                skip_y_conversion=True,
             )
 
             if sample_weight is not None:
@@ -814,6 +815,7 @@ class ForestClassifier(_sklearn_ForestClassifier, BaseForest):
                 ensure_all_finite=False,
                 reset=False,
                 ensure_2d=True,
+                skip_y_conversion=True,
             )
             if hasattr(self, "n_features_in_"):
                 try:
@@ -848,6 +850,7 @@ class ForestClassifier(_sklearn_ForestClassifier, BaseForest):
                 ensure_all_finite=False,
                 reset=False,
                 ensure_2d=True,
+                skip_y_conversion=True,
             )
 
         return self._onedal_estimator.predict_proba(X, queue=queue)
@@ -1157,6 +1160,7 @@ class ForestRegressor(_sklearn_ForestRegressor, BaseForest):
                 ensure_all_finite=False,
                 reset=False,
                 ensure_2d=True,
+                skip_y_conversion=True,
             )  # Warning, order of dtype matters
 
         return self._onedal_estimator.predict(X, queue=queue)

--- a/sklearnex/linear_model/incremental_linear.py
+++ b/sklearnex/linear_model/incremental_linear.py
@@ -31,13 +31,10 @@ from onedal.linear_model import (
 )
 from sklearnex._config import get_config
 
+from ..utils.validation import validate_data
+
 if sklearn_check_version("1.2"):
     from sklearn.utils._param_validation import Interval
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = BaseEstimator._validate_data
 
 from onedal.common.hyperparameters import get_hyperparameters
 
@@ -164,20 +161,13 @@ class IncrementalLinearRegression(
             if sklearn_check_version("1.2"):
                 self._validate_params()
 
-            if sklearn_check_version("1.0"):
-                X = validate_data(
-                    self,
-                    X,
-                    dtype=[np.float64, np.float32],
-                    copy=self.copy_X,
-                    reset=False,
-                )
-            else:
-                X = check_array(
-                    X,
-                    dtype=[np.float64, np.float32],
-                    copy=self.copy_X,
-                )
+            X = validate_data(
+                self,
+                X,
+                dtype=[np.float64, np.float32],
+                copy=self.copy_X,
+                reset=False,
+            )
 
         assert hasattr(self, "_onedal_estimator")
         if self._need_to_finalize:
@@ -199,31 +189,16 @@ class IncrementalLinearRegression(
         # never check input when using raw input
         check_input &= use_raw_input is False
         if check_input:
-            if sklearn_check_version("1.0"):
-                X, y = validate_data(
-                    self,
-                    X,
-                    y,
-                    dtype=[np.float64, np.float32],
-                    reset=first_pass,
-                    copy=self.copy_X,
-                    multi_output=True,
-                    force_all_finite=False,
-                )
-            else:
-                X = check_array(
-                    X,
-                    dtype=[np.float64, np.float32],
-                    copy=self.copy_X,
-                    force_all_finite=False,
-                )
-                y = check_array(
-                    y,
-                    dtype=[np.float64, np.float32],
-                    copy=False,
-                    ensure_2d=False,
-                    force_all_finite=False,
-                )
+            X, y = validate_data(
+                self,
+                X,
+                y,
+                dtype=[np.float64, np.float32],
+                reset=first_pass,
+                copy=self.copy_X,
+                multi_output=True,
+                ensure_all_finite=False,
+            )
 
         if first_pass:
             self.n_samples_seen_ = X.shape[0]
@@ -258,28 +233,15 @@ class IncrementalLinearRegression(
         if get_config()["use_raw_input"] is False:
             if sklearn_check_version("1.2"):
                 self._validate_params()
-            if sklearn_check_version("1.0"):
-                X, y = validate_data(
-                    self,
-                    X,
-                    y,
-                    dtype=[np.float64, np.float32],
-                    copy=self.copy_X,
-                    multi_output=True,
-                    ensure_2d=True,
-                )
-            else:
-                X = check_array(
-                    X,
-                    dtype=[np.float64, np.float32],
-                    copy=self.copy_X,
-                )
-                y = check_array(
-                    y,
-                    dtype=[np.float64, np.float32],
-                    copy=False,
-                    ensure_2d=False,
-                )
+            X, y = validate_data(
+                self,
+                X,
+                y,
+                dtype=[np.float64, np.float32],
+                copy=self.copy_X,
+                multi_output=True,
+                ensure_2d=True,
+            )
 
         n_samples, n_features = X.shape
 

--- a/sklearnex/linear_model/incremental_ridge.py
+++ b/sklearnex/linear_model/incremental_ridge.py
@@ -27,6 +27,8 @@ from sklearn.utils.validation import check_is_fitted, check_X_y
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn.utils.validation import sklearn_check_version
 
+from ..utils.validation import validate_data
+
 if sklearn_check_version("1.2"):
     from sklearn.utils._param_validation import Interval
 
@@ -38,11 +40,6 @@ from .._utils import (
     PatchingConditionsChain,
     _add_inc_serialization_note,
 )
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = BaseEstimator._validate_data
 
 
 @control_n_jobs(
@@ -142,8 +139,7 @@ class IncrementalRidge(
         if sklearn_check_version("1.2"):
             self._validate_params()
 
-        if sklearn_check_version("1.0"):
-            X = validate_data(self, X, accept_sparse=False, reset=False)
+        X = validate_data(self, X, accept_sparse=False, reset=False)
 
         assert hasattr(self, "_onedal_estimator")
         if self._need_to_finalize:
@@ -162,19 +158,16 @@ class IncrementalRidge(
             self._validate_params()
 
         if check_input:
-            if sklearn_check_version("1.0"):
-                X, y = validate_data(
-                    self,
-                    X,
-                    y,
-                    dtype=[np.float64, np.float32],
-                    reset=first_pass,
-                    copy=self.copy_X,
-                    multi_output=True,
-                    force_all_finite=False,
-                )
-            else:
-                check_X_y(X, y, multi_output=True, y_numeric=True)
+            X, y = validate_data(
+                self,
+                X,
+                y,
+                dtype=[np.float64, np.float32],
+                reset=first_pass,
+                copy=self.copy_X,
+                multi_output=True,
+                ensure_all_finite=False,
+            )
 
         if first_pass:
             self.n_samples_seen_ = X.shape[0]
@@ -206,18 +199,15 @@ class IncrementalRidge(
         if sklearn_check_version("1.2"):
             self._validate_params()
 
-        if sklearn_check_version("1.0"):
-            X, y = validate_data(
-                self,
-                X,
-                y,
-                dtype=[np.float64, np.float32],
-                copy=self.copy_X,
-                multi_output=True,
-                ensure_2d=True,
-            )
-        else:
-            check_X_y(X, y, multi_output=True, y_numeric=True)
+        X, y = validate_data(
+            self,
+            X,
+            y,
+            dtype=[np.float64, np.float32],
+            copy=self.copy_X,
+            multi_output=True,
+            ensure_2d=True,
+        )
 
         n_samples, n_features = X.shape
 

--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -61,7 +61,7 @@ class LinearRegression(PatchableEstimator, _sklearn_LinearRegression):
                 self,
                 fit_intercept=True,
                 copy_X=True,
-                tol=1e-06,
+                tol=1e-06,  # for sparse solver only, not used by oneDAL
                 n_jobs=None,
                 positive=False,
             ):

--- a/sklearnex/linear_model/linear.py
+++ b/sklearnex/linear_model/linear.py
@@ -32,8 +32,9 @@ from .._utils import (
     get_patch_message,
     register_hyperparameters,
 )
+from ..utils.validation import validate_data
 
-if sklearn_check_version("1.0") and not sklearn_check_version("1.2"):
+if not sklearn_check_version("1.2"):
     from sklearn.linear_model._base import _deprecate_normalize
 
 from scipy.sparse import issparse
@@ -42,11 +43,6 @@ from sklearn.utils.validation import check_is_fitted, check_X_y
 from onedal.common.hyperparameters import get_hyperparameters
 from onedal.linear_model import LinearRegression as onedal_LinearRegression
 from onedal.utils.validation import _num_features, _num_samples
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = _sklearn_LinearRegression._validate_data
 
 
 @register_hyperparameters({"fit": get_hyperparameters("linear_regression", "train")})
@@ -59,26 +55,46 @@ class LinearRegression(PatchableEstimator, _sklearn_LinearRegression):
             **_sklearn_LinearRegression._parameter_constraints
         }
 
-        def __init__(
-            self,
-            fit_intercept=True,
-            copy_X=True,
-            n_jobs=None,
-            positive=False,
-        ):
-            super().__init__(
-                fit_intercept=fit_intercept,
-                copy_X=copy_X,
-                n_jobs=n_jobs,
-                positive=positive,
-            )
+        if sklearn_check_version("1.7"):
+
+            def __init__(
+                self,
+                fit_intercept=True,
+                copy_X=True,
+                tol=1e-06,
+                n_jobs=None,
+                positive=False,
+            ):
+                super().__init__(
+                    fit_intercept=fit_intercept,
+                    copy_X=copy_X,
+                    tol=tol,
+                    n_jobs=n_jobs,
+                    positive=positive,
+                )
+
+        else:
+
+            def __init__(
+                self,
+                fit_intercept=True,
+                copy_X=True,
+                n_jobs=None,
+                positive=False,
+            ):
+                super().__init__(
+                    fit_intercept=fit_intercept,
+                    copy_X=copy_X,
+                    n_jobs=n_jobs,
+                    positive=positive,
+                )
 
     else:
 
         def __init__(
             self,
             fit_intercept=True,
-            normalize="deprecated" if sklearn_check_version("1.0") else False,
+            normalize="deprecated",
             copy_X=True,
             n_jobs=None,
             positive=False,
@@ -245,20 +261,17 @@ class LinearRegression(PatchableEstimator, _sklearn_LinearRegression):
         assert sample_weight is None
 
         supports_multi_output = daal_check_version((2025, "P", 1))
-        check_params = {
-            "X": X,
-            "y": y,
-            "dtype": [np.float64, np.float32],
-            "accept_sparse": ["csr", "csc", "coo"],
-            "y_numeric": True,
-            "multi_output": supports_multi_output,
-        }
-        if sklearn_check_version("1.0"):
-            X, y = validate_data(self, **check_params)
-        else:
-            X, y = check_X_y(**check_params)
+        X, y = validate_data(
+            self,
+            X=X,
+            y=y,
+            dtype=[np.float64, np.float32],
+            accept_sparse=["csr", "csc", "coo"],
+            y_numeric=True,
+            multi_output=supports_multi_output,
+        )
 
-        if sklearn_check_version("1.0") and not sklearn_check_version("1.2"):
+        if not sklearn_check_version("1.2"):
             self._normalize = _deprecate_normalize(
                 self.normalize,
                 default=False,
@@ -286,10 +299,7 @@ class LinearRegression(PatchableEstimator, _sklearn_LinearRegression):
             self._save_attributes()
 
     def _onedal_predict(self, X, queue=None):
-        if sklearn_check_version("1.0"):
-            X = validate_data(self, X, accept_sparse=False, reset=False)
-        else:
-            X = check_array(X, accept_sparse=False)
+        X = validate_data(self, X, accept_sparse=False, reset=False)
 
         if not hasattr(self, "_onedal_estimator"):
             self._initialize_onedal_estimator()

--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -39,11 +39,7 @@ if daal_check_version((2024, "P", 1)):
     from .._config import get_config
     from .._device_offload import dispatch, wrap_output_data
     from .._utils import PatchableEstimator, PatchingConditionsChain, get_patch_message
-
-    if sklearn_check_version("1.6"):
-        from sklearn.utils.validation import validate_data
-    else:
-        validate_data = _sklearn_LogisticRegression._validate_data
+    from ..utils.validation import validate_data
 
     _sparsity_enabled = daal_check_version((2024, "P", 700))
 
@@ -293,23 +289,14 @@ if daal_check_version((2024, "P", 1)):
 
             assert sample_weight is None
 
-            if sklearn_check_version("1.0"):
-                X, y = validate_data(
-                    self,
-                    X,
-                    y,
-                    accept_sparse=_sparsity_enabled,
-                    accept_large_sparse=_sparsity_enabled,
-                    dtype=[np.float64, np.float32],
-                )
-            else:
-                X, y = check_X_y(
-                    X,
-                    y,
-                    accept_sparse=_sparsity_enabled,
-                    accept_large_sparse=_sparsity_enabled,
-                    dtype=[np.float64, np.float32],
-                )
+            X, y = validate_data(
+                self,
+                X,
+                y,
+                accept_sparse=_sparsity_enabled,
+                accept_large_sparse=_sparsity_enabled,
+                dtype=[np.float64, np.float32],
+            )
 
             self._onedal_gpu_initialize_estimator()
             try:
@@ -332,22 +319,14 @@ if daal_check_version((2024, "P", 1)):
             if queue is None or queue.sycl_device.is_cpu:
                 return daal4py_predict(self, X, "computeClassLabels")
 
-            if sklearn_check_version("1.0"):
-                X = validate_data(
-                    self,
-                    X,
-                    reset=False,
-                    accept_sparse=_sparsity_enabled,
-                    accept_large_sparse=_sparsity_enabled,
-                    dtype=[np.float64, np.float32],
-                )
-            else:
-                X = check_array(
-                    X,
-                    accept_sparse=_sparsity_enabled,
-                    accept_large_sparse=_sparsity_enabled,
-                    dtype=[np.float64, np.float32],
-                )
+            X = validate_data(
+                self,
+                X,
+                reset=False,
+                accept_sparse=_sparsity_enabled,
+                accept_large_sparse=_sparsity_enabled,
+                dtype=[np.float64, np.float32],
+            )
 
             assert hasattr(self, "_onedal_estimator")
             return self._onedal_estimator.predict(X, queue=queue)
@@ -356,22 +335,14 @@ if daal_check_version((2024, "P", 1)):
             if queue is None or queue.sycl_device.is_cpu:
                 return daal4py_predict(self, X, "computeClassProbabilities")
 
-            if sklearn_check_version("1.0"):
-                X = validate_data(
-                    self,
-                    X,
-                    reset=False,
-                    accept_sparse=_sparsity_enabled,
-                    accept_large_sparse=_sparsity_enabled,
-                    dtype=[np.float64, np.float32],
-                )
-            else:
-                X = check_array(
-                    X,
-                    accept_sparse=_sparsity_enabled,
-                    accept_large_sparse=_sparsity_enabled,
-                    dtype=[np.float64, np.float32],
-                )
+            X = validate_data(
+                self,
+                X,
+                reset=False,
+                accept_sparse=_sparsity_enabled,
+                accept_large_sparse=_sparsity_enabled,
+                dtype=[np.float64, np.float32],
+            )
 
             assert hasattr(self, "_onedal_estimator")
             return self._onedal_estimator.predict_proba(X, queue=queue)
@@ -380,22 +351,14 @@ if daal_check_version((2024, "P", 1)):
             if queue is None or queue.sycl_device.is_cpu:
                 return daal4py_predict(self, X, "computeClassLogProbabilities")
 
-            if sklearn_check_version("1.0"):
-                X = validate_data(
-                    self,
-                    X,
-                    reset=False,
-                    accept_sparse=_sparsity_enabled,
-                    accept_large_sparse=_sparsity_enabled,
-                    dtype=[np.float64, np.float32],
-                )
-            else:
-                X = check_array(
-                    X,
-                    accept_sparse=_sparsity_enabled,
-                    accept_large_sparse=_sparsity_enabled,
-                    dtype=[np.float64, np.float32],
-                )
+            X = validate_data(
+                self,
+                X,
+                reset=False,
+                accept_sparse=_sparsity_enabled,
+                accept_large_sparse=_sparsity_enabled,
+                dtype=[np.float64, np.float32],
+            )
 
             assert hasattr(self, "_onedal_estimator")
             return self._onedal_estimator.predict_log_proba(X, queue=queue)

--- a/sklearnex/linear_model/ridge.py
+++ b/sklearnex/linear_model/ridge.py
@@ -39,11 +39,7 @@ if daal_check_version((2024, "P", 600)):
 
     from .._device_offload import dispatch, wrap_output_data
     from .._utils import PatchableEstimator, PatchingConditionsChain
-
-    if sklearn_check_version("1.6"):
-        from sklearn.utils.validation import validate_data
-    else:
-        validate_data = _sklearn_Ridge._validate_data
+    from ..utils.validation import validate_data
 
     @control_n_jobs(decorated_methods=["fit", "predict", "score"])
     class Ridge(PatchableEstimator, _sklearn_Ridge):
@@ -307,15 +303,15 @@ if daal_check_version((2024, "P", 600)):
                         include_boundaries="left",
                     )
 
-            check_params = {
-                "X": X,
-                "y": y,
-                "dtype": [np.float64, np.float32],
-                "accept_sparse": ["csr", "csc", "coo"],
-                "y_numeric": True,
-                "multi_output": True,
-            }
-            X, y = validate_data(self, **check_params)
+            X, y = validate_data(
+                self,
+                X=X,
+                y=y,
+                dtype=[np.float64, np.float32],
+                accept_sparse=["csr", "csc", "coo"],
+                y_numeric=True,
+                multi_output=True,
+            )
 
             if not sklearn_check_version("1.2"):
                 self._normalize = _deprecate_normalize(

--- a/sklearnex/neighbors/_lof.py
+++ b/sklearnex/neighbors/_lof.py
@@ -28,11 +28,7 @@ from sklearnex.neighbors.common import KNeighborsDispatchingBase
 from sklearnex.neighbors.knn_unsupervised import NearestNeighbors
 
 from ..utils._array_api import get_namespace
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = _sklearn_LocalOutlierFactor._validate_data
+from ..utils.validation import check_feature_names
 
 
 @control_n_jobs(decorated_methods=["fit", "kneighbors", "_kneighbors"])
@@ -172,8 +168,8 @@ class LocalOutlierFactor(KNeighborsDispatchingBase, _sklearn_LocalOutlierFactor)
 
     def _kneighbors(self, X=None, n_neighbors=None, return_distance=True):
         check_is_fitted(self)
-        if sklearn_check_version("1.0") and X is not None:
-            self._check_feature_names(X, reset=False)
+        if X is not None:
+            check_feature_names(self, X, reset=False)
         return dispatch(
             self,
             "kneighbors",

--- a/sklearnex/neighbors/common.py
+++ b/sklearnex/neighbors/common.py
@@ -29,14 +29,14 @@ from onedal.utils.validation import _check_array, _num_features, _num_samples
 
 from .._utils import PatchableEstimator, PatchingConditionsChain
 from ..utils._array_api import get_namespace
+from ..utils.validation import check_feature_names
 
 
 class KNeighborsDispatchingBase(PatchableEstimator):
     def _fit_validation(self, X, y=None):
         if sklearn_check_version("1.2"):
             self._validate_params()
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=True)
+        check_feature_names(self, X, reset=True)
         if self.metric_params is not None and "p" in self.metric_params:
             if self.p is not None:
                 warnings.warn(
@@ -308,3 +308,13 @@ class KNeighborsDispatchingBase(PatchableEstimator):
         return kneighbors_graph
 
     kneighbors_graph.__doc__ = KNeighborsMixin.kneighbors_graph.__doc__
+
+    def _get_requires_y(self):
+        if sklearn_check_version("1.6"):
+            requires_y = self.__sklearn_tags__().target_tags.required
+        else:
+            try:
+                requires_y = self._get_tags()["requires_y"]
+            except KeyError:
+                requires_y = False
+        return requires_y

--- a/sklearnex/neighbors/common.py
+++ b/sklearnex/neighbors/common.py
@@ -308,13 +308,3 @@ class KNeighborsDispatchingBase(PatchableEstimator):
         return kneighbors_graph
 
     kneighbors_graph.__doc__ = KNeighborsMixin.kneighbors_graph.__doc__
-
-    def _get_requires_y(self):
-        if sklearn_check_version("1.6"):
-            requires_y = self.__sklearn_tags__().target_tags.required
-        else:
-            try:
-                requires_y = self._get_tags()["requires_y"]
-            except KeyError:
-                requires_y = False
-        return requires_y

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -23,6 +23,7 @@ from sklearn.utils.validation import _deprecate_positional_args, check_is_fitted
 
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import sklearn_check_version
+from daal4py.sklearn.utils.validation import get_requires_y_tag
 from onedal.neighbors import KNeighborsClassifier as onedal_KNeighborsClassifier
 
 from .._device_offload import dispatch, wrap_output_data
@@ -147,7 +148,7 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
         }
 
         self._onedal_estimator = onedal_KNeighborsClassifier(**onedal_params)
-        self._onedal_estimator.requires_y = self._get_requires_y()
+        self._onedal_estimator.requires_y = get_requires_y_tag(self)
         self._onedal_estimator.effective_metric_ = self.effective_metric_
         self._onedal_estimator.effective_metric_params_ = self.effective_metric_params_
         self._onedal_estimator.fit(X, y, queue=queue)

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -18,8 +18,7 @@ from sklearn.metrics import accuracy_score
 from sklearn.neighbors._classification import (
     KNeighborsClassifier as _sklearn_KNeighborsClassifier,
 )
-from sklearn.neighbors._unsupervised import NearestNeighbors as _sklearn_NearestNeighbors
-from sklearn.utils.validation import _deprecate_positional_args, check_is_fitted
+from sklearn.utils.validation import check_is_fitted
 
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import sklearn_check_version

--- a/sklearnex/neighbors/knn_classification.py
+++ b/sklearnex/neighbors/knn_classification.py
@@ -26,12 +26,8 @@ from daal4py.sklearn._utils import sklearn_check_version
 from onedal.neighbors import KNeighborsClassifier as onedal_KNeighborsClassifier
 
 from .._device_offload import dispatch, wrap_output_data
+from ..utils.validation import check_feature_names
 from .common import KNeighborsDispatchingBase
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = _sklearn_KNeighborsClassifier._validate_data
 
 
 @control_n_jobs(
@@ -44,58 +40,28 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
             **_sklearn_KNeighborsClassifier._parameter_constraints
         }
 
-    if sklearn_check_version("1.0"):
-
-        def __init__(
-            self,
-            n_neighbors=5,
-            *,
-            weights="uniform",
-            algorithm="auto",
-            leaf_size=30,
-            p=2,
-            metric="minkowski",
-            metric_params=None,
-            n_jobs=None,
-        ):
-            super().__init__(
-                n_neighbors=n_neighbors,
-                weights=weights,
-                algorithm=algorithm,
-                leaf_size=leaf_size,
-                metric=metric,
-                p=p,
-                metric_params=metric_params,
-                n_jobs=n_jobs,
-            )
-
-    else:
-
-        @_deprecate_positional_args
-        def __init__(
-            self,
-            n_neighbors=5,
-            *,
-            weights="uniform",
-            algorithm="auto",
-            leaf_size=30,
-            p=2,
-            metric="minkowski",
-            metric_params=None,
-            n_jobs=None,
-            **kwargs,
-        ):
-            super().__init__(
-                n_neighbors=n_neighbors,
-                weights=weights,
-                algorithm=algorithm,
-                leaf_size=leaf_size,
-                metric=metric,
-                p=p,
-                metric_params=metric_params,
-                n_jobs=n_jobs,
-                **kwargs,
-            )
+    def __init__(
+        self,
+        n_neighbors=5,
+        *,
+        weights="uniform",
+        algorithm="auto",
+        leaf_size=30,
+        p=2,
+        metric="minkowski",
+        metric_params=None,
+        n_jobs=None,
+    ):
+        super().__init__(
+            n_neighbors=n_neighbors,
+            weights=weights,
+            algorithm=algorithm,
+            leaf_size=leaf_size,
+            metric=metric,
+            p=p,
+            metric_params=metric_params,
+            n_jobs=n_jobs,
+        )
 
     def fit(self, X, y):
         dispatch(
@@ -113,8 +79,7 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
     @wrap_output_data
     def predict(self, X):
         check_is_fitted(self)
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=False)
+        check_feature_names(self, X, reset=False)
         return dispatch(
             self,
             "predict",
@@ -128,8 +93,7 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
     @wrap_output_data
     def predict_proba(self, X):
         check_is_fitted(self)
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=False)
+        check_feature_names(self, X, reset=False)
         return dispatch(
             self,
             "predict_proba",
@@ -143,8 +107,7 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
     @wrap_output_data
     def score(self, X, y, sample_weight=None):
         check_is_fitted(self)
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=False)
+        check_feature_names(self, X, reset=False)
         return dispatch(
             self,
             "score",
@@ -160,8 +123,8 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
     @wrap_output_data
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True):
         check_is_fitted(self)
-        if sklearn_check_version("1.0") and X is not None:
-            self._check_feature_names(X, reset=False)
+        if X is not None:
+            check_feature_names(self, X, reset=False)
         return dispatch(
             self,
             "kneighbors",
@@ -183,13 +146,8 @@ class KNeighborsClassifier(KNeighborsDispatchingBase, _sklearn_KNeighborsClassif
             "p": self.effective_metric_params_["p"],
         }
 
-        try:
-            requires_y = self._get_tags()["requires_y"]
-        except KeyError:
-            requires_y = False
-
         self._onedal_estimator = onedal_KNeighborsClassifier(**onedal_params)
-        self._onedal_estimator.requires_y = requires_y
+        self._onedal_estimator.requires_y = self._get_requires_y()
         self._onedal_estimator.effective_metric_ = self.effective_metric_
         self._onedal_estimator.effective_metric_params_ = self.effective_metric_params_
         self._onedal_estimator.fit(X, y, queue=queue)

--- a/sklearnex/neighbors/knn_regression.py
+++ b/sklearnex/neighbors/knn_regression.py
@@ -25,12 +25,8 @@ from daal4py.sklearn._utils import sklearn_check_version
 from onedal.neighbors import KNeighborsRegressor as onedal_KNeighborsRegressor
 
 from .._device_offload import dispatch, wrap_output_data
+from ..utils.validation import check_feature_names
 from .common import KNeighborsDispatchingBase
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = _sklearn_KNeighborsRegressor._validate_data
 
 
 @control_n_jobs(decorated_methods=["fit", "predict", "kneighbors", "score"])
@@ -41,58 +37,28 @@ class KNeighborsRegressor(KNeighborsDispatchingBase, _sklearn_KNeighborsRegresso
             **_sklearn_KNeighborsRegressor._parameter_constraints
         }
 
-    if sklearn_check_version("1.0"):
-
-        def __init__(
-            self,
-            n_neighbors=5,
-            *,
-            weights="uniform",
-            algorithm="auto",
-            leaf_size=30,
-            p=2,
-            metric="minkowski",
-            metric_params=None,
-            n_jobs=None,
-        ):
-            super().__init__(
-                n_neighbors=n_neighbors,
-                weights=weights,
-                algorithm=algorithm,
-                leaf_size=leaf_size,
-                metric=metric,
-                p=p,
-                metric_params=metric_params,
-                n_jobs=n_jobs,
-            )
-
-    else:
-
-        @_deprecate_positional_args
-        def __init__(
-            self,
-            n_neighbors=5,
-            *,
-            weights="uniform",
-            algorithm="auto",
-            leaf_size=30,
-            p=2,
-            metric="minkowski",
-            metric_params=None,
-            n_jobs=None,
-            **kwargs,
-        ):
-            super().__init__(
-                n_neighbors=n_neighbors,
-                weights=weights,
-                algorithm=algorithm,
-                leaf_size=leaf_size,
-                metric=metric,
-                p=p,
-                metric_params=metric_params,
-                n_jobs=n_jobs,
-                **kwargs,
-            )
+    def __init__(
+        self,
+        n_neighbors=5,
+        *,
+        weights="uniform",
+        algorithm="auto",
+        leaf_size=30,
+        p=2,
+        metric="minkowski",
+        metric_params=None,
+        n_jobs=None,
+    ):
+        super().__init__(
+            n_neighbors=n_neighbors,
+            weights=weights,
+            algorithm=algorithm,
+            leaf_size=leaf_size,
+            metric=metric,
+            p=p,
+            metric_params=metric_params,
+            n_jobs=n_jobs,
+        )
 
     def fit(self, X, y):
         dispatch(
@@ -110,8 +76,7 @@ class KNeighborsRegressor(KNeighborsDispatchingBase, _sklearn_KNeighborsRegresso
     @wrap_output_data
     def predict(self, X):
         check_is_fitted(self)
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=False)
+        check_feature_names(self, X, reset=False)
         return dispatch(
             self,
             "predict",
@@ -125,8 +90,7 @@ class KNeighborsRegressor(KNeighborsDispatchingBase, _sklearn_KNeighborsRegresso
     @wrap_output_data
     def score(self, X, y, sample_weight=None):
         check_is_fitted(self)
-        if sklearn_check_version("1.0"):
-            self._check_feature_names(X, reset=False)
+        check_feature_names(self, X, reset=False)
         return dispatch(
             self,
             "score",
@@ -142,8 +106,8 @@ class KNeighborsRegressor(KNeighborsDispatchingBase, _sklearn_KNeighborsRegresso
     @wrap_output_data
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True):
         check_is_fitted(self)
-        if sklearn_check_version("1.0") and X is not None:
-            self._check_feature_names(X, reset=False)
+        if X is not None:
+            check_feature_names(self, X, reset=False)
         return dispatch(
             self,
             "kneighbors",
@@ -165,13 +129,8 @@ class KNeighborsRegressor(KNeighborsDispatchingBase, _sklearn_KNeighborsRegresso
             "p": self.effective_metric_params_["p"],
         }
 
-        try:
-            requires_y = self._get_tags()["requires_y"]
-        except KeyError:
-            requires_y = False
-
         self._onedal_estimator = onedal_KNeighborsRegressor(**onedal_params)
-        self._onedal_estimator.requires_y = requires_y
+        self._onedal_estimator.requires_y = self._get_requires_y()
         self._onedal_estimator.effective_metric_ = self.effective_metric_
         self._onedal_estimator.effective_metric_params_ = self.effective_metric_params_
         self._onedal_estimator.fit(X, y, queue=queue)

--- a/sklearnex/neighbors/knn_regression.py
+++ b/sklearnex/neighbors/knn_regression.py
@@ -22,6 +22,7 @@ from sklearn.utils.validation import _deprecate_positional_args, check_is_fitted
 
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import sklearn_check_version
+from daal4py.sklearn.utils.validation import get_requires_y_tag
 from onedal.neighbors import KNeighborsRegressor as onedal_KNeighborsRegressor
 
 from .._device_offload import dispatch, wrap_output_data
@@ -130,7 +131,7 @@ class KNeighborsRegressor(KNeighborsDispatchingBase, _sklearn_KNeighborsRegresso
         }
 
         self._onedal_estimator = onedal_KNeighborsRegressor(**onedal_params)
-        self._onedal_estimator.requires_y = self._get_requires_y()
+        self._onedal_estimator.requires_y = get_requires_y_tag(self)
         self._onedal_estimator.effective_metric_ = self.effective_metric_
         self._onedal_estimator.effective_metric_params_ = self.effective_metric_params_
         self._onedal_estimator.fit(X, y, queue=queue)

--- a/sklearnex/neighbors/knn_regression.py
+++ b/sklearnex/neighbors/knn_regression.py
@@ -18,7 +18,7 @@ from sklearn.metrics import r2_score
 from sklearn.neighbors._regression import (
     KNeighborsRegressor as _sklearn_KNeighborsRegressor,
 )
-from sklearn.utils.validation import _deprecate_positional_args, check_is_fitted
+from sklearn.utils.validation import check_is_fitted
 
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import sklearn_check_version

--- a/sklearnex/neighbors/knn_unsupervised.py
+++ b/sklearnex/neighbors/knn_unsupervised.py
@@ -22,12 +22,8 @@ from daal4py.sklearn._utils import sklearn_check_version
 from onedal.neighbors import NearestNeighbors as onedal_NearestNeighbors
 
 from .._device_offload import dispatch, wrap_output_data
+from ..utils.validation import check_feature_names
 from .common import KNeighborsDispatchingBase
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = _sklearn_NearestNeighbors._validate_data
 
 
 @control_n_jobs(decorated_methods=["fit", "kneighbors", "radius_neighbors"])
@@ -77,8 +73,8 @@ class NearestNeighbors(KNeighborsDispatchingBase, _sklearn_NearestNeighbors):
     @wrap_output_data
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True):
         check_is_fitted(self)
-        if sklearn_check_version("1.0") and X is not None:
-            self._check_feature_names(X, reset=False)
+        if X is not None:
+            check_feature_names(self, X, reset=False)
         return dispatch(
             self,
             "kneighbors",
@@ -139,13 +135,8 @@ class NearestNeighbors(KNeighborsDispatchingBase, _sklearn_NearestNeighbors):
             "p": self.effective_metric_params_["p"],
         }
 
-        try:
-            requires_y = self._get_tags()["requires_y"]
-        except KeyError:
-            requires_y = False
-
         self._onedal_estimator = onedal_NearestNeighbors(**onedal_params)
-        self._onedal_estimator.requires_y = requires_y
+        self._onedal_estimator.requires_y = self._get_requires_y()
         self._onedal_estimator.effective_metric_ = self.effective_metric_
         self._onedal_estimator.effective_metric_params_ = self.effective_metric_params_
         self._onedal_estimator.fit(X, y, queue=queue)

--- a/sklearnex/neighbors/knn_unsupervised.py
+++ b/sklearnex/neighbors/knn_unsupervised.py
@@ -19,6 +19,7 @@ from sklearn.utils.validation import _deprecate_positional_args, check_is_fitted
 
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import sklearn_check_version
+from daal4py.sklearn.utils.validation import get_requires_y_tag
 from onedal.neighbors import NearestNeighbors as onedal_NearestNeighbors
 
 from .._device_offload import dispatch, wrap_output_data
@@ -136,7 +137,7 @@ class NearestNeighbors(KNeighborsDispatchingBase, _sklearn_NearestNeighbors):
         }
 
         self._onedal_estimator = onedal_NearestNeighbors(**onedal_params)
-        self._onedal_estimator.requires_y = self._get_requires_y()
+        self._onedal_estimator.requires_y = get_requires_y_tag(self)
         self._onedal_estimator.effective_metric_ = self.effective_metric_
         self._onedal_estimator.effective_metric_params_ = self.effective_metric_params_
         self._onedal_estimator.fit(X, y, queue=queue)

--- a/sklearnex/preview/covariance/covariance.py
+++ b/sklearnex/preview/covariance/covariance.py
@@ -34,11 +34,7 @@ from ..._utils import (
     PatchingConditionsChain,
     register_hyperparameters,
 )
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = _sklearn_EmpiricalCovariance._validate_data
+from ...utils.validation import validate_data
 
 
 @register_hyperparameters({"fit": get_hyperparameters("covariance", "compute")})
@@ -99,10 +95,7 @@ class EmpiricalCovariance(PatchableEstimator, _sklearn_EmpiricalCovariance):
     def fit(self, X, y=None):
         if sklearn_check_version("1.2"):
             self._validate_params()
-        if sklearn_check_version("0.23"):
-            X = validate_data(self, X, force_all_finite=False)
-        else:
-            X = check_array(X, force_all_finite=False)
+        X = validate_data(self, X, ensure_all_finite=False)
 
         dispatch(
             self,
@@ -119,10 +112,7 @@ class EmpiricalCovariance(PatchableEstimator, _sklearn_EmpiricalCovariance):
     # expose sklearnex pairwise_distances if mahalanobis distance eventually supported
     @wrap_output_data
     def mahalanobis(self, X):
-        if sklearn_check_version("1.0"):
-            X = validate_data(self, X, reset=False)
-        else:
-            X = check_array(X)
+        X = validate_data(self, X, reset=False)
 
         precision = self.get_precision()
         with config_context(assume_finite=True):

--- a/sklearnex/preview/decomposition/incremental_pca.py
+++ b/sklearnex/preview/decomposition/incremental_pca.py
@@ -29,11 +29,7 @@ from ..._utils import (
     PatchingConditionsChain,
     _add_inc_serialization_note,
 )
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = _sklearn_IncrementalPCA._validate_data
+from ...utils.validation import validate_data
 
 
 @control_n_jobs(
@@ -80,16 +76,7 @@ class IncrementalPCA(ExtensionEstimator, _sklearn_IncrementalPCA):
         # never check input when using raw input
         check_input &= use_raw_input is False
         if check_input:
-            if sklearn_check_version("1.0"):
-                X = validate_data(
-                    self, X, dtype=[np.float64, np.float32], reset=first_pass
-                )
-            else:
-                X = check_array(
-                    X,
-                    dtype=[np.float64, np.float32],
-                    copy=self.copy,
-                )
+            X = validate_data(self, X, dtype=[np.float64, np.float32], reset=first_pass)
 
         n_samples, n_features = X.shape
 
@@ -136,14 +123,7 @@ class IncrementalPCA(ExtensionEstimator, _sklearn_IncrementalPCA):
             if sklearn_check_version("1.2"):
                 self._validate_params()
 
-            if sklearn_check_version("1.0"):
-                X = validate_data(self, X, dtype=[np.float64, np.float32], copy=self.copy)
-            else:
-                X = check_array(
-                    X,
-                    dtype=[np.float64, np.float32],
-                    copy=self.copy,
-                )
+            X = validate_data(self, X, dtype=[np.float64, np.float32], copy=self.copy)
 
         n_samples, n_features = X.shape
 

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -165,7 +165,6 @@ class BaseSVM(PatchableEstimator, BaseEstimator, ABC):
             dtype=[np.float64, np.float32],
             ensure_all_finite=False,
             accept_sparse="csr",
-            skip_y_conversion=True,
         )
         y = self._validate_targets(y)
         sample_weight = self._get_sample_weight(X, y, sample_weight)

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -30,11 +30,7 @@ from onedal.utils.validation import _check_array, _check_X_y, _column_or_1d
 
 from .._config import config_context, get_config
 from .._utils import PatchableEstimator, PatchingConditionsChain
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = BaseEstimator._validate_data
+from ..utils.validation import validate_data
 
 
 class BaseSVM(PatchableEstimator, BaseEstimator, ABC):
@@ -161,25 +157,16 @@ class BaseSVM(PatchableEstimator, BaseEstimator, ABC):
                     f"This {self.__class__.__name__} estimator "
                     f"requires y to be passed, but the target y is None."
                 )
-        # using onedal _check_X_y to insure X and y are contiguous
         # finite check occurs in onedal estimator
-        if sklearn_check_version("1.0"):
-            X, y = validate_data(
-                self,
-                X,
-                y,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                accept_sparse="csr",
-            )
-        else:
-            X, y = _check_X_y(
-                X,
-                y,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                accept_sparse="csr",
-            )
+        X, y = validate_data(
+            self,
+            X,
+            y,
+            dtype=[np.float64, np.float32],
+            ensure_all_finite=False,
+            accept_sparse="csr",
+            skip_y_conversion=True,
+        )
         y = self._validate_targets(y)
         sample_weight = self._get_sample_weight(X, y, sample_weight)
         return X, y, sample_weight

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -26,6 +26,7 @@ from sklearn.metrics import r2_score
 from sklearn.preprocessing import LabelEncoder
 
 from daal4py.sklearn._utils import sklearn_check_version
+from daal4py.sklearn.utils.validation import get_requires_y_tag
 from onedal.utils.validation import _check_array, _check_X_y, _column_or_1d
 
 from .._config import config_context, get_config
@@ -152,7 +153,7 @@ class BaseSVM(PatchableEstimator, BaseEstimator, ABC):
                 )
 
         if y is None:
-            if self._get_tags()["requires_y"]:
+            if get_requires_y_tag(self):
                 raise ValueError(
                     f"This {self.__class__.__name__} estimator "
                     f"requires y to be passed, but the target y is None."

--- a/sklearnex/svm/nusvc.py
+++ b/sklearnex/svm/nusvc.py
@@ -18,6 +18,7 @@ import numpy as np
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import accuracy_score
 from sklearn.svm import NuSVC as _sklearn_NuSVC
+from sklearn.utils.metaestimators import available_if
 from sklearn.utils.validation import (
     _deprecate_positional_args,
     check_array,
@@ -26,20 +27,12 @@ from sklearn.utils.validation import (
 
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import sklearn_check_version
+from onedal.svm import NuSVC as onedal_NuSVC
 
 from .._device_offload import dispatch, wrap_output_data
 from ..utils._array_api import get_namespace
+from ..utils.validation import validate_data
 from ._common import BaseSVC
-
-if sklearn_check_version("1.0"):
-    from sklearn.utils.metaestimators import available_if
-
-from onedal.svm import NuSVC as onedal_NuSVC
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = BaseSVC._validate_data
 
 
 @control_n_jobs(
@@ -145,99 +138,77 @@ class NuSVC(_sklearn_NuSVC, BaseSVC):
             sample_weight=sample_weight,
         )
 
-    if sklearn_check_version("1.0"):
+    @available_if(_sklearn_NuSVC._check_proba)
+    def predict_proba(self, X):
+        """
+        Compute probabilities of possible outcomes for samples in X.
 
-        @available_if(_sklearn_NuSVC._check_proba)
-        def predict_proba(self, X):
-            """
-            Compute probabilities of possible outcomes for samples in X.
+        The model need to have probability information computed at training
+        time: fit with attribute `probability` set to True.
 
-            The model need to have probability information computed at training
-            time: fit with attribute `probability` set to True.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            For kernel="precomputed", the expected shape of X is
+            (n_samples_test, n_samples_train).
 
-            Parameters
-            ----------
-            X : array-like of shape (n_samples, n_features)
-                For kernel="precomputed", the expected shape of X is
-                (n_samples_test, n_samples_train).
+        Returns
+        -------
+        T : ndarray of shape (n_samples, n_classes)
+            Returns the probability of the sample for each class in
+            the model. The columns correspond to the classes in sorted
+            order, as they appear in the attribute :term:`classes_`.
 
-            Returns
-            -------
-            T : ndarray of shape (n_samples, n_classes)
-                Returns the probability of the sample for each class in
-                the model. The columns correspond to the classes in sorted
-                order, as they appear in the attribute :term:`classes_`.
+        Notes
+        -----
+        The probability model is created using cross validation, so
+        the results can be slightly different than those obtained by
+        predict. Also, it will produce meaningless results on very small
+        datasets.
+        """
+        check_is_fitted(self)
+        return self._predict_proba(X)
 
-            Notes
-            -----
-            The probability model is created using cross validation, so
-            the results can be slightly different than those obtained by
-            predict. Also, it will produce meaningless results on very small
-            datasets.
-            """
-            check_is_fitted(self)
-            return self._predict_proba(X)
+    @available_if(_sklearn_NuSVC._check_proba)
+    def predict_log_proba(self, X):
+        """Compute log probabilities of possible outcomes for samples in X.
 
-        @available_if(_sklearn_NuSVC._check_proba)
-        def predict_log_proba(self, X):
-            """Compute log probabilities of possible outcomes for samples in X.
+        The model need to have probability information computed at training
+        time: fit with attribute `probability` set to True.
 
-            The model need to have probability information computed at training
-            time: fit with attribute `probability` set to True.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features) or \
+                (n_samples_test, n_samples_train)
+            For kernel="precomputed", the expected shape of X is
+            (n_samples_test, n_samples_train).
 
-            Parameters
-            ----------
-            X : array-like of shape (n_samples, n_features) or \
-                    (n_samples_test, n_samples_train)
-                For kernel="precomputed", the expected shape of X is
-                (n_samples_test, n_samples_train).
+        Returns
+        -------
+        T : ndarray of shape (n_samples, n_classes)
+            Returns the log-probabilities of the sample for each class in
+            the model. The columns correspond to the classes in sorted
+            order, as they appear in the attribute :term:`classes_`.
 
-            Returns
-            -------
-            T : ndarray of shape (n_samples, n_classes)
-                Returns the log-probabilities of the sample for each class in
-                the model. The columns correspond to the classes in sorted
-                order, as they appear in the attribute :term:`classes_`.
+        Notes
+        -----
+        The probability model is created using cross validation, so
+        the results can be slightly different than those obtained by
+        predict. Also, it will produce meaningless results on very small
+        datasets.
+        """
+        xp, _ = get_namespace(X)
 
-            Notes
-            -----
-            The probability model is created using cross validation, so
-            the results can be slightly different than those obtained by
-            predict. Also, it will produce meaningless results on very small
-            datasets.
-            """
-            xp, _ = get_namespace(X)
-
-            return xp.log(self.predict_proba(X))
-
-    else:
-
-        @property
-        def predict_proba(self):
-            self._check_proba()
-            check_is_fitted(self)
-            return self._predict_proba
-
-        def _predict_log_proba(self, X):
-            xp, _ = get_namespace(X)
-            return xp.log(self.predict_proba(X))
-
-        predict_proba.__doc__ = _sklearn_NuSVC.predict_proba.__doc__
+        return xp.log(self.predict_proba(X))
 
     @wrap_output_data
     def _predict_proba(self, X):
-        sklearn_pred_proba = (
-            _sklearn_NuSVC.predict_proba
-            if sklearn_check_version("1.0")
-            else _sklearn_NuSVC._predict_proba
-        )
-
         return dispatch(
             self,
             "predict_proba",
             {
                 "onedal": self.__class__._onedal_predict_proba,
-                "sklearn": sklearn_pred_proba,
+                "sklearn": _sklearn_NuSVC.predict_proba,
             },
             X,
         )
@@ -306,23 +277,16 @@ class NuSVC(_sklearn_NuSVC, BaseSVC):
         self._save_attributes()
 
     def _onedal_predict(self, X, queue=None):
-        if sklearn_check_version("1.0"):
-            validate_data(
-                self,
-                X,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                ensure_2d=False,
-                accept_sparse="csr",
-                reset=False,
-            )
-        else:
-            X = check_array(
-                X,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                accept_sparse="csr",
-            )
+        validate_data(
+            self,
+            X,
+            dtype=[np.float64, np.float32],
+            ensure_all_finite=False,
+            ensure_2d=False,
+            accept_sparse="csr",
+            reset=False,
+            skip_y_conversion=True,
+        )
 
         return self._onedal_estimator.predict(X, queue=queue)
 
@@ -341,22 +305,15 @@ class NuSVC(_sklearn_NuSVC, BaseSVC):
             return self.clf_prob.predict_proba(X)
 
     def _onedal_decision_function(self, X, queue=None):
-        if sklearn_check_version("1.0"):
-            validate_data(
-                self,
-                X,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                accept_sparse="csr",
-                reset=False,
-            )
-        else:
-            X = check_array(
-                X,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                accept_sparse="csr",
-            )
+        validate_data(
+            self,
+            X,
+            dtype=[np.float64, np.float32],
+            ensure_all_finite=False,
+            accept_sparse="csr",
+            reset=False,
+            skip_y_conversion=True,
+        )
 
         return self._onedal_estimator.decision_function(X, queue=queue)
 

--- a/sklearnex/svm/nusvc.py
+++ b/sklearnex/svm/nusvc.py
@@ -285,7 +285,6 @@ class NuSVC(_sklearn_NuSVC, BaseSVC):
             ensure_2d=False,
             accept_sparse="csr",
             reset=False,
-            skip_y_conversion=True,
         )
 
         return self._onedal_estimator.predict(X, queue=queue)
@@ -312,7 +311,6 @@ class NuSVC(_sklearn_NuSVC, BaseSVC):
             ensure_all_finite=False,
             accept_sparse="csr",
             reset=False,
-            skip_y_conversion=True,
         )
 
         return self._onedal_estimator.decision_function(X, queue=queue)

--- a/sklearnex/svm/nusvr.py
+++ b/sklearnex/svm/nusvr.py
@@ -150,7 +150,6 @@ class NuSVR(_sklearn_NuSVR, BaseSVR):
             ensure_all_finite=False,
             accept_sparse="csr",
             reset=False,
-            skip_y_conversion=True,
         )
         return self._onedal_estimator.predict(X, queue=queue)
 

--- a/sklearnex/svm/nusvr.py
+++ b/sklearnex/svm/nusvr.py
@@ -27,12 +27,8 @@ from daal4py.sklearn._utils import sklearn_check_version
 from onedal.svm import NuSVR as onedal_NuSVR
 
 from .._device_offload import dispatch, wrap_output_data
+from ..utils.validation import validate_data
 from ._common import BaseSVR
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = BaseSVR._validate_data
 
 
 @control_n_jobs(decorated_methods=["fit", "predict", "score"])
@@ -147,22 +143,15 @@ class NuSVR(_sklearn_NuSVR, BaseSVR):
         self._save_attributes()
 
     def _onedal_predict(self, X, queue=None):
-        if sklearn_check_version("1.0"):
-            X = validate_data(
-                self,
-                X,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                accept_sparse="csr",
-                reset=False,
-            )
-        else:
-            X = check_array(
-                X,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                accept_sparse="csr",
-            )
+        X = validate_data(
+            self,
+            X,
+            dtype=[np.float64, np.float32],
+            ensure_all_finite=False,
+            accept_sparse="csr",
+            reset=False,
+            skip_y_conversion=True,
+        )
         return self._onedal_estimator.predict(X, queue=queue)
 
     fit.__doc__ = _sklearn_NuSVR.fit.__doc__

--- a/sklearnex/svm/svc.py
+++ b/sklearnex/svm/svc.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from functools import wraps
+
 import numpy as np
 from scipy import sparse as sp
 from sklearn.exceptions import NotFittedError
@@ -141,64 +143,14 @@ class SVC(_sklearn_SVC, BaseSVC):
         )
 
     @available_if(_sklearn_SVC._check_proba)
+    @wraps(_sklearn_SVC.predict_proba, assigned=["__doc__"])
     def predict_proba(self, X):
-        """
-        Compute probabilities of possible outcomes for samples in X.
-
-        The model need to have probability information computed at training
-        time: fit with attribute `probability` set to True.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            For kernel="precomputed", the expected shape of X is
-            (n_samples_test, n_samples_train).
-
-        Returns
-        -------
-        T : ndarray of shape (n_samples, n_classes)
-            Returns the probability of the sample for each class in
-            the model. The columns correspond to the classes in sorted
-            order, as they appear in the attribute :term:`classes_`.
-
-        Notes
-        -----
-        The probability model is created using cross validation, so
-        the results can be slightly different than those obtained by
-        predict. Also, it will produce meaningless results on very small
-        datasets.
-        """
         check_is_fitted(self)
         return self._predict_proba(X)
 
     @available_if(_sklearn_SVC._check_proba)
+    @wraps(_sklearn_SVC.predict_log_proba, assigned=["__doc__"])
     def predict_log_proba(self, X):
-        """Compute log probabilities of possible outcomes for samples in X.
-
-        The model need to have probability information computed at training
-        time: fit with attribute `probability` set to True.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features) or \
-                (n_samples_test, n_samples_train)
-            For kernel="precomputed", the expected shape of X is
-            (n_samples_test, n_samples_train).
-
-        Returns
-        -------
-        T : ndarray of shape (n_samples, n_classes)
-            Returns the log-probabilities of the sample for each class in
-            the model. The columns correspond to the classes in sorted
-            order, as they appear in the attribute :term:`classes_`.
-
-        Notes
-        -----
-        The probability model is created using cross validation, so
-        the results can be slightly different than those obtained by
-        predict. Also, it will produce meaningless results on very small
-        datasets.
-        """
         xp, _ = get_namespace(X)
 
         return xp.log(self.predict_proba(X))

--- a/sklearnex/svm/svc.py
+++ b/sklearnex/svm/svc.py
@@ -19,6 +19,7 @@ from scipy import sparse as sp
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import accuracy_score
 from sklearn.svm import SVC as _sklearn_SVC
+from sklearn.utils.metaestimators import available_if
 from sklearn.utils.validation import (
     _deprecate_positional_args,
     check_array,
@@ -27,21 +28,13 @@ from sklearn.utils.validation import (
 
 from daal4py.sklearn._n_jobs_support import control_n_jobs
 from daal4py.sklearn._utils import sklearn_check_version
+from onedal.svm import SVC as onedal_SVC
 
 from .._device_offload import dispatch, wrap_output_data
 from .._utils import PatchingConditionsChain
 from ..utils._array_api import get_namespace
+from ..utils.validation import validate_data
 from ._common import BaseSVC
-
-if sklearn_check_version("1.0"):
-    from sklearn.utils.metaestimators import available_if
-
-from onedal.svm import SVC as onedal_SVC
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = BaseSVC._validate_data
 
 
 @control_n_jobs(
@@ -147,99 +140,77 @@ class SVC(_sklearn_SVC, BaseSVC):
             sample_weight=sample_weight,
         )
 
-    if sklearn_check_version("1.0"):
+    @available_if(_sklearn_SVC._check_proba)
+    def predict_proba(self, X):
+        """
+        Compute probabilities of possible outcomes for samples in X.
 
-        @available_if(_sklearn_SVC._check_proba)
-        def predict_proba(self, X):
-            """
-            Compute probabilities of possible outcomes for samples in X.
+        The model need to have probability information computed at training
+        time: fit with attribute `probability` set to True.
 
-            The model need to have probability information computed at training
-            time: fit with attribute `probability` set to True.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            For kernel="precomputed", the expected shape of X is
+            (n_samples_test, n_samples_train).
 
-            Parameters
-            ----------
-            X : array-like of shape (n_samples, n_features)
-                For kernel="precomputed", the expected shape of X is
-                (n_samples_test, n_samples_train).
+        Returns
+        -------
+        T : ndarray of shape (n_samples, n_classes)
+            Returns the probability of the sample for each class in
+            the model. The columns correspond to the classes in sorted
+            order, as they appear in the attribute :term:`classes_`.
 
-            Returns
-            -------
-            T : ndarray of shape (n_samples, n_classes)
-                Returns the probability of the sample for each class in
-                the model. The columns correspond to the classes in sorted
-                order, as they appear in the attribute :term:`classes_`.
+        Notes
+        -----
+        The probability model is created using cross validation, so
+        the results can be slightly different than those obtained by
+        predict. Also, it will produce meaningless results on very small
+        datasets.
+        """
+        check_is_fitted(self)
+        return self._predict_proba(X)
 
-            Notes
-            -----
-            The probability model is created using cross validation, so
-            the results can be slightly different than those obtained by
-            predict. Also, it will produce meaningless results on very small
-            datasets.
-            """
-            check_is_fitted(self)
-            return self._predict_proba(X)
+    @available_if(_sklearn_SVC._check_proba)
+    def predict_log_proba(self, X):
+        """Compute log probabilities of possible outcomes for samples in X.
 
-        @available_if(_sklearn_SVC._check_proba)
-        def predict_log_proba(self, X):
-            """Compute log probabilities of possible outcomes for samples in X.
+        The model need to have probability information computed at training
+        time: fit with attribute `probability` set to True.
 
-            The model need to have probability information computed at training
-            time: fit with attribute `probability` set to True.
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features) or \
+                (n_samples_test, n_samples_train)
+            For kernel="precomputed", the expected shape of X is
+            (n_samples_test, n_samples_train).
 
-            Parameters
-            ----------
-            X : array-like of shape (n_samples, n_features) or \
-                    (n_samples_test, n_samples_train)
-                For kernel="precomputed", the expected shape of X is
-                (n_samples_test, n_samples_train).
+        Returns
+        -------
+        T : ndarray of shape (n_samples, n_classes)
+            Returns the log-probabilities of the sample for each class in
+            the model. The columns correspond to the classes in sorted
+            order, as they appear in the attribute :term:`classes_`.
 
-            Returns
-            -------
-            T : ndarray of shape (n_samples, n_classes)
-                Returns the log-probabilities of the sample for each class in
-                the model. The columns correspond to the classes in sorted
-                order, as they appear in the attribute :term:`classes_`.
+        Notes
+        -----
+        The probability model is created using cross validation, so
+        the results can be slightly different than those obtained by
+        predict. Also, it will produce meaningless results on very small
+        datasets.
+        """
+        xp, _ = get_namespace(X)
 
-            Notes
-            -----
-            The probability model is created using cross validation, so
-            the results can be slightly different than those obtained by
-            predict. Also, it will produce meaningless results on very small
-            datasets.
-            """
-            xp, _ = get_namespace(X)
-
-            return xp.log(self.predict_proba(X))
-
-    else:
-
-        @property
-        def predict_proba(self):
-            self._check_proba()
-            check_is_fitted(self)
-            return self._predict_proba
-
-        def _predict_log_proba(self, X):
-            xp, _ = get_namespace(X)
-            return xp.log(self.predict_proba(X))
-
-        predict_proba.__doc__ = _sklearn_SVC.predict_proba.__doc__
+        return xp.log(self.predict_proba(X))
 
     @wrap_output_data
     def _predict_proba(self, X):
-        sklearn_pred_proba = (
-            _sklearn_SVC.predict_proba
-            if sklearn_check_version("1.0")
-            else _sklearn_SVC._predict_proba
-        )
-
         return dispatch(
             self,
             "predict_proba",
             {
                 "onedal": self.__class__._onedal_predict_proba,
-                "sklearn": sklearn_pred_proba,
+                "sklearn": _sklearn_SVC.predict_proba,
             },
             X,
         )
@@ -336,23 +307,16 @@ class SVC(_sklearn_SVC, BaseSVC):
         self._save_attributes()
 
     def _onedal_predict(self, X, queue=None):
-        if sklearn_check_version("1.0"):
-            X = validate_data(
-                self,
-                X,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                ensure_2d=False,
-                accept_sparse="csr",
-                reset=False,
-            )
-        else:
-            X = check_array(
-                X,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                accept_sparse="csr",
-            )
+        X = validate_data(
+            self,
+            X,
+            dtype=[np.float64, np.float32],
+            ensure_all_finite=False,
+            ensure_2d=False,
+            accept_sparse="csr",
+            reset=False,
+            skip_y_conversion=True,
+        )
         return self._onedal_estimator.predict(X, queue=queue)
 
     def _onedal_predict_proba(self, X, queue=None):
@@ -370,22 +334,15 @@ class SVC(_sklearn_SVC, BaseSVC):
             return self.clf_prob.predict_proba(X)
 
     def _onedal_decision_function(self, X, queue=None):
-        if sklearn_check_version("1.0"):
-            X = validate_data(
-                self,
-                X,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                accept_sparse="csr",
-                reset=False,
-            )
-        else:
-            X = check_array(
-                X,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                accept_sparse="csr",
-            )
+        X = validate_data(
+            self,
+            X,
+            dtype=[np.float64, np.float32],
+            ensure_all_finite=False,
+            accept_sparse="csr",
+            reset=False,
+            skip_y_conversion=True,
+        )
         return self._onedal_estimator.decision_function(X, queue=queue)
 
     def _onedal_score(self, X, y, sample_weight=None, queue=None):

--- a/sklearnex/svm/svc.py
+++ b/sklearnex/svm/svc.py
@@ -315,7 +315,6 @@ class SVC(_sklearn_SVC, BaseSVC):
             ensure_2d=False,
             accept_sparse="csr",
             reset=False,
-            skip_y_conversion=True,
         )
         return self._onedal_estimator.predict(X, queue=queue)
 
@@ -341,7 +340,6 @@ class SVC(_sklearn_SVC, BaseSVC):
             ensure_all_finite=False,
             accept_sparse="csr",
             reset=False,
-            skip_y_conversion=True,
         )
         return self._onedal_estimator.decision_function(X, queue=queue)
 

--- a/sklearnex/svm/svr.py
+++ b/sklearnex/svm/svr.py
@@ -23,12 +23,8 @@ from daal4py.sklearn._utils import sklearn_check_version
 from onedal.svm import SVR as onedal_SVR
 
 from .._device_offload import dispatch, wrap_output_data
+from ..utils.validation import validate_data
 from ._common import BaseSVR
-
-if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import validate_data
-else:
-    validate_data = BaseSVR._validate_data
 
 
 @control_n_jobs(decorated_methods=["fit", "predict", "score"])
@@ -144,22 +140,15 @@ class SVR(_sklearn_SVR, BaseSVR):
         self._save_attributes()
 
     def _onedal_predict(self, X, queue=None):
-        if sklearn_check_version("1.0"):
-            X = validate_data(
-                self,
-                X,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                accept_sparse="csr",
-                reset=False,
-            )
-        else:
-            X = check_array(
-                X,
-                dtype=[np.float64, np.float32],
-                force_all_finite=False,
-                accept_sparse="csr",
-            )
+        X = validate_data(
+            self,
+            X,
+            dtype=[np.float64, np.float32],
+            ensure_all_finite=False,
+            accept_sparse="csr",
+            reset=False,
+            skip_y_conversion=True,
+        )
         return self._onedal_estimator.predict(X, queue=queue)
 
     fit.__doc__ = _sklearn_SVR.fit.__doc__

--- a/sklearnex/svm/svr.py
+++ b/sklearnex/svm/svr.py
@@ -147,7 +147,6 @@ class SVR(_sklearn_SVR, BaseSVR):
             ensure_all_finite=False,
             accept_sparse="csr",
             reset=False,
-            skip_y_conversion=True,
         )
         return self._onedal_estimator.predict(X, queue=queue)
 

--- a/sklearnex/tests/test_common.py
+++ b/sklearnex/tests/test_common.py
@@ -424,17 +424,21 @@ def call_validate_data(text, estimator, method):
 
     assert (
         len(validate_data_calls) == 2,
-        "validate_data should be called two times: once for sklearn and once for sklearnex"
+        "validate_data should be called two times: once for sklearn and once for sklearnex",
     )
     assert (
         validate_data_calls[0] == {"sklearnex.utils.validation", "validate_data"},
-        "sklearnex's validate_data should be called first"
+        "sklearnex's validate_data should be called first",
     )
     assert (
-        (validate_data_calls[1] == {"sklearn.utils.validation", "validate_data"})
-        if sklearn_check_version("1.6")
-        else (validate_data_calls[1] == {"sklearn.utils.validation", "_validate_data"}),
-        "sklearn's validate_data should be called second"
+        (
+            (validate_data_calls[1] == {"sklearn.utils.validation", "validate_data"})
+            if sklearn_check_version("1.6")
+            else (
+                validate_data_calls[1] == {"sklearn.utils.validation", "_validate_data"}
+            )
+        ),
+        "sklearn's validate_data should be called second",
     )
     assert (
         valid_funcs.count("_check_feature_names") == 1

--- a/sklearnex/tests/test_common.py
+++ b/sklearnex/tests/test_common.py
@@ -423,23 +423,17 @@ def call_validate_data(text, estimator, method):
             validate_data_calls.append({module, func})
 
     assert (
-        len(validate_data_calls) == 2,
-        "validate_data should be called two times: once for sklearn and once for sklearnex",
-    )
+        len(validate_data_calls) == 2
+    ), "validate_data should be called two times: once for sklearn and once for sklearnex"
+    assert validate_data_calls[0] == {
+        "sklearnex.utils.validation",
+        "validate_data",
+    }, "sklearnex's validate_data should be called first"
     assert (
-        validate_data_calls[0] == {"sklearnex.utils.validation", "validate_data"},
-        "sklearnex's validate_data should be called first",
-    )
-    assert (
-        (
-            (validate_data_calls[1] == {"sklearn.utils.validation", "validate_data"})
-            if sklearn_check_version("1.6")
-            else (
-                validate_data_calls[1] == {"sklearn.utils.validation", "_validate_data"}
-            )
-        ),
-        "sklearn's validate_data should be called second",
-    )
+        (validate_data_calls[1] == {"sklearn.utils.validation", "validate_data"})
+        if sklearn_check_version("1.6")
+        else (validate_data_calls[1] == {"sklearn.base", "_validate_data"})
+    ), "sklearn's validate_data should be called second"
     assert (
         valid_funcs.count("_check_feature_names") == 1
     ), "estimator should check feature names in validate_data"

--- a/sklearnex/tests/test_common.py
+++ b/sklearnex/tests/test_common.py
@@ -415,11 +415,9 @@ def call_validate_data(text, estimator, method):
     except ValueError:
         pytest.skip("onedal backend not used in this function")
 
-    validate_data = "validate_data" if sklearn_check_version("1.6") else "_validate_data"
-
     assert (
-        validfuncs.count(validate_data) == 1
-    ), f"sklearn's {validate_data} should be called"
+        validfuncs.count("validate_data") + validfuncs.count("_validate_data") == 2
+    ), f"sklearn's validate_data should be called"
     assert (
         validfuncs.count("_check_feature_names") == 1
     ), "estimator should check feature names in validate_data"
@@ -467,11 +465,12 @@ def fit_check_before_support_check(text, estimator, method):
         pytest.skip(f"fitting occurs in {estimator}.{method}")
 
 
-DESIGN_RULES = [n_jobs_check, runtime_property_check, fit_check_before_support_check]
-
-
-if sklearn_check_version("1.0"):
-    DESIGN_RULES += [call_validate_data]
+DESIGN_RULES = [
+    n_jobs_check,
+    runtime_property_check,
+    fit_check_before_support_check,
+    call_validate_data,
+]
 
 
 @pytest.mark.parametrize("design_pattern", DESIGN_RULES)

--- a/sklearnex/utils/validation.py
+++ b/sklearnex/utils/validation.py
@@ -21,15 +21,12 @@ from sklearn.utils.validation import _assert_all_finite as _sklearn_assert_all_f
 from sklearn.utils.validation import _num_samples, check_array, check_non_negative
 
 from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
+from daal4py.sklearn.utils.validation import check_feature_names, check_n_features
 from onedal.utils.validation import is_contiguous
 
 from ._array_api import get_namespace
 
 if sklearn_check_version("1.6"):
-    from sklearn.utils.validation import (
-        _check_feature_names as _sklearn_check_feature_names,
-    )
-    from sklearn.utils.validation import _check_n_features as _sklearn_check_n_features
     from sklearn.utils.validation import validate_data as _sklearn_validate_data
 
     _finite_keyword = "ensure_all_finite"
@@ -37,8 +34,6 @@ else:
     from sklearn.base import BaseEstimator
 
     _sklearn_validate_data = BaseEstimator._validate_data
-    _sklearn_check_feature_names = BaseEstimator._check_feature_names
-    _sklearn_check_n_features = BaseEstimator._check_n_features
     _finite_keyword = "force_all_finite"
 
 
@@ -102,7 +97,7 @@ def validate_data(
     /,
     X="no_validation",
     y="no_validation",
-    skip_y_conversion=False,
+    ensure_y_dtype=False,
     **kwargs,
 ):
     # force finite check to not occur in sklearn, default is True
@@ -136,7 +131,7 @@ def validate_data(
         if check_y:
             assert_all_finite(next(arg), allow_nan=allow_nan, input_name="y")
 
-    if check_y and "dtype" in kwargs and not skip_y_conversion:
+    if ensure_y_dtype and check_y and "dtype" in kwargs:
         # validate_data does not do full dtype conversions, as it uses check_X_y
         # oneDAL can make tables from [int32, float32, float64], requiring
         # a dtype check and conversion. This will query the array_namespace and
@@ -209,11 +204,3 @@ def _check_sample_weight(
         check_non_negative(sample_weight, "`sample_weight`")
 
     return sample_weight
-
-
-def check_feature_names(*args, **kwargs):
-    _sklearn_check_feature_names(*args, **kwargs)
-
-
-def check_n_features(*args, **kwargs):
-    _sklearn_check_n_features(*args, **kwargs)

--- a/sklearnex/utils/validation.py
+++ b/sklearnex/utils/validation.py
@@ -26,14 +26,19 @@ from onedal.utils.validation import is_contiguous
 from ._array_api import get_namespace
 
 if sklearn_check_version("1.6"):
+    from sklearn.utils.validation import (
+        _check_feature_names as _sklearn_check_feature_names,
+    )
+    from sklearn.utils.validation import _check_n_features as _sklearn_check_n_features
     from sklearn.utils.validation import validate_data as _sklearn_validate_data
 
     _finite_keyword = "ensure_all_finite"
-
 else:
     from sklearn.base import BaseEstimator
 
     _sklearn_validate_data = BaseEstimator._validate_data
+    _sklearn_check_feature_names = BaseEstimator._check_feature_names
+    _sklearn_check_n_features = BaseEstimator._check_n_features
     _finite_keyword = "force_all_finite"
 
 
@@ -97,6 +102,7 @@ def validate_data(
     /,
     X="no_validation",
     y="no_validation",
+    skip_y_conversion=False,
     **kwargs,
 ):
     # force finite check to not occur in sklearn, default is True
@@ -130,7 +136,7 @@ def validate_data(
         if check_y:
             assert_all_finite(next(arg), allow_nan=allow_nan, input_name="y")
 
-    if check_y and "dtype" in kwargs:
+    if check_y and "dtype" in kwargs and not skip_y_conversion:
         # validate_data does not do full dtype conversions, as it uses check_X_y
         # oneDAL can make tables from [int32, float32, float64], requiring
         # a dtype check and conversion. This will query the array_namespace and
@@ -203,3 +209,11 @@ def _check_sample_weight(
         check_non_negative(sample_weight, "`sample_weight`")
 
     return sample_weight
+
+
+def check_feature_names(*args, **kwargs):
+    _sklearn_check_feature_names(*args, **kwargs)
+
+
+def check_n_features(*args, **kwargs):
+    _sklearn_check_n_features(*args, **kwargs)

--- a/sklearnex/utils/validation.py
+++ b/sklearnex/utils/validation.py
@@ -21,7 +21,11 @@ from sklearn.utils.validation import _assert_all_finite as _sklearn_assert_all_f
 from sklearn.utils.validation import _num_samples, check_array, check_non_negative
 
 from daal4py.sklearn._utils import daal_check_version, sklearn_check_version
-from daal4py.sklearn.utils.validation import check_feature_names, check_n_features
+from daal4py.sklearn.utils.validation import (
+    add_dispatcher_docstring,
+    check_feature_names,
+    check_n_features,
+)
 from onedal.utils.validation import is_contiguous
 
 from ._array_api import get_namespace
@@ -92,6 +96,7 @@ def assert_all_finite(
     )
 
 
+@add_dispatcher_docstring(_sklearn_validate_data)
 def validate_data(
     _estimator,
     /,

--- a/sklearnex/utils/validation.py
+++ b/sklearnex/utils/validation.py
@@ -102,7 +102,6 @@ def validate_data(
     /,
     X="no_validation",
     y="no_validation",
-    ensure_y_dtype=False,
     **kwargs,
 ):
     # force finite check to not occur in sklearn, default is True
@@ -135,22 +134,6 @@ def validate_data(
             assert_all_finite(next(arg), allow_nan=allow_nan, input_name="X")
         if check_y:
             assert_all_finite(next(arg), allow_nan=allow_nan, input_name="y")
-
-    if ensure_y_dtype and check_y and "dtype" in kwargs:
-        # validate_data does not do full dtype conversions, as it uses check_X_y
-        # oneDAL can make tables from [int32, float32, float64], requiring
-        # a dtype check and conversion. This will query the array_namespace and
-        # convert y as necessary. This is important especially for regressors.
-        dtype = kwargs["dtype"]
-        if not isinstance(dtype, (tuple, list)):
-            dtype = tuple(dtype)
-
-        outx, outy = out if check_x else (None, out)
-        if outy.dtype not in dtype:
-            yp, _ = get_namespace(outy)
-            # use asarray rather than astype because of numpy support
-            outy = yp.asarray(outy, dtype=dtype[0])
-            out = (outx, outy) if check_x else outy
 
     return out
 


### PR DESCRIPTION
## Description

Changes:
- Fully apply deprecations and removals from sklearn 1.7 in sklearnex and daal4py by adding dispatchers based on used sklearn version in daal4py and sklearnex modules:
  - `BaseEstimator._check_feature_names` changed to `sklearn.utils.validation.check_feature_names` (dispatcher in `daal4py.sklearn.utils.validation` module)
  - `BaseEstimator._check_n_features` changed to `sklearn.utils.validation.check_n_features` (dispatcher in `daal4py.sklearn.utils.validation` module)
  - `BaseEstimator._validate_data` changed to `sklearn.utils.validation.validate_data` (dispatchers in `daal4py.sklearn.utils.validation` and `sklearnex.utils.validation` modules, sklearnex's one uses onedal4py finiteness checker)
  - `force_all_finite` argument changed to `ensure_all_finite` in `validate_data` and other functions
- Unify sklearn tags (`requires_y`, `array_api_support`) getting in few functions
- Remove numeric y_dtype conversion from `sklearnex.utils.validation.validate_data` for compatibility with sklearn which allows object types output
- Change `validate_date` design rule in `test_common.py` to correctly count sklearn's and sklearnex's calls
- Add `tol` to LinearRegression parameters (new in 1.7 version)
- Remove code branches for unsupported sklearn versions < 1.0

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
