### PR TITLE
FIX: Fix incorrect scale of base_score being used for XGB regression objectives

### DIFF
--- a/src/gbt_convertors.pyx
+++ b/src/gbt_convertors.pyx
@@ -450,6 +450,8 @@ def get_gbt_model_from_xgboost(booster: Any, xgb_config=None) -> Any:
     # it needs to be converted to the link scale.
     if objective_fun in ["count:poisson", "reg:gamma", "reg:tweedie", "survival:aft"]:
         base_score = float(np.log(base_score))
+    elif objective_fun == "reg:logistic":
+        base_score = float(np.log(base_score / (1 - base_score)))
     elif objective_fun.startswith("rank"):
         raise TypeError("Ranking objectives are not supported.")
 

--- a/src/gbt_convertors.pyx
+++ b/src/gbt_convertors.pyx
@@ -444,6 +444,15 @@ def get_gbt_model_from_xgboost(booster: Any, xgb_config=None) -> Any:
 
     is_regression = False
     objective_fun = xgb_config["learner"]["learner_train_param"]["objective"]
+
+    # Note: the base score from XGBoost is in the response scale, but the predictions
+    # are calculated in the link scale, so when there is a non-identity link function,
+    # it needs to be converted to the link scale.
+    if objective_fun in ["count:poisson", "reg:gamma", "reg:tweedie", "survival:aft"]:
+        base_score = float(np.log(base_score))
+    elif objective_fun.startswith("rank"):
+        raise TypeError("Ranking objectives are not supported.")
+
     if n_classes > 2:
         if objective_fun not in ["multi:softprob", "multi:softmax"]:
             raise TypeError(
@@ -463,9 +472,7 @@ def get_gbt_model_from_xgboost(booster: Any, xgb_config=None) -> Any:
                 "XGBoost returns raw class scores when calling pred_proba()\n"
                 "whilst scikit-learn-intelex always uses binary:logistic\n"
             )
-            if base_score != 0.5:
-                warn("objective='binary:logitraw' ignores base_score, fixing base_score to 0.5")
-                base_score = 0.5
+            base_score = float(1 / (1 + np.exp(-base_score)))
     else:
         is_regression = True
 


### PR DESCRIPTION
## Description

This PR fixes an issue with the daal4py model builders using the intercepts from XGBoost models incorrectly when it comes to regression models that have a link function, such as Poisson or Gamma.

Compared to the other GBT libraries supported by model builders, XGBoost has a 'base_score' field which is in the scale of the response variable (i.e. inverse link function is applied to it), but the model builders assume that the intercept is on the link scale, so predictions will be wrong when there is a non-identity link function.

Along the way, it also fixes an issue of the intercept not being applied to objective `binary:logitraw` due to this same issue, which was previously being approach through workarounds that remove the intercept.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

Not applicable.
