### PR TITLE
DOC: Remove backslash that breaks doc formatting

### DIFF
--- a/generator/parse.py
+++ b/generator/parse.py
@@ -684,6 +684,8 @@ def parse_header(header, ignores):
         if not re.search(r"https?://", elem):
             elem = elem.split("//")[0]
         # delete 'DAAL_DEPRECATED'
+        # Note that it might be prefixed with backslashes
+        elem = elem.replace("\\DAAL_DEPRECATED ", "")
         elem = elem.replace("DAAL_DEPRECATED ", "")
         # apply each parser, continue to next line if possible
         for p in parsers:


### PR DESCRIPTION
## Description

The generator for daal4py takes docstrings from oneDAL, which uses `\DAAL_DEPRECATED`. It currently removes the deprecated part, but not the backslash, which results in incorrectly formatted docs:
![image](https://github.com/user-attachments/assets/3b722eab-54fa-45bb-80dd-d11151886370)
![image](https://github.com/user-attachments/assets/eb6a69ac-652c-4978-ae80-2be9b49da22e)

This PR fixes this typo. Unfortunately, it won't reach the deployed docs for daal4py since there's no re-deployment pipeline, but should at least solve the issue locally (for now).

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
