### PR TITLE
Fix for misuse of sklearnex verbosity

### DIFF
--- a/onedal/common/_backend.py
+++ b/onedal/common/_backend.py
@@ -25,11 +25,6 @@ logger = logging.getLogger("sklearnex")
 # define types for backend functions: default, dpc, spmd
 BackendType = Literal["none", "host", "dpc", "spmd"]
 
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-)
-
 
 class BackendManager:
     def __init__(self, backend_module):


### PR DESCRIPTION
## Description

Fix for wrong verbosity setting introduced in https://github.com/uxlfoundation/scikit-learn-intelex/pull/2168.

Example of wrong verbosity behaviour:
```python
from sklearnex.svm import SVC
from sklearn.datasets import make_classification

svc = SVC()
svc.fit(*make_classification())
```

```
DEBUG:sklearnex: Assigned method '<dpc_backend>.svm.regression.train' to 'SVR.train'
2025-03-27 12:21:02,448 - sklearnex - DEBUG - Assigned method '<dpc_backend>.svm.regression.train' to 'SVR.train'
DEBUG:sklearnex: Assigned method '<dpc_backend>.svm.regression.infer' to 'SVR.infer'
2025-03-27 12:21:02,449 - sklearnex - DEBUG - Assigned method '<dpc_backend>.svm.regression.infer' to 'SVR.infer'
DEBUG:sklearnex: Assigned method '<dpc_backend>.svm.regression.model' to 'SVR.model'
2025-03-27 12:21:02,449 - sklearnex - DEBUG - Assigned method '<dpc_backend>.svm.regression.model' to 'SVR.model'
DEBUG:sklearnex: Assigned method '<dpc_backend>.svm.classification.train' to 'SVC.train'
2025-03-27 12:21:02,449 - sklearnex - DEBUG - Assigned method '<dpc_backend>.svm.classification.train' to 'SVC.train'
DEBUG:sklearnex: Assigned method '<dpc_backend>.svm.classification.infer' to 'SVC.infer'
2025-03-27 12:21:02,449 - sklearnex - DEBUG - Assigned method '<dpc_backend>.svm.classification.infer' to 'SVC.infer'
DEBUG:sklearnex: Assigned method '<dpc_backend>.svm.classification.model' to 'SVC.model'
2025-03-27 12:21:02,449 - sklearnex - DEBUG - Assigned method '<dpc_backend>.svm.classification.model' to 'SVC.model'
DEBUG:sklearnex: Assigned method '<dpc_backend>.svm.nu_regression.train' to 'NuSVR.train'
2025-03-27 12:21:02,449 - sklearnex - DEBUG - Assigned method '<dpc_backend>.svm.nu_regression.train' to 'NuSVR.train'
DEBUG:sklearnex: Assigned method '<dpc_backend>.svm.nu_regression.infer' to 'NuSVR.infer'
2025-03-27 12:21:02,449 - sklearnex - DEBUG - Assigned method '<dpc_backend>.svm.nu_regression.infer' to 'NuSVR.infer'
DEBUG:sklearnex: Assigned method '<dpc_backend>.svm.nu_regression.model' to 'NuSVR.model'
2025-03-27 12:21:02,449 - sklearnex - DEBUG - Assigned method '<dpc_backend>.svm.nu_regression.model' to 'NuSVR.model'
DEBUG:sklearnex: Assigned method '<dpc_backend>.svm.nu_classification.train' to 'NuSVC.train'
2025-03-27 12:21:02,449 - sklearnex - DEBUG - Assigned method '<dpc_backend>.svm.nu_classification.train' to 'NuSVC.train'
DEBUG:sklearnex: Assigned method '<dpc_backend>.svm.nu_classification.infer' to 'NuSVC.infer'
2025-03-27 12:21:02,449 - sklearnex - DEBUG - Assigned method '<dpc_backend>.svm.nu_classification.infer' to 'NuSVC.infer'
DEBUG:sklearnex: Assigned method '<dpc_backend>.svm.nu_classification.model' to 'NuSVC.model'
2025-03-27 12:21:02,449 - sklearnex - DEBUG - Assigned method '<dpc_backend>.svm.nu_classification.model' to 'NuSVC.model'
INFO:sklearnex: sklearn.svm.SVC.fit: running accelerated version on CPU
2025-03-27 12:21:02,471 - sklearnex - INFO - sklearn.svm.SVC.fit: running accelerated version on CPU
/miniconda3/envs/build/lib/python3.12/site-packages/sklearn/utils/deprecation.py:151: FutureWarning: 'force_all_finite' was renamed to 'ensure_all_finite' in 1.6 and will be removed in 1.8.
  warnings.warn(
/miniconda3/envs/build/lib/python3.12/site-packages/sklearn/utils/deprecation.py:151: FutureWarning: 'force_all_finite' was renamed to 'ensure_all_finite' in 1.6 and will be removed in 1.8.
  warnings.warn(
/miniconda3/envs/build/lib/python3.12/site-packages/sklearn/utils/deprecation.py:151: FutureWarning: 'force_all_finite' was renamed to 'ensure_all_finite' in 1.6 and will be removed in 1.8.
  warnings.warn(
DEBUG:sklearnex: Dispatching function 'svm.classification.train' with policy <onedal._onedal_py_dpc.host_policy object at 0x7fa41cb87a70> to Backend(<module 'onedal._onedal_py_dpc' from /miniconda3/envs/build/lib/python3.12/site-packages/onedal/_onedal_py_dpc.cpython-312-x86_64-linux-gnu.so'>, is_dpc=True, is_spmd=False)
2025-03-27 12:21:02,472 - sklearnex - DEBUG - Dispatching function 'svm.classification.train' with policy <onedal._onedal_py_dpc.host_policy object at 0x7fa41cb87a70> to Backend(<module 'onedal._onedal_py_dpc' from '/miniconda3/envs/build/lib/python3.12/site-packages/onedal/_onedal_py_dpc.cpython-312-x86_64-linux-gnu.so'>, is_dpc=True, is_spmd=False)
```

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

N/A.