### PR TITLE
DOC: Document full extent of extension estimators

### DIFF
--- a/doc/sources/non-scikit-algorithms.rst
+++ b/doc/sources/non-scikit-algorithms.rst
@@ -17,33 +17,27 @@ Non-Scikit-Learn Algorithms
 Algorithms not presented in the original scikit-learn are described here. All algorithms are
 available for both CPU and GPU (including distributed mode)
 
-BasicStatistics
----------------
 .. autoclass:: sklearnex.basic_statistics.BasicStatistics
-.. automethod:: sklearnex.basic_statistics.BasicStatistics.fit
+    :members:
+    :inherited-members:
+    :show-inheritance:
 
-IncrementalBasicStatistics
---------------------------
 .. autoclass:: sklearnex.basic_statistics.IncrementalBasicStatistics
-.. automethod:: sklearnex.basic_statistics.IncrementalBasicStatistics.fit
-.. automethod:: sklearnex.basic_statistics.IncrementalBasicStatistics.partial_fit
+    :members:
+    :inherited-members:
+    :show-inheritance:
 
-IncrementalEmpiricalCovariance
-------------------------------
 .. autoclass:: sklearnex.covariance.IncrementalEmpiricalCovariance
-.. automethod:: sklearnex.covariance.IncrementalEmpiricalCovariance.fit
-.. automethod:: sklearnex.covariance.IncrementalEmpiricalCovariance.partial_fit
+    :members:
+    :inherited-members:
+    :show-inheritance:
 
-IncrementalLinearRegression
----------------------------
 .. autoclass:: sklearnex.linear_model.IncrementalLinearRegression
-.. automethod:: sklearnex.linear_model.IncrementalLinearRegression.fit
-.. automethod:: sklearnex.linear_model.IncrementalLinearRegression.partial_fit
-.. automethod:: sklearnex.linear_model.IncrementalLinearRegression.predict
+    :members:
+    :inherited-members:
+    :show-inheritance:
 
-IncrementalRidge
-----------------
 .. autoclass:: sklearnex.linear_model.IncrementalRidge
-.. automethod:: sklearnex.linear_model.IncrementalRidge.fit
-.. automethod:: sklearnex.linear_model.IncrementalRidge.partial_fit
-.. automethod:: sklearnex.linear_model.IncrementalRidge.predict
+    :members:
+    :inherited-members:
+    :show-inheritance:

--- a/sklearnex/linear_model/incremental_linear.py
+++ b/sklearnex/linear_model/incremental_linear.py
@@ -444,7 +444,8 @@ class IncrementalLinearRegression(
 
     @wrap_output_data
     def score(self, X, y, sample_weight=None):
-        """Return the coefficient of determination of the prediction.
+        """
+        Return the coefficient of determination of the prediction.
 
         The coefficient of determination :math:`R^2` is defined as
         :math:`(1 - \\frac{u}{v})`, where :math:`u` is the residual


### PR DESCRIPTION
## Description

We have extension estimators (= not present in sklearn) which inherit from scikit-learn estimators. This inheritance brings up base method like ability to set metadata routing and similar, but those are not documented and it's not clear from the docs that the extension estimators actually support all of this.

This PR changes the documentation logic to:
* Document all members and inherited members (which incidentally also fixes the issue of docs missing methods like `score`).
* Put all estimators in the same section, since they are already indexed - this way, it only takes one click on one plus sign to see the methods for each.

By now, we have intersphinx configured to link to sklearn's documentation wherever appropriate, so this doesn't trigger any kind of warning now, and the docs for extension estimators link to docs from sklearn where appropriate (e.g. for R2 function).

Before:
![image](https://github.com/user-attachments/assets/63ee6382-ceeb-4ace-8869-bdd4ccacb129)

After:
![image](https://github.com/user-attachments/assets/02e6d390-0f92-437d-95b6-334d979e2eac)

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
