### PR TITLE
FIX: Fix unpropagated `I_MPI_ROOT` as replacement for `MPIROOT`.

### DIFF
--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -45,6 +45,7 @@ def custom_build_cmake_clib(
     cxx=None,
     onedal_major_binary_version=1,
     no_dist=True,
+    mpi_root=None,
     use_parameters_lib=True,
     use_abs_rpath=False,
     use_gcov=False,
@@ -80,7 +81,6 @@ def custom_build_cmake_clib(
     logger.info(f"Build DPCPP SPMD functionality: {str(build_distribute)}")
 
     if build_distribute:
-        mpi_root = os.environ["MPIROOT"]
         MPI_INCDIRS = jp(mpi_root, "include")
         MPI_LIBDIRS = jp(mpi_root, "lib")
         MPI_LIBNAME = getattr(os.environ, "MPI_LIBNAME", None)

--- a/setup.py
+++ b/setup.py
@@ -437,6 +437,7 @@ class onedal_build:
             iface=iface,
             cxx=cxx,
             onedal_major_binary_version=ONEDAL_MAJOR_BINARY_VERSION,
+            mpi_root=mpi_root,
             no_dist=no_dist,
             use_parameters_lib=use_parameters_lib,
             use_abs_rpath=USE_ABS_RPATH,


### PR DESCRIPTION
## Description

A previous PR introduced the option of taking the path `MPIROOT` from env. variable `I_MPI_ROOT` when the former is not set but the latter is, but it did so only for the daal4py part, so it would currently generate an error if trying to build the whole package (including onedal extension) under  that setup.

This PR fixes the issue by propagating the variable to the CMake part.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
