### PR TITLE
FIX: Fix docs about enums listing incorrect acceptable values

### DIFF
--- a/generator/wrapper_gen.py
+++ b/generator/wrapper_gen.py
@@ -1597,7 +1597,19 @@ class wrapper_gen(object):
             t = jenv.from_string(algo_wrapper_template)
             cpp_end += t.render(**jparams) + "\n"
 
+        for k, v in self.get_adhoc_doc_replacements().items():
+            pyx_end = pyx_end.replace(k, v)
+
         return (cpp_map, cpp_begin, cpp_end, pyx_map, pyx_begin, pyx_end, typesstr)
+
+    def get_adhoc_doc_replacements(self) -> dict[str, str]:
+        return {
+            "64 bit integer flag that indicates the results to compute": 'Type of results to compute or to evaluate. Can pass one of ``"computeClassLabels"``,'
+            ' ``"computeClassProbabilities"``, ``"computeClassLogProbabilities"``; or more than one by'
+            ' joining them with separator bars (e.g. ``"computeClassLabels|computeClassProbabilities"``).'
+            " Note that not all of these are supported on every class/method accepting this argument"
+            " (see docs for oneDAL for details on what this specific class/method supports)."
+        }
 
     ##################################################################################
     def gen_footers(


### PR DESCRIPTION
## Description

Currently, the auto-generated daal4py docs take text verbatim from oneDAL. Some parameters are enum types, which are passed as integer types to oneDAL, but daal4py adds wrappers that translate between strings and integers, accepting instead string arguments despite what the docs mention.

This PR fixes the docs for the particular case of `resultsToEvaluate` and `resultsToCompute`. I'm not entirely sure if this covers all the cases, but at least should provide a mechanism to make more corrections later on if further inconsistencies are found.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
