### PR TITLE
FIX: Fix incorrect logic for detecting intel compilers in setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -263,14 +263,21 @@ def get_build_options():
     # FIXME it is a wrong place for this dependency
     if not no_dist:
         include_dir_plat.append(mpi_root + "/include")
-    using_intel = os.environ.get("cc", "") in [
-        "icc",
-        "icpc",
-        "icl",
-        "dpcpp",
-        "icx",
-        "icpx",
-    ]
+
+    using_intel = any(
+        [
+            intel_exec in os.environ.get("CXX", "")
+            for intel_exec in [
+                "icc",
+                "icpc",
+                "icl",
+                "dpcpp",
+                "icx",
+                "icpx",
+            ]
+        ]
+    )
+
     eca = [
         "-DPY_ARRAY_UNIQUE_SYMBOL=daal4py_array_API",
         '-DD4P_VERSION="' + sklearnex_version + '"',


### PR DESCRIPTION
## Description

The `setup.py` file tries to identify when it is invoked with an intel compiler in order to set those warnings.

It does so by comparing env. variable "cc" against a list of names that intel compiler executables can take, but this is incorrect:
* `cc` is an executable or alias, not an environment variable.
* Environment variable is `CC`, and takes precedence over `cc`. But for C++ which is what the setup uses, the env. variable is `CXX`.
* It looks for exact matches, but the variable would still be valid if pointing to a full .exe file for example, or setting options directly to the compiler (e.g. `CXX="icpx -fsycl"`), or using it together with another program (e.g. `CXX="ccache icpx"`).

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
