### PR TITLE
FIX: Deploy fixed version switcher in online docs

### DIFF
--- a/2025.4/_static/version_switcher.js
+++ b/2025.4/_static/version_switcher.js
@@ -1,16 +1,16 @@
-# Copyright contributors to the oneDAL project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+// Copyright contributors to the oneDAL project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 function load_versions(json){
     var button = document.getElementById('version-switcher-button')
     var container = document.getElementById('version-switcher-dropdown')

--- a/latest/_static/version_switcher.js
+++ b/latest/_static/version_switcher.js
@@ -1,16 +1,16 @@
-# Copyright contributors to the oneDAL project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+// Copyright contributors to the oneDAL project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 function load_versions(json){
     var button = document.getElementById('version-switcher-button')
     var container = document.getElementById('version-switcher-dropdown')


### PR DESCRIPTION
## Description

As a follow up from previous PR: https://github.com/uxlfoundation/scikit-learn-intelex/pull/2412

This PR backports fixes for the version switcher which currently cause it to not work in the latest deployed docs when the focus is on the 2025.4 version.

Result can be previewed here: https://david-cortes-intel.github.io/scikit-learn-intelex

CC @napetrov 

Before:
![image](https://github.com/user-attachments/assets/6344a81a-dda8-430b-9049-6281246e78bb)
![image](https://github.com/user-attachments/assets/d1fe350f-ad60-4a2d-a09f-20184e056c22)

After:
![image](https://github.com/user-attachments/assets/986cbce7-f7e5-4384-b288-b4e21a7c1999)
![image](https://github.com/user-attachments/assets/8364dcc7-15d9-48fc-9a45-f6a25ed0db42)

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.

**Performance**

Not applicable.
