### PR TITLE
DOC: Include new notebooks in .rst docs

### DIFF
--- a/doc/sources/samples.rst
+++ b/doc/sources/samples.rst
@@ -30,6 +30,7 @@ If you want to run them locally, refer to `these instructions
    k-Nearest Neighbors (kNN) for MNIST dataset <samples/knn_mnist.ipynb>
    Logistic Regression for Cifar dataset <samples/logistictic_regression_cifar.ipynb>
    Support Vector Classification (SVC) for Adult dataset <samples/svc_adult.ipynb>
+   Random Forest Classification on rain in Australia dataset <samples/random_forest_rain.ipynb>
 
 .. rubric:: Regression Tasks
 
@@ -42,6 +43,9 @@ If you want to run them locally, refer to `these instructions
    Nu-Support Vector Regression (NuSVR) for Medical Charges dataset <samples/nusvr_medical_charges.ipynb>
    Random Forest for Yolanda dataset <samples/random_forest_yolanda.ipynb>
    Rigde Regression for Airlines DepDelay dataset <samples/ridge_regression.ipynb>
+   Ridge Regression on New York City Bike Share dataset <samples/ridge_regression_bike_sharing.ipynb>
+   Ridge Regression on IEEE-CIS Fraud Detection dataset <samples/ridge_regression_fraud_detection.ipynb>
+   Ridge Regression on Higgs dataset <samples/ridge_regression_higgs.ipynb>
 
 .. rubric:: Clustering Tasks
 


### PR DESCRIPTION
## Description

ref https://github.com/uxlfoundation/scikit-learn-intelex/pull/2343

The PR above introduced new notebooks showcasing speedups of sklearnex.

All of these notebooks get copied automatically into the docs folder from where the .rst files include them. Since our docs build logic is to turn all warnings into errors, this currently leads to errors like these:
```
checking consistency... /home/vsts/work/1/s/doc/sources/samples/random_forest_rain.ipynb: WARNING: document isn't included in any toctree [toc.not_included]
/home/vsts/work/1/s/doc/sources/samples/ridge_regression_bike_sharing.ipynb: WARNING: document isn't included in any toctree [toc.not_included]
/home/vsts/work/1/s/doc/sources/samples/ridge_regression_fraud_detection.ipynb: WARNING: document isn't included in any toctree [toc.not_included]
/home/vsts/work/1/s/doc/sources/samples/ridge_regression_higgs.ipynb: WARNING: document isn't included in any toctree [toc.not_included]
```

This PR fixes them by including these new notebooks in the relevant .rst files.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
