### PR TITLE
FIX: Respect user-supplied `$CXX`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -215,7 +215,9 @@ without reinstalling the package after a small change.
    python setup.py build
    ```
 
-**Note:** the `setup.py` file will accept an optional argument `--abs-rpath` on linux (for all of `build`/`install`/`develop`/etc.) which will make it add the absolute path to oneDAL's shared objects (.so files) to the rpath of the scikit-learn-intelex extension's shared object files in order to load them automatically. This is not necessary when installing from pip or conda, but can be helpful for development purposes when using a from-source build of oneDAL that resides in a custom folder, as it won't assume that oneDAL's files will be found under default system paths. Example:
+**Note1:** the `daal4py` extension module which is built through `build_ext` does not use any kind of build caching for incremental compilation. For development purposes, one might want to use it together with `ccache`, for example by setting `export CXX="ccache icpx"`.
+
+**Note2:** the `setup.py` file will accept an optional argument `--abs-rpath` on linux (for all of `build`/`install`/`develop`/etc.) which will make it add the absolute path to oneDAL's shared objects (.so files) to the rpath of the scikit-learn-intelex extension's shared object files in order to load them automatically. This is not necessary when installing from pip or conda, but can be helpful for development purposes when using a from-source build of oneDAL that resides in a custom folder, as it won't assume that oneDAL's files will be found under default system paths. Example:
 
 ```shell
 python setup.py build_ext --inplace --force --abs-rpath

--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -42,7 +42,6 @@ elif sys.platform in ["win32", "cygwin"]:
 
 def custom_build_cmake_clib(
     iface,
-    cxx=None,
     onedal_major_binary_version=1,
     no_dist=True,
     use_parameters_lib=True,
@@ -67,13 +66,16 @@ def custom_build_cmake_clib(
     python_library_dir = win_python_path_lib if IS_WIN else get_config_var("LIBDIR")
     numpy_include = np.get_include()
 
+    cxx = os.getenv("CXX")
     if iface in ["dpc", "spmd_dpc"]:
-        if IS_WIN:
-            cxx = "icx"
-        else:
-            cxx = "icpx"
-    elif cxx is None:
-        raise RuntimeError("CXX compiler shall be specified")
+        default_dpc_compiler = "icx" if IS_WIN else "icpx"
+        if not cxx:
+            cxx = default_dpc_compiler
+        elif not (default_dpc_compiler in cxx):
+            logger.warning(
+                "Trying to build DPC module with a potentially non-DPC-capable compiler. Will forcefully change compiler to ICX."
+            )
+            cxx = default_dpc_compiler
 
     build_distribute = iface == "spmd_dpc" and not no_dist and IS_LIN
 
@@ -101,12 +103,17 @@ def custom_build_cmake_clib(
     use_parameters_arg = "yes" if use_parameters_lib else "no"
     logger.info(f"Build using parameters library: {use_parameters_arg}")
 
+    # Note: this uses env. variable 'CXX' instead of option 'CMAKE_CXX_COMPILER',
+    # in order to propagate both potential user-passed arguments and flags, such as:
+    #     CXX="ccache icpx"
+    #     CXX="icpx -O0"
+    if cxx:
+        os.environ["CXX"] = cxx
     cmake_args = [
         "cmake",
         cmake_generator,
         "-S" + builder_directory,
         "-B" + abs_build_temp_path,
-        "-DCMAKE_CXX_COMPILER=" + cxx,
         "-DCMAKE_INSTALL_PREFIX=" + install_directory,
         "-DCMAKE_PREFIX_PATH=" + install_directory,
         "-DIFACE=" + iface,

--- a/setup.py
+++ b/setup.py
@@ -432,10 +432,8 @@ class onedal_build:
         elif n_threads is True:
             n_threads = os.cpu_count() or 1
 
-        cxx = os.getenv("CXX", "cl" if IS_WIN else "g++")
         build_onedal = lambda iface: build_backend.custom_build_cmake_clib(
             iface=iface,
-            cxx=cxx,
             onedal_major_binary_version=ONEDAL_MAJOR_BINARY_VERSION,
             no_dist=no_dist,
             use_parameters_lib=use_parameters_lib,


### PR DESCRIPTION
## Description

Currently, the logic in the setup script propagates build-related environment variables correctly for the `daal4py` module which is built through `build_ext`, but it overrides those for the `onedal` module which is built through cmake.

Similar to https://github.com/uxlfoundation/scikit-learn-intelex/pull/2397 , it uses a flawed logic that checks for exact string matches in order to determine if it's using ICX, which would break for example if one tries something like the following:
```
export CXX="icpx -Wl,-rpath,..."
export CXX="ccache icpx"
```

This PR fixes it so that it doesn't override user-supplied compiler commands when not strictly needed.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
