### PR TITLE
DOC: Use common variable for serialization note

### DIFF
--- a/daal4py/sklearn/_n_jobs_support.py
+++ b/daal4py/sklearn/_n_jobs_support.py
@@ -214,7 +214,11 @@ def control_n_jobs(decorated_methods: list = []):
             and "n_jobs : int" not in original_class.__doc__
         ):
             # Python 3.13 removed extra tab in class doc string
-            tab = "    " if sys.version_info.minor < 13 else ""
+            tab = (
+                "    "
+                if (sys.version_info.major == 3 and sys.version_info.minor < 13)
+                else ""
+            )
             parameters_doc_tail = f"\n{tab}Attributes"
             n_jobs_doc = f"""
 {tab}n_jobs : int, default=None

--- a/sklearnex/_utils.py
+++ b/sklearnex/_utils.py
@@ -156,10 +156,11 @@ class ExtensionEstimator(BaseForHTMLDocLink):
         return f"https://uxlfoundation.github.io/scikit-learn-intelex/latest/non-scikit-algorithms.html#{module_path}.{class_name}"
 
 
-# Adds a small note note about serialization for extension estimators that are incremental.
-# The class docstrings should leave a placeholder '%incremental_serialization_note%' inside
-# their docstrings, which will be replaced by this note.
 def _add_inc_serialization_note(class_docstrings: str) -> str:
+    """Adds a small note note about serialization for extension estimators that are incremental.
+    The class docstrings should leave a placeholder '%incremental_serialization_note%' inside
+    their docstrings, which will be replaced by this note.
+    """
     # In python versions >=3.13, leading whitespace in docstrings defined through
     # static strings (but **not through other ways**) is automatically removed
     # from the final docstrings, while in earlier versions is kept.

--- a/sklearnex/_utils.py
+++ b/sklearnex/_utils.py
@@ -155,6 +155,16 @@ class ExtensionEstimator(BaseForHTMLDocLink):
         return f"https://uxlfoundation.github.io/scikit-learn-intelex/latest/non-scikit-algorithms.html#{module_path}.{class_name}"
 
 
+# A note about serialization for extension estimators that are incremental
+_inc_serialization_note = """Note
+    ----
+    Serializing instances of this class will trigger a forced finalization of calculations
+    when the inputs are in a sycl queue or when using GPUs. Since (internal method)
+    finalize_fit can't be dispatched without directly provided queue and the dispatching
+    policy can't be serialized, the computation is finalized during serialization call and
+    the policy is not saved in serialized data."""
+
+
 # This abstract class is meant to generate a clickable doc link for classses
 # in sklearnex that have counterparts in scikit-learn.
 class PatchableEstimator(BaseForHTMLDocLink):

--- a/sklearnex/_utils.py
+++ b/sklearnex/_utils.py
@@ -17,6 +17,7 @@
 import logging
 import os
 import re
+import sys
 import warnings
 from abc import ABC
 
@@ -155,14 +156,27 @@ class ExtensionEstimator(BaseForHTMLDocLink):
         return f"https://uxlfoundation.github.io/scikit-learn-intelex/latest/non-scikit-algorithms.html#{module_path}.{class_name}"
 
 
-# A note about serialization for extension estimators that are incremental
-_inc_serialization_note = """Note
-    ----
-    Serializing instances of this class will trigger a forced finalization of calculations
-    when the inputs are in a sycl queue or when using GPUs. Since (internal method)
-    finalize_fit can't be dispatched without directly provided queue and the dispatching
-    policy can't be serialized, the computation is finalized during serialization call and
-    the policy is not saved in serialized data."""
+# Adds a small note note about serialization for extension estimators that are incremental.
+# The class docstrings should leave a placeholder '%incremental_serialization_note%' inside
+# their docstrings, which will be replaced by this note.
+def _add_inc_serialization_note(class_docstrings: str) -> str:
+    # In python versions >=3.13, leading whitespace in docstrings defined through
+    # static strings (but **not through other ways**) is automatically removed
+    # from the final docstrings, while in earlier versions is kept.
+    inc_serialization_note = """Note
+----
+Serializing instances of this class will trigger a forced finalization of calculations
+when the inputs are in a sycl queue or when using GPUs. Since (internal method)
+finalize_fit can't be dispatched without directly provided queue and the dispatching
+policy can't be serialized, the computation is finalized during serialization call and
+the policy is not saved in serialized data."""
+    if sys.version_info.major == 3 and sys.version_info.minor <= 12:
+        inc_serialization_note = re.sub(
+            r"^", " " * 4, inc_serialization_note, flags=re.MULTILINE
+        )
+    return class_docstrings.replace(
+        r"%incremental_serialization_note%", inc_serialization_note
+    )
 
 
 # This abstract class is meant to generate a clickable doc link for classses

--- a/sklearnex/_utils.py
+++ b/sklearnex/_utils.py
@@ -174,6 +174,7 @@ the policy is not saved in serialized data."""
         inc_serialization_note = re.sub(
             r"^", " " * 4, inc_serialization_note, flags=re.MULTILINE
         )
+        inc_serialization_note = inc_serialization_note.strip()
     return class_docstrings.replace(
         r"%incremental_serialization_note%", inc_serialization_note
     )

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -27,7 +27,11 @@ from onedal.basic_statistics import (
 
 from .._config import get_config
 from .._device_offload import dispatch
-from .._utils import ExtensionEstimator, PatchingConditionsChain, _inc_serialization_note
+from .._utils import (
+    ExtensionEstimator,
+    PatchingConditionsChain,
+    _add_inc_serialization_note,
+)
 
 if sklearn_check_version("1.2"):
     from sklearn.utils._param_validation import Interval, StrOptions
@@ -43,7 +47,7 @@ else:
 
 @control_n_jobs(decorated_methods=["partial_fit", "_onedal_finalize_fit"])
 class IncrementalBasicStatistics(ExtensionEstimator, BaseEstimator):
-    __doc__ = f"""
+    """
     Calculates basic statistics on the given data, allows for computation when the data are split into
     batches. The user can use ``partial_fit`` method to provide a single batch of data or use the ``fit`` method to provide
     the entire dataset.
@@ -104,12 +108,12 @@ class IncrementalBasicStatistics(ExtensionEstimator, BaseEstimator):
     ----
     Attribute exists only if corresponding result option has been provided.
 
-    {_inc_serialization_note}
-
     Note
     ----
     Names of attributes without the trailing underscore are
     supported currently but deprecated in 2025.1 and will be removed in 2026.0
+
+    %incremental_serialization_note%
 
     Examples
     --------
@@ -129,6 +133,8 @@ class IncrementalBasicStatistics(ExtensionEstimator, BaseEstimator):
     >>> incbs.max_
     np.array([3., 4.])
     """
+
+    __doc__ = _add_inc_serialization_note(__doc__)
 
     _onedal_incremental_basic_statistics = staticmethod(onedal_IncrementalBasicStatistics)
 

--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -27,7 +27,7 @@ from onedal.basic_statistics import (
 
 from .._config import get_config
 from .._device_offload import dispatch
-from .._utils import ExtensionEstimator, PatchingConditionsChain
+from .._utils import ExtensionEstimator, PatchingConditionsChain, _inc_serialization_note
 
 if sklearn_check_version("1.2"):
     from sklearn.utils._param_validation import Interval, StrOptions
@@ -43,7 +43,7 @@ else:
 
 @control_n_jobs(decorated_methods=["partial_fit", "_onedal_finalize_fit"])
 class IncrementalBasicStatistics(ExtensionEstimator, BaseEstimator):
-    """
+    __doc__ = f"""
     Calculates basic statistics on the given data, allows for computation when the data are split into
     batches. The user can use ``partial_fit`` method to provide a single batch of data or use the ``fit`` method to provide
     the entire dataset.
@@ -104,12 +104,7 @@ class IncrementalBasicStatistics(ExtensionEstimator, BaseEstimator):
     ----
     Attribute exists only if corresponding result option has been provided.
 
-    Note
-    ----
-    Serializing instances of this class will trigger a forced finalization of calculations.
-    Since finalize_fit can't be dispatched without directly provided queue
-    and the dispatching policy can't be serialized, the computation is finalized
-    during serialization call and the policy is not saved in serialized data.
+    {_inc_serialization_note}
 
     Note
     ----

--- a/sklearnex/covariance/incremental_covariance.py
+++ b/sklearnex/covariance/incremental_covariance.py
@@ -34,7 +34,12 @@ from sklearnex import config_context
 
 from .._config import get_config
 from .._device_offload import dispatch, wrap_output_data
-from .._utils import ExtensionEstimator, PatchingConditionsChain, register_hyperparameters
+from .._utils import (
+    ExtensionEstimator,
+    PatchingConditionsChain,
+    _inc_serialization_note,
+    register_hyperparameters,
+)
 from ..metrics import pairwise_distances
 from ..utils._array_api import get_namespace
 
@@ -49,7 +54,7 @@ else:
 
 @control_n_jobs(decorated_methods=["partial_fit", "fit", "_onedal_finalize_fit"])
 class IncrementalEmpiricalCovariance(ExtensionEstimator, BaseEstimator):
-    """
+    __doc__ = f"""
     Maximum likelihood covariance estimator that allows for the estimation when the data are split into
     batches. The user can use the ``partial_fit`` method to provide a single batch of data or use the ``fit`` method to provide
     the entire dataset.
@@ -93,12 +98,7 @@ class IncrementalEmpiricalCovariance(ExtensionEstimator, BaseEstimator):
     n_features_in_ : int
         Number of features seen during ``fit`` or ``partial_fit``.
 
-    Note
-    ----
-    Serializing instances of this class will trigger a forced finalization of calculations.
-    Since finalize_fit can't be dispatched without directly provided queue
-    and the dispatching policy can't be serialized, the computation is finalized
-    during serialization and the policy is not saved in serialized data.
+    {_inc_serialization_note}
 
     Examples
     --------

--- a/sklearnex/covariance/incremental_covariance.py
+++ b/sklearnex/covariance/incremental_covariance.py
@@ -37,7 +37,7 @@ from .._device_offload import dispatch, wrap_output_data
 from .._utils import (
     ExtensionEstimator,
     PatchingConditionsChain,
-    _inc_serialization_note,
+    _add_inc_serialization_note,
     register_hyperparameters,
 )
 from ..metrics import pairwise_distances
@@ -54,7 +54,7 @@ else:
 
 @control_n_jobs(decorated_methods=["partial_fit", "fit", "_onedal_finalize_fit"])
 class IncrementalEmpiricalCovariance(ExtensionEstimator, BaseEstimator):
-    __doc__ = f"""
+    """
     Maximum likelihood covariance estimator that allows for the estimation when the data are split into
     batches. The user can use the ``partial_fit`` method to provide a single batch of data or use the ``fit`` method to provide
     the entire dataset.
@@ -98,7 +98,7 @@ class IncrementalEmpiricalCovariance(ExtensionEstimator, BaseEstimator):
     n_features_in_ : int
         Number of features seen during ``fit`` or ``partial_fit``.
 
-    {_inc_serialization_note}
+    %incremental_serialization_note%
 
     Examples
     --------
@@ -118,6 +118,8 @@ class IncrementalEmpiricalCovariance(ExtensionEstimator, BaseEstimator):
     >>> inccov.location_
     np.array([2., 3.])
     """
+
+    __doc__ = _add_inc_serialization_note(__doc__)
 
     _onedal_incremental_covariance = staticmethod(onedal_IncrementalEmpiricalCovariance)
 

--- a/sklearnex/linear_model/incremental_linear.py
+++ b/sklearnex/linear_model/incremental_linear.py
@@ -44,7 +44,7 @@ from .._device_offload import dispatch, wrap_output_data
 from .._utils import (
     ExtensionEstimator,
     PatchingConditionsChain,
-    _inc_serialization_note,
+    _add_inc_serialization_note,
     register_hyperparameters,
 )
 
@@ -61,7 +61,7 @@ from .._utils import (
 class IncrementalLinearRegression(
     ExtensionEstimator, MultiOutputMixin, RegressorMixin, BaseEstimator
 ):
-    __doc__ = f"""
+    """
     Trains a linear regression model, allows for computation if the data are split into
     batches. The user can use the ``partial_fit`` method to provide a single batch of data or use the ``fit`` method to provide
     the entire dataset.
@@ -109,7 +109,7 @@ class IncrementalLinearRegression(
     n_features_in_ : int
         Number of features seen during ``fit`` or ``partial_fit``.
 
-    {_inc_serialization_note}
+    %incremental_serialization_note%
 
     Examples
     --------
@@ -130,6 +130,8 @@ class IncrementalLinearRegression(
     >>> inclr.intercept_
     np.array(0.)
     """
+
+    __doc__ = _add_inc_serialization_note(__doc__)
 
     _onedal_incremental_linear = staticmethod(onedal_IncrementalLinearRegression)
 

--- a/sklearnex/linear_model/incremental_linear.py
+++ b/sklearnex/linear_model/incremental_linear.py
@@ -41,7 +41,12 @@ else:
 from onedal.common.hyperparameters import get_hyperparameters
 
 from .._device_offload import dispatch, wrap_output_data
-from .._utils import ExtensionEstimator, PatchingConditionsChain, register_hyperparameters
+from .._utils import (
+    ExtensionEstimator,
+    PatchingConditionsChain,
+    _inc_serialization_note,
+    register_hyperparameters,
+)
 
 
 @register_hyperparameters(
@@ -56,7 +61,7 @@ from .._utils import ExtensionEstimator, PatchingConditionsChain, register_hyper
 class IncrementalLinearRegression(
     ExtensionEstimator, MultiOutputMixin, RegressorMixin, BaseEstimator
 ):
-    """
+    __doc__ = f"""
     Trains a linear regression model, allows for computation if the data are split into
     batches. The user can use the ``partial_fit`` method to provide a single batch of data or use the ``fit`` method to provide
     the entire dataset.
@@ -104,12 +109,7 @@ class IncrementalLinearRegression(
     n_features_in_ : int
         Number of features seen during ``fit`` or ``partial_fit``.
 
-    Note
-    ----
-    Serializing instances of this class will trigger a forced finalization of calculations.
-    Since finalize_fit can't be dispatched without directly provided queue
-    and the dispatching policy can't be serialized, the computation is finalized
-    during serialization call and the policy is not saved in serialized data.
+    {_inc_serialization_note}
 
     Examples
     --------

--- a/sklearnex/linear_model/incremental_ridge.py
+++ b/sklearnex/linear_model/incremental_ridge.py
@@ -32,7 +32,11 @@ if sklearn_check_version("1.2"):
 from onedal.linear_model import IncrementalRidge as onedal_IncrementalRidge
 
 from .._device_offload import dispatch, wrap_output_data
-from .._utils import ExtensionEstimator, PatchingConditionsChain, _inc_serialization_note
+from .._utils import (
+    ExtensionEstimator,
+    PatchingConditionsChain,
+    _add_inc_serialization_note,
+)
 
 if sklearn_check_version("1.6"):
     from sklearn.utils.validation import validate_data
@@ -46,7 +50,7 @@ else:
 class IncrementalRidge(
     ExtensionEstimator, MultiOutputMixin, RegressorMixin, BaseEstimator
 ):
-    __doc__ = f"""
+    """
     Incremental estimator for Ridge Regression.
     Allows to train Ridge Regression if data is splitted into batches.
 
@@ -99,8 +103,10 @@ class IncrementalRidge(
     batch_size_ : int
         Inferred batch size from ``batch_size``.
 
-    {_inc_serialization_note}
+    %incremental_serialization_note%
     """
+
+    __doc__ = _add_inc_serialization_note(__doc__)
 
     _onedal_incremental_ridge = staticmethod(onedal_IncrementalRidge)
 

--- a/sklearnex/linear_model/incremental_ridge.py
+++ b/sklearnex/linear_model/incremental_ridge.py
@@ -32,7 +32,7 @@ if sklearn_check_version("1.2"):
 from onedal.linear_model import IncrementalRidge as onedal_IncrementalRidge
 
 from .._device_offload import dispatch, wrap_output_data
-from .._utils import ExtensionEstimator, PatchingConditionsChain
+from .._utils import ExtensionEstimator, PatchingConditionsChain, _inc_serialization_note
 
 if sklearn_check_version("1.6"):
     from sklearn.utils.validation import validate_data
@@ -46,7 +46,7 @@ else:
 class IncrementalRidge(
     ExtensionEstimator, MultiOutputMixin, RegressorMixin, BaseEstimator
 ):
-    """
+    __doc__ = f"""
     Incremental estimator for Ridge Regression.
     Allows to train Ridge Regression if data is splitted into batches.
 
@@ -99,12 +99,7 @@ class IncrementalRidge(
     batch_size_ : int
         Inferred batch size from ``batch_size``.
 
-    Note
-    ----
-    Serializing instances of this class will trigger a forced finalization of calculations.
-    Since finalize_fit can't be dispatched without directly provided queue
-    and the dispatching policy can't be serialized, the computation is finalized
-    during serialization call and the policy is not saved in serialized data.
+    {_inc_serialization_note}
     """
 
     _onedal_incremental_ridge = staticmethod(onedal_IncrementalRidge)

--- a/sklearnex/preview/decomposition/incremental_pca.py
+++ b/sklearnex/preview/decomposition/incremental_pca.py
@@ -24,7 +24,11 @@ from onedal.decomposition import IncrementalPCA as onedal_IncrementalPCA
 
 from ..._config import get_config
 from ..._device_offload import dispatch, wrap_output_data
-from ..._utils import ExtensionEstimator, PatchingConditionsChain
+from ..._utils import (
+    ExtensionEstimator,
+    PatchingConditionsChain,
+    _add_inc_serialization_note,
+)
 
 if sklearn_check_version("1.6"):
     from sklearn.utils.validation import validate_data
@@ -237,17 +241,8 @@ class IncrementalPCA(ExtensionEstimator, _sklearn_IncrementalPCA):
             X,
         )
 
-    __doc__ = (
-        _sklearn_IncrementalPCA.__doc__
-        + """
-
-    Note
-    ----
-    Serializing instances of this class will trigger a forced finalization of calculations.
-    Since finalize_fit can't be dispatched without directly provided queue
-    and the dispatching policy can't be serialized, the computation is finalized
-    during serialization call and the policy is not saved in serialized data.
-    """
+    __doc__ = _add_inc_serialization_note(
+        _sklearn_IncrementalPCA.__doc__ + "\n" + r"%incremental_serialization_note%"
     )
     fit.__doc__ = _sklearn_IncrementalPCA.fit.__doc__
     fit_transform.__doc__ = _sklearn_IncrementalPCA.fit_transform.__doc__


### PR DESCRIPTION
## Description

The incremental algorithms all share a common note about what happens when serializing them. This PR moves that note to a common variable, and rewords it a bit along the way.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.