### PR TITLE
[bug] fix csr kMeans Init offloading when SYCL CPU device is unavailable

### DIFF
--- a/onedal/cluster/kmeans_init.py
+++ b/onedal/cluster/kmeans_init.py
@@ -45,7 +45,7 @@ if daal_check_version((2023, "P", 200)):
         function: The wrapped function with the modified configuration if the input data is in CSR format.
         """
         config = get_config()
-        # `auto` rather than `cpu` is necessary in order to force host when a cpu target is unavailable
+        # `auto` rather than `cpu` is necessary in order to force host when a SYCL cpu target is unavailable
         config["target_offload"] = "auto"
 
         def wrapper(self, *args, **kwargs):

--- a/onedal/cluster/kmeans_init.py
+++ b/onedal/cluster/kmeans_init.py
@@ -45,7 +45,8 @@ if daal_check_version((2023, "P", 200)):
         function: The wrapped function with the modified configuration if the input data is in CSR format.
         """
         config = get_config()
-        config["target_offload"] = "cpu"
+        # `auto` rather than `cpu` is necessary in order to force host when a cpu target is unavailable
+        config["target_offload"] = "auto"
 
         def wrapper(self, *args, **kwargs):
             if self.is_csr:


### PR DESCRIPTION
## Description

Ran into this bug locally.  When ```target_offload='cpu'``` is currently used it attempts to extract a SYCL cpu device queue. If the openCL Runtime is unavailable but it is a dpc build, the SyclQueue creation will fail.  Setting to "auto" will clear out the queue for any device and will implicitly use "cpu" even if there isn't a SYCL CPU device.

No performance benchmarks necessary.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
