### PR TITLE
ENH: Don't cythonize pure-python GBT conversion code

### DIFF
--- a/daal4py/mb/gbt_convertors.py
+++ b/daal4py/mb/gbt_convertors.py
@@ -22,6 +22,8 @@ from warnings import warn
 
 import numpy as np
 
+from .. import gbt_clf_model_builder, gbt_reg_model_builder
+
 
 class CatBoostNode:
     def __init__(
@@ -37,6 +39,7 @@ class CatBoostNode:
         self.right = right
         self.left = left
         self.cover = cover
+
 
 class CatBoostModelData:
     """Wrapper around the CatBoost model dump for easier access to properties"""

--- a/daal4py/mb/model_builders.py
+++ b/daal4py/mb/model_builders.py
@@ -32,6 +32,15 @@ except (ImportError, ModuleNotFoundError):
 
 from sklearn.utils.metaestimators import available_if
 
+from .gbt_convertors import (
+    get_catboost_params,
+    get_gbt_model_from_catboost,
+    get_gbt_model_from_lightgbm,
+    get_gbt_model_from_xgboost,
+    get_lightgbm_params,
+    get_xgboost_params,
+)
+
 
 def parse_dtype(dt):
     if dt == np.double:
@@ -85,18 +94,18 @@ class GBTDAALBaseModel:
         self.n_features_in_ = len(params["features_info"]["float_features"])
 
     def _convert_model_from_lightgbm(self, booster):
-        lgbm_params = d4p.get_lightgbm_params(booster)
-        self.daal_model_ = d4p.get_gbt_model_from_lightgbm(booster, lgbm_params)
+        lgbm_params = get_lightgbm_params(booster)
+        self.daal_model_ = get_gbt_model_from_lightgbm(booster, lgbm_params)
         self._get_params_from_lightgbm(lgbm_params)
 
     def _convert_model_from_xgboost(self, booster):
-        xgb_params = d4p.get_xgboost_params(booster)
-        self.daal_model_ = d4p.get_gbt_model_from_xgboost(booster, xgb_params)
+        xgb_params = get_xgboost_params(booster)
+        self.daal_model_ = get_gbt_model_from_xgboost(booster, xgb_params)
         self._get_params_from_xgboost(xgb_params)
 
     def _convert_model_from_catboost(self, booster):
-        catboost_params = d4p.get_catboost_params(booster)
-        self.daal_model_ = d4p.get_gbt_model_from_catboost(booster)
+        catboost_params = get_catboost_params(booster)
+        self.daal_model_ = get_gbt_model_from_catboost(booster)
         self._get_params_from_catboost(catboost_params)
 
     def _convert_model(self, model):

--- a/generator/gen_daal4py.py
+++ b/generator/gen_daal4py.py
@@ -1255,8 +1255,6 @@ def gen_daal4py(dalroot, outdir, version, warn_all=False, no_dist=False, no_stre
     ):
         with open(jp("src", "gbt_model_builder.pyx"), "r") as f:
             pyx_gbt_model_builder = f.read()
-        with open(jp("src", "gbt_convertors.pyx"), "r") as f:
-            pyx_gbt_generators = f.read()
     if (
         "algorithms::logistic_regression" in iface.namespace_dict
         and "ModelBuilder"

--- a/tests/test_model_builders.py
+++ b/tests/test_model_builders.py
@@ -32,6 +32,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 
 import daal4py as d4p
+from daal4py.mb import gbt_convertors
 from daal4py.sklearn._utils import daal_check_version
 
 try:
@@ -920,18 +921,18 @@ class ModelBuilderTreeView(unittest.TestCase):
                 ]
 
         mock = MockBooster()
-        result = d4p.TreeList.from_xgb_booster(mock, max_trees=0)
+        result = gbt_convertors.TreeList.from_xgb_booster(mock, max_trees=0)
         self.assertEqual(len(result), 2)
 
         tree0 = result[0]
-        self.assertIsInstance(tree0, d4p.TreeView)
+        self.assertIsInstance(tree0, gbt_convertors.TreeView)
         self.assertFalse(tree0.is_leaf)
         with self.assertRaises(ValueError):
             tree0.cover
         with self.assertRaises(ValueError):
             tree0.value
 
-        self.assertIsInstance(tree0.root_node, d4p.Node)
+        self.assertIsInstance(tree0.root_node, gbt_convertors.Node)
 
         self.assertEqual(tree0.root_node.cover, 4)
         self.assertEqual(tree0.root_node.left_child.cover, 6)
@@ -965,7 +966,7 @@ class ModelBuilderTreeView(unittest.TestCase):
         self.assertIsNone(tree0.root_node.right_child.right_child)
 
         tree1 = result[1]
-        self.assertIsInstance(tree1, d4p.TreeView)
+        self.assertIsInstance(tree1, gbt_convertors.TreeView)
         self.assertTrue(tree1.is_leaf)
         self.assertEqual(tree1.n_nodes, 1)
         self.assertEqual(tree1.cover, 42)


### PR DESCRIPTION
## Description

Currently, there is a .pyx file under `src/` containing the code for the model builders from xgb/lgb/cb. This code is written in pure python without using any cython types or functions, hence it doesn't see any speed ups from being compiled through cython. Moreover, since the code deals with python objects like strings, passing it through cython might actually cause slight slowdowns.

This PR moves the code to pure-python .py files. Benefits:
* Reduced compilation times.
* Better error traces.
* Easier to modify.

As a comparison, I timed a model conversion from XGB from the model fitted on the bosch dataset from the regular config in the benchmarks using the jupyter 'timeit' tool.
* Before (current main): 47.7 ms ± 2 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
* After (this PR): 45.2 ms ± 1.2 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

So as can be seen, there is no performance degradation from this move.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
