### PR TITLE
[enhancement] add ```__version__``` attribute to ```onedal``` and ```sklearnex```

### DIFF
--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -121,3 +121,6 @@ if _spmd_backend is not None:
         ]
     if daal_check_version((2023, "P", 200)):
         __all__ += ["spmd.cluster"]
+
+__version__ = "2199.9.9"
+

--- a/setup.py
+++ b/setup.py
@@ -422,6 +422,16 @@ class onedal_build:
         self.onedal_run()
         super(onedal_build, self).run()
         self.onedal_post_build()
+        if hasattr(self, "build_lib"):
+            # swap out __version__ before install
+            for p in ["onedal", "sklearnex"]:
+                loc = os.sep.join((self.build_lib, p, "__init__.py"))
+                if os.path.isfile(loc):
+                    with open(loc, "r+") as f:
+                        data = f.read().replace("2199.9.9", sklearnex_version)
+                        f.seek(0)
+                        f.write(data)
+                        f.truncate()
 
     def onedal_run(self):
         n_threads = self.parallel

--- a/sklearnex/__init__.py
+++ b/sklearnex/__init__.py
@@ -52,6 +52,7 @@ __all__ = [
     "unpatch_sklearn",
     "utils",
 ]
+__version__ = "2199.9.9"
 onedal_iface_flag = os.environ.get("OFF_ONEDAL_IFACE", "0")
 if onedal_iface_flag == "0":
     from onedal import _spmd_backend


### PR DESCRIPTION
## Description

A setup.py install sets a version in pip but does not include that information in the ```__version__``` attribute of the various packages. This adds a small script in the run step which accesses the copied source files in the build directory and modifies the hardcoded default version.  The default version is "2199.9.9" which matches oneDAL convention. If no intermediate build directory exists, this step will be skipped (possible in ```setup.py develop```).

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
