### PR TITLE
feat: Add OASEstimator class with oneDAL support and corresponding tests

### DIFF
--- a/sklearnex/covariance/oas_estimator.py
+++ b/sklearnex/covariance/oas_estimator.py
@@ -1,0 +1,126 @@
+from sklearn.covariance import EmpiricalCovariance
+import numpy as np
+from sklearn.utils.validation import check_is_fitted
+
+from daal4py.sklearn._n_jobs_support import control_n_jobs
+from daal4py.sklearn._utils import sklearn_check_version
+
+from .._device_offload import dispatch, wrap_output_data
+
+if sklearn_check_version("1.6"):
+    from sklearn.utils.validation import validate_data
+else:
+    validate_data = EmpiricalCovariance._validate_data
+
+@control_n_jobs(decorated_methods=["fit", "score"])
+class OASEstimator(EmpiricalCovariance):
+    __doc__ = EmpiricalCovariance.__doc__
+
+    def __init__(self, shrinkage=0.1):
+        super().__init__()
+        self.shrinkage = shrinkage
+
+    def fit(self, X, y=None):
+        dispatch(
+            self,
+            "fit",
+            {
+                "onedal": self._onedal_fit,
+                "sklearn": self._sklearn_fit,
+            },
+            X,
+            y,
+        )
+        return self
+
+    def _sklearn_fit(self, X, y=None):
+        super().fit(X, y)
+        mean = np.mean(X, axis=0)
+        n_samples, n_features = X.shape
+        emp_cov = self.covariance_
+        shrinkage = self.shrinkage
+        oas_cov = (1 - shrinkage) * emp_cov + shrinkage * np.mean(np.diag(emp_cov)) * np.eye(n_features)
+        self.covariance_ = oas_cov
+
+    def _onedal_fit(self, X, y=None, queue=None):
+        from onedal.covariance import OASEstimator as onedal_OASEstimator
+
+        use_raw_input = get_config().get("use_raw_input", False) is True
+        if not use_raw_input:
+            if sklearn_check_version("1.2"):
+                self._validate_params()
+
+            if sklearn_check_version("1.0"):
+                X = validate_data(
+                    self,
+                    X,
+                    dtype=[np.float64, np.float32],
+                    copy=self.copy,
+                    force_all_finite=False,
+                )
+            else:
+                X = check_array(
+                    X,
+                    dtype=[np.float64, np.float32],
+                    copy=self.copy,
+                    force_all_finite=False,
+                )
+
+        onedal_params = {
+            "shrinkage": self.shrinkage,
+        }
+
+        self._onedal_estimator = onedal_OASEstimator(**onedal_params)
+        self._onedal_estimator.fit(X, queue=queue)
+
+        self.covariance_ = self._onedal_estimator.covariance_
+
+    @wrap_output_data
+    def score(self, X, y=None):
+        check_is_fitted(self)
+        return dispatch(
+            self,
+            "score",
+            {
+                "onedal": self._onedal_score,
+                "sklearn": super().score,
+            },
+            X,
+            y,
+        )
+
+    def _onedal_score(self, X, y=None, queue=None):
+        from onedal.covariance import OASEstimator as onedal_OASEstimator
+
+        use_raw_input = get_config().get("use_raw_input", False) is True
+        if not use_raw_input:
+            if sklearn_check_version("1.0"):
+                X = validate_data(
+                    self,
+                    X,
+                    dtype=[np.float64, np.float32],
+                    copy=self.copy,
+                    force_all_finite=False,
+                )
+            else:
+                X = check_array(
+                    X,
+                    dtype=[np.float64, np.float32],
+                    copy=self.copy,
+                    force_all_finite=False,
+                )
+
+        if not hasattr(self, "_onedal_estimator"):
+            onedal_params = {
+                "shrinkage": self.shrinkage,
+            }
+            self._onedal_estimator = onedal_OASEstimator(**onedal_params)
+            self._onedal_estimator.fit(X, queue=queue)
+
+        return self._onedal_estimator.score(X, queue=queue)
+
+    def _more_tags(self):
+        return {'allow_nan': False}
+
+    fit.__doc__ = EmpiricalCovariance.fit.__doc__
+    score.__doc__ = EmpiricalCovariance.score.__doc__

--- a/sklearnex/tests/test_oas_estimator.py
+++ b/sklearnex/tests/test_oas_estimator.py
@@ -1,0 +1,15 @@
+import numpy as np
+from sklearnex.covariance.oas_estimator import OASEstimator
+
+def test_oas_estimator_fit():
+    X = np.random.randn(100, 5)
+    estimator = OASEstimator(shrinkage=0.1)
+    estimator.fit(X)
+    assert estimator.covariance_ is not None
+
+def test_oas_estimator_score():
+    X = np.random.randn(100, 5)
+    estimator = OASEstimator(shrinkage=0.1)
+    estimator.fit(X)
+    score = estimator.score(X)
+    assert isinstance(score, float)


### PR DESCRIPTION
- Implemented OASEstimator class in oas_estimator.py inheriting from EmpiricalCovariance.
- Added methods _sklearn_fit, _onedal_fit, score, and _onedal_score to support both scikit-learn and oneDAL backends.
- Integrated dispatch mechanism to switch between scikit-learn and oneDAL implementations.
- Added tests for OASEstimator in 	est_oas_estimator.py to verify fit and score functionalities.

## Description

_Add a comprehensive description of proposed changes_

_List associated issue number(s) if exist(s): #6 (for example)_

_Documentation PR (if needed): #1340 (for example)_

_Benchmarks PR (if needed): https://github.com/IntelPython/scikit-learn_bench/pull/155 (for example)_

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
