### PR TITLE
MAINT: Reuse docstring from sklearn classes instead of copy-pastying in extension estimators

### DIFF
--- a/sklearnex/basic_statistics/incremental_basic_statistics.py
+++ b/sklearnex/basic_statistics/incremental_basic_statistics.py
@@ -309,7 +309,7 @@ class IncrementalBasicStatistics(ExtensionEstimator, BaseEstimator):
 
         Returns
         -------
-        self : object
+        self : IncrementalBasicStatistics
             Returns the instance itself.
         """
         dispatch(
@@ -326,7 +326,7 @@ class IncrementalBasicStatistics(ExtensionEstimator, BaseEstimator):
         return self
 
     def fit(self, X, y=None, sample_weight=None):
-        """Calculate statistics of X using minibatches of size batch_size.
+        """Calculate statistics of X using minibatches of size ``batch_size``.
 
         Parameters
         ----------
@@ -342,7 +342,7 @@ class IncrementalBasicStatistics(ExtensionEstimator, BaseEstimator):
 
         Returns
         -------
-        self : object
+        self : IncrementalBasicStatistics
             Returns the instance itself.
         """
         dispatch(

--- a/sklearnex/covariance/incremental_covariance.py
+++ b/sklearnex/covariance/incremental_covariance.py
@@ -289,7 +289,7 @@ class IncrementalEmpiricalCovariance(ExtensionEstimator, BaseEstimator):
 
         Returns
         -------
-        self : object
+        self : IncrementalEmpiricalCovariance
             Returns the instance itself.
         """
         return dispatch(
@@ -305,7 +305,7 @@ class IncrementalEmpiricalCovariance(ExtensionEstimator, BaseEstimator):
 
     def fit(self, X, y=None):
         """
-        Fit the model with X, using minibatches of size batch_size.
+        Fit the model with X, using minibatches of size ``batch_size``.
 
         Parameters
         ----------
@@ -318,7 +318,7 @@ class IncrementalEmpiricalCovariance(ExtensionEstimator, BaseEstimator):
 
         Returns
         -------
-        self : object
+        self : IncrementalEmpiricalCovariance
             Returns the instance itself.
         """
 

--- a/sklearnex/linear_model/incremental_linear.py
+++ b/sklearnex/linear_model/incremental_linear.py
@@ -19,6 +19,7 @@ import warnings
 
 import numpy as np
 from sklearn.base import BaseEstimator, MultiOutputMixin, RegressorMixin
+from sklearn.linear_model import LinearRegression as _sklearn_LinearRegression
 from sklearn.metrics import r2_score
 from sklearn.utils import check_array, gen_batches
 from sklearn.utils.validation import check_is_fitted
@@ -361,7 +362,7 @@ class IncrementalLinearRegression(
 
         Returns
         -------
-        self : object
+        self : IncrementalLinearRegression
             Returns the instance itself.
         """
 
@@ -397,7 +398,7 @@ class IncrementalLinearRegression(
 
         Returns
         -------
-        self : object
+        self : IncrementalLinearRegression
             Returns the instance itself.
         """
 
@@ -415,22 +416,6 @@ class IncrementalLinearRegression(
 
     @wrap_output_data
     def predict(self, X, y=None):
-        """
-        Predict using the linear model.
-
-        Parameters
-        ----------
-        X : array-like or sparse matrix, shape (n_samples, n_features)
-            Samples.
-
-        y : Ignored
-            Not used, present for API consistency by convention.
-
-        Returns
-        -------
-        C : array, shape (n_samples, n_targets)
-            Returns predicted values.
-        """
         check_is_fitted(self)
         return dispatch(
             self,
@@ -444,46 +429,6 @@ class IncrementalLinearRegression(
 
     @wrap_output_data
     def score(self, X, y, sample_weight=None):
-        """
-        Return the coefficient of determination of the prediction.
-
-        The coefficient of determination :math:`R^2` is defined as
-        :math:`(1 - \\frac{u}{v})`, where :math:`u` is the residual
-        sum of squares ``((y_true - y_pred)** 2).sum()`` and :math:`v`
-        is the total sum of squares ``((y_true - y_true.mean()) ** 2).sum()``.
-        The best possible score is 1.0 and it can be negative (because the
-        model can be arbitrarily worse). A constant model that always predicts
-        the expected value of `y`, disregarding the input features, would get
-        a :math:`R^2` score of 0.0.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            Test samples. For some estimators this may be a precomputed
-            kernel matrix or a list of generic objects instead with shape
-            ``(n_samples, n_samples_fitted)``, where ``n_samples_fitted``
-            is the number of samples used in the fitting for the estimator.
-
-        y : array-like of shape (n_samples,) or (n_samples, n_outputs)
-            True values for `X`.
-
-        sample_weight : array-like of shape (n_samples,), default=None
-            Sample weights.
-
-        Returns
-        -------
-        score : float
-            :math:`R^2` of ``self.predict(X)`` w.r.t. `y`.
-
-        Notes
-        -----
-        The :math:`R^2` score used when calling ``score`` on a regressor uses
-        ``multioutput='uniform_average'`` from version 0.23 to keep consistent
-        with default value of :func:`~sklearn.metrics.r2_score`.
-        This influences the ``score`` method of all the multioutput
-        regressors (except for
-        :class:`~sklearn.multioutput.MultiOutputRegressor`).
-        """
         check_is_fitted(self)
         return dispatch(
             self,
@@ -496,3 +441,6 @@ class IncrementalLinearRegression(
             y,
             sample_weight=sample_weight,
         )
+
+    score.__doc__ = _sklearn_LinearRegression.score.__doc__
+    predict.__doc__ = _sklearn_LinearRegression.predict.__doc__

--- a/sklearnex/linear_model/incremental_ridge.py
+++ b/sklearnex/linear_model/incremental_ridge.py
@@ -19,6 +19,7 @@ import warnings
 
 import numpy as np
 from sklearn.base import BaseEstimator, MultiOutputMixin, RegressorMixin
+from sklearn.linear_model import Ridge as _sklearn_Ridge
 from sklearn.metrics import r2_score
 from sklearn.utils import gen_batches
 from sklearn.utils.validation import check_is_fitted, check_X_y
@@ -268,7 +269,7 @@ class IncrementalRidge(
 
         Returns
         -------
-        self : object
+        self : IncrementalRidge
             Returns the instance itself.
         """
 
@@ -287,7 +288,7 @@ class IncrementalRidge(
 
     def fit(self, X, y):
         """
-        Fit the model with X and y, using minibatches of size batch_size.
+        Fit the model with X and y, using minibatches of size ``batch_size``.
 
         Parameters
         ----------
@@ -304,7 +305,7 @@ class IncrementalRidge(
 
         Returns
         -------
-        self : object
+        self : IncrementalRidge
             Returns the instance itself.
         """
 
@@ -322,19 +323,6 @@ class IncrementalRidge(
 
     @wrap_output_data
     def predict(self, X, y=None):
-        """
-        Predict using the linear model.
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            Samples.
-
-        Returns
-        -------
-        array, shape (n_samples,) or (n_samples, n_targets)
-            Returns predicted values.
-        """
         check_is_fitted(
             self,
             msg=f"This {self.__class__.__name__} instance is not fitted yet. Call 'fit' with appropriate arguments before using this estimator.",
@@ -352,33 +340,6 @@ class IncrementalRidge(
 
     @wrap_output_data
     def score(self, X, y, sample_weight=None):
-        """
-        Return the coefficient of determination R^2 of the prediction.
-
-        The coefficient R^2 is defined as (1 - u/v), where u is the residual
-        sum of squares ((y_true - y_pred) ** 2).sum() and v is the total sum
-        of squares ((y_true - y_true.mean()) ** 2).sum().
-        The best possible score is 1.0 and it can be negative (because the
-        model can be arbitrarily worse). A constant model that always
-        predicts the expected value of y, disregarding the input features,
-        would get a R^2 score of 0.0.
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            Test samples.
-
-        y : array-like of shape (n_samples,) or (n_samples, n_targets)
-            True values for X.
-
-        sample_weight : array-like of shape (n_samples,), default=None
-            Sample weights.
-
-        Returns
-        -------
-        score : float
-            R^2 of self.predict(X) wrt. y.
-        """
         check_is_fitted(
             self,
             msg=f"This {self.__class__.__name__} instance is not fitted yet. Call 'fit' with appropriate arguments before using this estimator.",
@@ -395,6 +356,9 @@ class IncrementalRidge(
             y,
             sample_weight=sample_weight,
         )
+
+    score.__doc__ = _sklearn_Ridge.score.__doc__
+    predict.__doc__ = _sklearn_Ridge.predict.__doc__
 
     @property
     def coef_(self):


### PR DESCRIPTION
## Description

Some extension estimators take docstrings from stock sklearn for their methods, but they do so by copy-pastying the whole docstring into the code, which is not a good practice as it can get out of synch. This PR modifies those to take the docstrings from sklearn at runtime instead, avoiding duplication.

Along the way, it also fixes the return types of fit/partial_fit to point to the class docs.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
