### PR TITLE
ENH: Add public-facing properties to model builder class to query type of model

### DIFF
--- a/daal4py/mb/model_builders.py
+++ b/daal4py/mb/model_builders.py
@@ -386,6 +386,16 @@ class GBTDAALModel(GBTDAALBaseModel):
                 X, fptype, "computeClassLabels", pred_contribs, pred_interactions
             )
 
+    @property
+    def is_classifier_(self) -> bool:
+        """Whether this is a classification model"""
+        return not self._is_regression
+
+    @property
+    def is_regressor_(self) -> bool:
+        """Whether this is a regression model"""
+        return self._is_regression
+
     def _check_proba(self):
         return not self._is_regression
 


### PR DESCRIPTION
## Description

This PR adds user-facing getters for properties that would allow to check whether a daal4py object created through model builders is of regression or classification type.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
