### PR TITLE
ENH: Better interface for model builder from logistic regression

### DIFF
--- a/daal4py/mb/__init__.py
+++ b/daal4py/mb/__init__.py
@@ -1,5 +1,4 @@
-# ==============================================================================
-# Copyright 2023 Intel Corporation
+# Copyright contributors to the oneDAL project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +11,73 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
 
-from .model_builders import GBTDAALBaseModel, GBTDAALModel, convert_model
+from sklearn.linear_model import LogisticRegression, SGDClassifier
 
-__all__ = ["GBTDAALBaseModel", "GBTDAALModel", "convert_model"]
+from .logistic_regression_builders import LogisticDAALModel
+from .tree_based_builders import GBTDAALBaseModel, GBTDAALModel
+
+__all__ = ["LogisticDAALModel", "GBTDAALModel", "convert_model"]
+
+
+def convert_model(model) -> GBTDAALModel | LogisticDAALModel:
+    """
+    Convert GBT or LogReg models to Daal4Py
+
+    This function can be used to convert machine learning models / estimators
+    created through other libraries to daal4py classes which offer accelerated
+    prediction methods.
+
+    It supports gradient-boosted decision tree ensembles (GBT) from the libraries
+    ``xgboost``, ``lightgbm``, and ``catboost``; and logistic regression (binary
+    and multinomial) models from scikit-learn.
+
+    See the documentation of the classes :obj:`daal4py.mb.GBTDAALModel` and
+    :obj:`daal4py.mb.LogisticDAALModel` for more details.
+
+    As an alternative to this function, models of a specific type (GBT or LogReg)
+    can also be instantiated by calling those classes directly - for example,
+    logistic regression models can be instantiated directly from fitted coefficients
+    and intercepts, thereby allowing to work with models from libraries beyond
+    scikit-learn.
+
+    Parameters
+    ----------
+    model : fitted model object
+        A fitted model object (either GBT or LogReg) from the supported libraries.
+
+    Returns
+    -------
+    obj : GBTDAALModel or LogisticDAALModel
+        A daal4py model object of the corresponding class for the model type, which
+        offers faster prediction methods.
+    """
+    if isinstance(model, LogisticRegression):
+        if model.classes_.shape[0] > 2:
+            if (model.multi_class == "ovr") or (
+                model.multi_class == "auto" and model.solver == "liblinear"
+            ):
+                raise TypeError(
+                    "Supplied 'model' object is a linear classifier, but not multinomial logistic"
+                    " (hint: pass multi_class='multinomial' to 'LogisticRegression')."
+                )
+        elif (model.classes_.shape[0] == 2) and (model.multi_class == "multinomial"):
+            raise TypeError(
+                "Supplied 'model' object is not a logistic regressor "
+                "(hint: pass multi_class='auto' to 'LogisticRegression')."
+            )
+        return LogisticDAALModel(model.coef_, model.intercept_)
+    if isinstance(model, SGDClassifier):
+        if model.classes_.shape[0] > 2:
+            raise TypeError(
+                "Supplied 'model' object is a linear classifier, but not multinomial logistic"
+                " (note: scikit-learn does not offer stochastic multinomial logistic models)."
+            )
+        if model.loss != "log_loss":
+            raise TypeError(
+                "Supplied 'model' object is not a logistic regressor "
+                "(hint: pass loss='log_loss' to 'SGDClassifier')."
+            )
+        return LogisticDAALModel(model.coef_, model.intercept_)
+
+    return GBTDAALModel(model)

--- a/daal4py/mb/logistic_regression_builders.py
+++ b/daal4py/mb/logistic_regression_builders.py
@@ -1,0 +1,205 @@
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+import sys
+
+import numpy as np
+
+from .. import (
+    classifier_prediction_result,
+    logistic_regression_model_builder,
+    logistic_regression_prediction,
+)
+
+_docstring_X = """Parameters
+----------
+X : array-like(n_samples, n_features)
+    The features / covariates for each row. Can be passed as either a NumPy array
+    or as a sparse CSR array/matrix from SciPy. For faster results, use the same
+    dtype as what this object was built for."""
+if (sys.version_info.major == 3) and (sys.version_info.minor <= 12):
+    _docstring_X = re.sub("^", " " * 8, _docstring_X, flags=re.MULTILINE).strip()
+
+
+class LogisticDAALModel:
+    """
+    Logistic Regression Predictor
+
+    Creates a logistic regression or multionomial logistic regression model object
+    which can calculate fast predictions of different types (classes, probabilities,
+    logarithms of probabilities), from fitted coefficients and intercepts obtained
+    elsewhere (such as from :obj:`sklearn.linear_model.LogisticRegression`), making
+    the predictions either in double (:obj:`np.float64`) or single (:obj:`np.float32`)
+    precision.
+
+    See Also
+    --------
+    :obj:`sklearn.linear_model.LogisticRegression`, :obj:`sklearn.linear_model.SGDClassifier`,
+    :obj:`daal4py.classifier_prediction_result`.
+
+    Parameters
+    ----------
+    coefs : array(n_classes, n_features) or array(n_features,)
+        The fitted model coefficients. Note that only dense arrays are supported.
+        In the case of binary classification, can be passed as a 1D array or as a
+        2D array having a single row.
+    intercepts: array(n_classes) or float
+        The fitted intercepts. In the case of binary classification, must be passed
+        as either a scalar, or as a 1D array with a single entry.
+    dtype : np.float32 or np.float64
+        The dtype to use for the object.
+
+    Attributes
+    ----------
+    n_classes_ : int
+        Number of classes in the model.
+    n_features_in_ : int
+        Number of features in the model.
+    dtype_ : np.dtype
+        The dtype of the model
+    """
+
+    def __init__(self, coefs, intercepts, dtype=np.float64):
+        assert dtype in [np.float32, np.float64]
+        coefs = np.require(coefs, requirements=["ENSUREARRAY"])
+        if len(coefs.shape) == 1:
+            coefs = coefs.reshape((1, -1))
+        self.n_features_in_ = coefs.shape[1]
+        self.n_classes_ = max(2, coefs.shape[0])
+        intercepts = np.require(intercepts, requirements=["ENSUREARRAY"]).reshape(-1)
+        if self.n_classes_ == 2:
+            assert len(intercepts) == 1
+        else:
+            assert intercepts.shape[0] == coefs.shape[0]
+        self._fptype = "float" if dtype == np.float32 else "double"
+        self.dtype_ = dtype
+        if coefs.dtype != self.dtype_:
+            coefs = coefs.astype(self.dtype_)
+        if intercepts.dtype != self.dtype_:
+            intercepts = intercepts.astype(self.dtype_)
+        builder = logistic_regression_model_builder(
+            n_classes=self.n_classes_, n_features=coefs.shape[1]
+        )
+        builder.set_beta(coefs, intercepts)
+        self._model = builder.model
+        self._alg_pred_class = logistic_regression_prediction(
+            nClasses=self.n_classes_,
+            fptype=self._fptype,
+            resultsToEvaluate="computeClassLabels",
+        )
+        self._alg_pred_prob = logistic_regression_prediction(
+            nClasses=self.n_classes_,
+            fptype=self._fptype,
+            resultsToEvaluate="computeClassProbabilities",
+        )
+        self._alg_pred_logprob = logistic_regression_prediction(
+            nClasses=self.n_classes_,
+            fptype=self._fptype,
+            resultsToEvaluate="computeClassLogProbabilities",
+        )
+
+    def predict(self, X) -> np.ndarray:
+        """
+        Predict most probable class
+
+        %docstring_X%
+
+        Returns
+        -------
+        classes : array(n_samples,)
+            The most probable class, as integer indexes
+        """
+        return (
+            self._alg_pred_class.compute(X, self._model)
+            .prediction.reshape(-1)
+            .astype(int)
+        )
+
+    predict.__doc__ = predict.__doc__.replace(r"%docstring_X%", _docstring_X)
+
+    def predict_proba(self, X) -> np.ndarray:
+        """
+        Predict probabilities of belonging to each class
+
+        %docstring_X%
+
+        Returns
+        -------
+        proba : array(n_samples, n_classes)
+            The predicted probabilities for each class.
+        """
+        return self._alg_pred_prob.compute(X, self._model).probabilities
+
+    predict_proba.__doc__ = predict_proba.__doc__.replace(r"%docstring_X%", _docstring_X)
+
+    def predict_log_proba(self, X) -> np.ndarray:
+        """
+        Predict log-probabilities of belonging to each class
+
+        %docstring_X%
+
+        Returns
+        -------
+        log_proba : array(n_samples, n_classes)
+            The logarithms of the predicted probabilities for each class.
+        """
+        return self._alg_pred_logprob.compute(X, self._model).logProbabilities
+
+    predict_log_proba.__doc__ = predict_log_proba.__doc__.replace(
+        r"%docstring_X%", _docstring_X
+    )
+
+    def predict_multiple(
+        self, X, classes: bool = True, proba: bool = True, log_proba: bool = True
+    ) -> classifier_prediction_result:
+        """
+        Make multiple prediction types at once
+
+        A method that can output the results from ``predict``, ``predict_proba``, and ``predict_log_proba``
+        all together in the same call more efficiently than computing them independently.
+
+        %docstring_X%
+        classes : bool
+            Whether to output class predictions (what is obtained from :meth:`predict`).
+        proba : bool
+            Whether to output per-class probability predictions (what is obtained from
+            :meth:`predict_proba`).
+        log_proba : bool
+            Whether to output per-class logarithms of probabilities (what is obtained
+            from :meth:`predict_log_proba`).
+
+        Returns
+        -------
+        predictions : classifier_prediction_result
+            An object of class :obj:`daal4py.classifier_prediction_result` with the requested
+            prediction types for the same ``X`` data.
+        """
+        pred_request = "|".join(
+            (["computeClassLabels"] if classes else [])
+            + (["computeClassProbabilities"] if proba else [])
+            + (["computeClassLogProbabilities"] if log_proba else [])
+        )
+        if not len(pred_request):
+            raise ValueError(
+                "Must request at least one of 'classes', 'proba', 'log_proba'."
+            )
+        return logistic_regression_prediction(
+            nClasses=self.n_classes_,
+            fptype=self._fptype,
+            resultsToEvaluate=pred_request,
+        ).compute(X, self._model)
+
+    predict_multiple.__doc__ = predict_multiple.__doc__.replace(
+        r"%docstring_X%", _docstring_X
+    )

--- a/daal4py/mb/tree_based_builders.py
+++ b/daal4py/mb/tree_based_builders.py
@@ -347,12 +347,37 @@ class GBTDAALModel(GBTDAALBaseModel):
     """
     Gradient Boosted Decision Tree Model
 
-    Model class offering accelerated predictions for gradient-boosted decision tree models
-    that were built using other libraries. See the documentation for :func:`convert_model`
-    for more details.
+    Model class offering accelerated predictions for gradient-boosted decision
+    tree models from other libraries.
 
-    .. note:: This class cannot be instantiated directly. Use :func:`convert_model` to instantiate an object of this class.
+    Objects of this class are meant to be initialized from GBT model objects
+    created through other libraries, returning a different class which can calculate
+    predictions faster than the original library that created said model.
+
+    Can be created from model objects that meet all of the following criteria:
+
+    - Were produced from one of the following libraries: ``xgboost``, ``lightgbm``, or ``catboost``.
+      It can work with either the base booster classes of those libraries or with their
+      scikit-learn-compatible classes.
+    - Do not use categorical features.
+    - Are for regression or classification (e.g. no ranking). In the case of XGBoost objective
+      ``binary:logitraw``, it will create a classification model out of it, and in the case of
+      objective ``reg:logistic``, will create a regression model.
+    - Are not multi-output models. Note that multi-class classification **is** supported.
+
+    Parameters
+    ----------
+    model : booster object from another library
+        The fitted GBT model from which this object will be created. See rest of the documentation
+        for supported input types.
     """
+
+    def __init__(self, model):
+        self._convert_model(model)
+        for type_str in ("xgboost", "lightgbm", "catboost"):
+            if type_str in str(type(model)):
+                self.model_type = type_str
+                break
 
     def predict(
         self, X, pred_contribs: bool = False, pred_interactions: bool = False
@@ -412,45 +437,3 @@ class GBTDAALModel(GBTDAALBaseModel):
         """
         fptype = getFPType(X)
         return self._predict_classification(X, fptype, "computeClassProbabilities")
-
-
-def convert_model(model) -> GBTDAALModel:
-    """
-    Converts a GBT model from a different library to daal4py's :obj:`GBTDAALModel`
-
-    Converts a gradient-boosted decision tree model object created through a
-    different library to a daal4py GBT model object, from which predictions on
-    new data can be calculated faster than in the original library that created
-    the model.
-
-    Can convert models that meet all of the following criteria:
-
-    - Were produced from one of the following libraries: ``xgboost``, ``lightgbm``, or ``catboost``.
-      It can work with either the base booster classes of those libraries or with their
-      scikit-learn-compatible classes.
-    - Do not use categorical features.
-    - Are for regression or classification (e.g. no ranking). In the case of XGBoost objective
-      ``binary:logitraw``, it will create a classification model out of it, and in the case of
-      objective ``reg:logistic`, will create a regression model.
-    - Are not multi-output models. Note that multi-class classification **is** supported.
-
-    :param model: A model object from ``xgboost``, ``lightgbm``, or ``catboost``.
-    :rtype: GBTDAALModel
-    """
-    try:
-        gbm = GBTDAALModel()
-        gbm._convert_model(model)
-    except TypeError as err:
-        if "Only GBTDAALRegressor can be created" in str(err):
-            gbm = d4p.sklearn.ensemble.GBTDAALRegressor.convert_model(model)
-        elif "Only GBTDAALClassifier can be created" in str(err):
-            gbm = d4p.sklearn.ensemble.GBTDAALClassifier.convert_model(model)
-        else:
-            raise
-
-    for type_str in ("xgboost", "lightgbm", "catboost"):
-        if type_str in str(type(model)):
-            gbm.model_type = type_str
-            break
-
-    return gbm

--- a/doc/sources/logistic_model_builder.rst
+++ b/doc/sources/logistic_model_builder.rst
@@ -1,0 +1,62 @@
+.. Copyright contributors to the oneDAL project
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..     http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+
+.. include:: substitutions.rst
+
+Serving Logistic Regression from Other Libraries
+================================================
+
+The |sklearnex| offers a prediction-only class :obj:`daal4py.mb.LogisticDAALModel` which
+can be used to accelerate calculations of predictions from logistic regression models
+(both binary and multinomial) produced by other libraries such as |sklearn|.
+
+Logistic regression models from |sklearn| (classes :obj:`sklearn.linear_model.LogisticRegression`
+and :obj:`sklearn.linear_model.SGDClassifier`) can be converted to daal4py's
+:obj:`daal4py.mb.LogisticDAALModel` through function :obj:`daal4py.mb.convert_model` in the
+model builders (``mb``) submodule. See :ref:`about_daal4py` for more information about the
+``daal4py`` module.
+
+Example:
+.. code-block:: python
+
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.datasets import load_iris
+    import numpy as np
+    import daal4py
+
+    X, y = load_iris(return_X_y=True)
+    model_skl = LogisticRegression().fit(X, y)
+    model_d4p = daal4py.mb.convert_model(model_skl)
+
+    np.testing.assert_almost_equal(
+        model_d4p.predict(X),
+        model_skl.predict(X),
+    )
+
+    np.testing.assert_almost_equal(
+        model_d4p.predict_proba(X),
+        model_skl.predict_proba(X),
+    )
+
+Acceleration is achieved by leveraging the `MKL library <https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html>`__
+for both faster linear algebra operations and faster exponentials / logarithms on Intel hardware.
+
+If you are already using Python libraries (NumPy and SciPy) linked against MKL - for example, by
+installing them from the Intel conda channel ``https://software.repos.intel.com/python/conda/`` - then
+this class might not offer much of a speedup over |sklearn|, but otherwise it offers an easy way to
+speed up inference by better utilizing capabilities of Intel hardware.
+
+Note that besides the :obj:`daal4py.mb.convert_model` function, class :obj:`daal4py.mb.LogisticDAALModel`
+can also be instantiated directly from arrays of fitted coefficients and intercepts, thereby allowing to
+create predictors out of models from other libraries beyond |sklearn|, such as `glum <https://glum.readthedocs.io/>`__.


### PR DESCRIPTION
## Description

This PR adds a class wrapper for the logistic regression builder similar to the one that exists for tree-based models, and modifies the `convert_model` function to also accept logistic regression models from sklearn, which are converted to this class instead.

Since this brings up a new type of model, I also refactored the conversion from GBT and docstrings, so that now the GBT predictor can also be instantiated directly from a GBT model object, while the conversion function handles both types.

The PR includes a .rst file for the docs and adds new classes with docstrings, but it does not include it anywhere - incorporation of that file and the docstrings will be handled in https://github.com/uxlfoundation/scikit-learn-intelex/pull/2395

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

Not applicable.
