### PR TITLE
ci: fix Jupyter CI job fail

### DIFF
--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -25,7 +25,7 @@ schedules:
 variables:
   COVERITY_TOOL_HOME: $(Agent.BuildDirectory)/cov-analysis
   DESCRIPTION: Nightly
-  python.version: '3.10'
+  python.version: '3.12'
   PYTHON: 'python'
   ARGS: '1'
   SELECTED_TESTS: 'all'


### PR DESCRIPTION
## Description

Fixes nightly CI jupyter fail due to requirements-doc.txt ipython version clashing with outdated python version specification.

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
