### PR TITLE
[bugfix] Normalize Decision Tree ```.values``` attribute to match sklearn

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,16 +15,6 @@
 #===============================================================================
 
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.1.1
-    hooks:
-      - id: black
-        language_version: python3.10
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        language_version: python3.10
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v14.0.6
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,16 @@
 #===============================================================================
 
 repos:
+  - repo: https://github.com/psf/black
+    rev: 24.1.1
+    hooks:
+      - id: black
+        language_version: python3.10
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        language_version: python3.10
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v14.0.6
     hooks:

--- a/onedal/primitives/tree_visitor.cpp
+++ b/onedal/primitives/tree_visitor.cpp
@@ -34,6 +34,8 @@ namespace py = pybind11;
 namespace dal = oneapi::dal;
 namespace df = dal::decision_forest;
 
+using namespace pybind11::literals;
+
 namespace oneapi::dal::python {
 
 inline static const double get_nan64() {
@@ -161,6 +163,8 @@ to_sklearn_tree_object_visitor<Task>::to_sklearn_tree_object_visitor(std::size_t
     auto value_ar_shape = py::array::ShapeContainer({ static_cast<Py_ssize_t>(this->node_count),
                                                       1,
                                                       static_cast<Py_ssize_t>(this->class_count) });
+
+
     auto value_ar_strides = py::array::StridesContainer(
         { this->class_count * sizeof(double), this->class_count * sizeof(double), sizeof(double) });
 
@@ -294,7 +298,14 @@ void init_get_tree_state(py::module_& m) {
                                                      n_classes);
             node_visitor<Task, decltype(tsv)> tsv_decorator{ &tsv };
             model.traverse_depth_first(iTree, std::move(tsv_decorator));
-            return tree_state_t(tsv);
+            tree_state_t output = tree_state_t(tsv);
+            // convert the value_ar to fractional values, rather than total ones
+            // the last axis (2) is the n_classes, which must be summed for the
+            // fraction
+            if (output.class_count > 1){
+                output.value_ar = output.value_ar / output.value_ar.attr("sum")("axis"_a=2, "keepdims"_a=true);
+            }
+            return output;
         }))
         .def_readwrite("node_ar", &tree_state_t::node_ar, py::return_value_policy::take_ownership)
         .def_readwrite("value_ar", &tree_state_t::value_ar, py::return_value_policy::take_ownership)

--- a/onedal/primitives/tree_visitor.cpp
+++ b/onedal/primitives/tree_visitor.cpp
@@ -300,8 +300,9 @@ void init_get_tree_state(py::module_& m) {
             // convert the value_ar to fractional values, rather than total ones
             // the last axis (2) is the n_classes, which must be summed for the
             // fraction
-            if (output.class_count > 1){
-                output.value_ar = output.value_ar / output.value_ar.attr("sum")("axis"_a=2, "keepdims"_a=true);
+            if (output.class_count > 1) {
+                output.value_ar = output.value_ar /
+                                  output.value_ar.attr("sum")("axis"_a = 2, "keepdims"_a = true);
             }
             return output;
         }))

--- a/onedal/primitives/tree_visitor.cpp
+++ b/onedal/primitives/tree_visitor.cpp
@@ -163,8 +163,6 @@ to_sklearn_tree_object_visitor<Task>::to_sklearn_tree_object_visitor(std::size_t
     auto value_ar_shape = py::array::ShapeContainer({ static_cast<Py_ssize_t>(this->node_count),
                                                       1,
                                                       static_cast<Py_ssize_t>(this->class_count) });
-
-
     auto value_ar_strides = py::array::StridesContainer(
         { this->class_count * sizeof(double), this->class_count * sizeof(double), sizeof(double) });
 

--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -476,9 +476,8 @@ class ForestClassifier(_sklearn_ForestClassifier, BaseForest):
 
     def _estimators_(self):
         super()._estimators_()
-        classes_ = self.classes_[0]
         for est in self._cached_estimators_:
-            est.classes_ = classes_
+            est.classes_ = self.classes_
 
     def fit(self, X, y, sample_weight=None):
         dispatch(


### PR DESCRIPTION
## Description

The values attribute (https://scikit-learn.org/stable/auto_examples/tree/plot_unveil_tree_structure.html#what-is-the-values-array-used-here) is normalized (i.e. the fraction of samples), where we had previously set it to the absolute number of samples.  A division after a sum is applied at the end in order to conform to sklearn and to try and fix the error observed in #1919.

A second error is mentioned in the issue where the classes aren't properly stored in the DecisionTree, a fix is made to use all of ```self.classes_``` instead of ```self.classes_[0]```.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
