### PR TITLE
[bugfix] repair "releases" azp pipeline

### DIFF
--- a/.ci/pipeline/release.yml
+++ b/.ci/pipeline/release.yml
@@ -14,6 +14,11 @@
 # limitations under the License.
 #===============================================================================
 
+pr:
+  branches:
+    include:
+    - main
+
 variables:
   DESCRIPTION: ReleaseTesting
 

--- a/.ci/pipeline/release.yml
+++ b/.ci/pipeline/release.yml
@@ -22,6 +22,7 @@ jobs:
   steps:
   - bash: python .ci/scripts/gen_release_jobs.py
     name: MatrixGen
+
 - job: ReleasePyPi
   dependsOn: GeneratorPyPi
   strategy:
@@ -43,10 +44,12 @@ jobs:
   - script: |
       bash .ci/scripts/run_sklearn_tests.sh
     displayName: 'Sklearn testing'
+
 - job: GeneratorConda
   steps:
   - bash: python .ci/scripts/gen_release_jobs.py --channels conda-forge
     name: MatrixGen
+
 - job: ReleaseConda
   dependsOn: GeneratorConda
   strategy:
@@ -62,11 +65,6 @@ jobs:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     condition: eq( variables['Agent.OS'], 'Windows_NT' )
     displayName: Add conda to PATH
-  - script: |
-      echo "##vso[task.prependpath]$CONDA/bin"
-      sudo chown -R $USER $CONDA
-    condition: eq( variables['Agent.OS'], 'Darwin')
-    displayName: Add sudo access
   - script: |
       conda config --append channels conda-forge
       conda config --remove channels defaults

--- a/.ci/pipeline/release.yml
+++ b/.ci/pipeline/release.yml
@@ -58,7 +58,7 @@ jobs:
 - job: ReleaseConda
   dependsOn: GeneratorConda
   strategy:
-    maxParallel: 5
+    maxParallel: 3
     matrix: $[ dependencies.GeneratorConda.outputs['MatrixGen.legs'] ]
   pool:
     vmImage: $(imageName)

--- a/.ci/scripts/gen_release_jobs.py
+++ b/.ci/scripts/gen_release_jobs.py
@@ -36,7 +36,7 @@ print(CHANNELS)
 
 def generate_python_versions(file="README.md"):
     """Attempt to centralize the supported versions in the right location: the README.
-    Take it from a badge which lists the supported versions."
+    Take it from a badge which lists the supported versions."""
     regex = r"(?<=\[python version\]\(https://img.shields.io/badge/python-).*(?=-blue\)\])"
     sep = "%20%7C%20"
     pydefaults = ["3.9", "3.10", "3.11"]

--- a/.ci/scripts/gen_release_jobs.py
+++ b/.ci/scripts/gen_release_jobs.py
@@ -16,33 +16,61 @@
 # ==============================================================================
 
 import argparse
+import os.path
 import sys
+import re
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--channels", nargs="+", default=["pypi"])
 args = parser.parse_args()
 
 CHANNELS = args.channels
-PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
 # image versions are pinned to exact number instead of "latest"
 # to avoid unexpected failures when images are updated
-SYSTEMS = ["ubuntu-22.04", "windows-2022"]
 ACTIVATE = {
-    "ubuntu-latest": "conda activate",
-    "windows-latest": "call activate",
+    "ubuntu": "conda activate",
+    "windows": "call activate",
 }
 
 print(CHANNELS)
 
+def generate_python_versions(file="README.md"):
+    """Attempt to centralize the supported versions in the right location: the README.
+    Take it from a badge which lists the supported versions."
+    regex = r"(?<=\[python version\]\(https://img.shields.io/badge/python-).*(?=-blue\)\])"
+    sep = "%20%7C%20"
+    pydefaults = ["3.9", "3.10", "3.11"]
+    if os.path.isfile(file):
+        with open(file, "r") as f:
+            pydefaults = re.findall(regex, f.read())[0].split(sep)
+    return pydefaults
+
+PYTHON_VERSIONS = generate_python_versions()
+
+def collect_azp_CI_OS_images(file=".ci/pipeline/ci.yml"):
+    """Attempt to centralize the supported version from the azp CI pipeline, which
+    represents the currently tested versions in Azure Pipelines."""
+    regex = r"(?<=vmImage: ').*(?=')"
+    sysdefaults = ["ubuntu-22.04", "windows-2022"]
+    if os.path.isfile(file):
+        with open(file, "r") as f:
+            # find unique values with set
+            sysdefaults = list(set(re.findall(regex, f.read())))
+    return sysdefaults
+
+OS_VERSIONS = collect_azp_CI_OS_images()
+
+
 res_enum = {}
 for channel in CHANNELS:
     for python_version in PYTHON_VERSIONS:
-        for os in SYSTEMS:
+        for vmOS in OS_VERSIONS:
             res_key = channel + " - " + "python" + python_version + " - " + os
             res_enum[res_key] = {}
             res_enum[res_key]["python.version"] = python_version
-            res_enum[res_key]["imageName"] = os
-            res_enum[res_key]["conda.activate"] = ACTIVATE[os]
+            res_enum[res_key]["imageName"] = vmOS
+            # collect only the OS name, not version via split
+            res_enum[res_key]["conda.activate"] = ACTIVATE[vmOS.split("-")[0]]
             res_enum[res_key]["conda.channel"] = channel
 
 sys.stderr.write("##vso[task.setVariable variable=legs;isOutput=true]{}".format(res_enum))

--- a/.ci/scripts/gen_release_jobs.py
+++ b/.ci/scripts/gen_release_jobs.py
@@ -71,7 +71,7 @@ res_enum = {}
 for channel in CHANNELS:
     for python_version in PYTHON_VERSIONS:
         for vmOS in OS_VERSIONS:
-            res_key = channel + " - " + "python" + python_version + " - " + os
+            res_key = channel + " - " + "python" + python_version + " - " + vmOS
             res_enum[res_key] = {}
             res_enum[res_key]["python.version"] = python_version
             res_enum[res_key]["imageName"] = vmOS

--- a/.ci/scripts/gen_release_jobs.py
+++ b/.ci/scripts/gen_release_jobs.py
@@ -16,7 +16,7 @@
 # ==============================================================================
 
 import argparse
-import os.path
+import os
 import sys
 import re
 
@@ -47,7 +47,7 @@ def generate_python_versions(file="README.md"):
 
 PYTHON_VERSIONS = generate_python_versions()
 
-def collect_azp_CI_OS_images(file=".ci/pipeline/ci.yml"):
+def collect_azp_CI_OS_images(file=f".ci{os.sep}pipeline{os.sep}ci.yml"):
     """Attempt to centralize the supported version from the azp CI pipeline, which
     represents the currently tested versions in Azure Pipelines."""
     regex = r"(?<=vmImage: ').*(?=')"

--- a/.ci/scripts/gen_release_jobs.py
+++ b/.ci/scripts/gen_release_jobs.py
@@ -17,8 +17,8 @@
 
 import argparse
 import os
-import sys
 import re
+import sys
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--channels", nargs="+", default=["pypi"])
@@ -34,10 +34,13 @@ ACTIVATE = {
 
 print(CHANNELS)
 
+
 def generate_python_versions(file="README.md"):
     """Attempt to centralize the supported versions in the right location: the README.
     Take it from a badge which lists the supported versions."""
-    regex = r"(?<=\[python version\]\(https://img.shields.io/badge/python-).*(?=-blue\)\])"
+    regex = (
+        r"(?<=\[python version\]\(https://img.shields.io/badge/python-).*(?=-blue\)\])"
+    )
     sep = "%20%7C%20"
     pydefaults = ["3.9", "3.10", "3.11"]
     if os.path.isfile(file):
@@ -45,7 +48,9 @@ def generate_python_versions(file="README.md"):
             pydefaults = re.findall(regex, f.read())[0].split(sep)
     return pydefaults
 
+
 PYTHON_VERSIONS = generate_python_versions()
+
 
 def collect_azp_CI_OS_images(file=f".ci{os.sep}pipeline{os.sep}ci.yml"):
     """Attempt to centralize the supported version from the azp CI pipeline, which
@@ -57,6 +62,7 @@ def collect_azp_CI_OS_images(file=f".ci{os.sep}pipeline{os.sep}ci.yml"):
             # find unique values with set
             sysdefaults = list(set(re.findall(regex, f.read())))
     return sysdefaults
+
 
 OS_VERSIONS = collect_azp_CI_OS_images()
 


### PR DESCRIPTION
## Description

Fix an issue related to the OS, which was not being correctly taken from the ```ACTIVATE``` dict in gen_release_jobs.py.  

Add some maintenance reductions by extracting OS and Python versions from the CI.yml pipeline and README respectively using regex.

Remove old Mac related code which is never run, make the yaml easier to read with proper job separations.

Since we have reduced the number of conda channels that need to be checked, the maxparallel value is reduced from 5 to 3 in order to limit concurrent resource usage (same number of channels must be checked for pip vs conda, and pip uses 3).

No performance benchmarks necessary.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
