### PR TITLE
MAINT: Inherit docstrings instead of copy-pasting them

### DIFF
--- a/sklearnex/neighbors/_lof.py
+++ b/sklearnex/neighbors/_lof.py
@@ -15,6 +15,7 @@
 # ===============================================================================
 
 import warnings
+from functools import wraps
 
 import numpy as np
 from sklearn.neighbors import LocalOutlierFactor as _sklearn_LocalOutlierFactor
@@ -142,28 +143,9 @@ class LocalOutlierFactor(KNeighborsDispatchingBase, _sklearn_LocalOutlierFactor)
     # This would cause issues in fit_predict. Also, available_if
     # is hard to unwrap, and this is the most straighforward way.
     @available_if(_sklearn_LocalOutlierFactor._check_novelty_fit_predict)
+    @wraps(_sklearn_LocalOutlierFactor.fit_predict, assigned=["__doc__"])
     @wrap_output_data
     def fit_predict(self, X, y=None):
-        """Fit the model to the training set X and return the labels.
-
-        **Not available for novelty detection (when novelty is set to True).**
-        Label is 1 for an inlier and -1 for an outlier according to the LOF
-        score and the contamination parameter.
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features), default=None
-            The query sample or samples to compute the Local Outlier Factor
-            w.r.t. the training samples.
-
-        y : Ignored
-            Not used, present for API consistency by convention.
-
-        Returns
-        -------
-        is_inlier : ndarray of shape (n_samples,)
-            Returns -1 for anomalies/outliers and 1 for inliers.
-        """
         return self.fit(X)._predict()
 
     def _kneighbors(self, X=None, n_neighbors=None, return_distance=True):
@@ -185,34 +167,9 @@ class LocalOutlierFactor(KNeighborsDispatchingBase, _sklearn_LocalOutlierFactor)
     kneighbors = wrap_output_data(_kneighbors)
 
     @available_if(_sklearn_LocalOutlierFactor._check_novelty_score_samples)
+    @wraps(_sklearn_LocalOutlierFactor.score_samples, assigned=["__doc__"])
     @wrap_output_data
     def score_samples(self, X):
-        """Opposite of the Local Outlier Factor of X.
-
-        It is the opposite as bigger is better, i.e. large values correspond
-        to inliers.
-
-        **Only available for novelty detection (when novelty is set to True).**
-        The argument X is supposed to contain *new data*: if X contains a
-        point from training, it considers the later in its own neighborhood.
-        Also, the samples in X are not considered in the neighborhood of any
-        point. Because of this, the scores obtained via ``score_samples`` may
-        differ from the standard LOF scores.
-        The standard LOF scores for the training data is available via the
-        ``negative_outlier_factor_`` attribute.
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            The query sample or samples to compute the Local Outlier Factor
-            w.r.t. the training samples.
-
-        Returns
-        -------
-        opposite_lof_scores : ndarray of shape (n_samples,)
-            The opposite of the Local Outlier Factor of each input samples.
-            The lower, the more abnormal.
-        """
         check_is_fitted(self)
 
         distances_X, neighbors_indices_X = self._kneighbors(

--- a/sklearnex/svm/nusvc.py
+++ b/sklearnex/svm/nusvc.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from functools import wraps
+
 import numpy as np
 from sklearn.exceptions import NotFittedError
 from sklearn.metrics import accuracy_score
@@ -139,64 +141,14 @@ class NuSVC(_sklearn_NuSVC, BaseSVC):
         )
 
     @available_if(_sklearn_NuSVC._check_proba)
+    @wraps(_sklearn_NuSVC.predict_proba, assigned=["__doc__"])
     def predict_proba(self, X):
-        """
-        Compute probabilities of possible outcomes for samples in X.
-
-        The model need to have probability information computed at training
-        time: fit with attribute `probability` set to True.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features)
-            For kernel="precomputed", the expected shape of X is
-            (n_samples_test, n_samples_train).
-
-        Returns
-        -------
-        T : ndarray of shape (n_samples, n_classes)
-            Returns the probability of the sample for each class in
-            the model. The columns correspond to the classes in sorted
-            order, as they appear in the attribute :term:`classes_`.
-
-        Notes
-        -----
-        The probability model is created using cross validation, so
-        the results can be slightly different than those obtained by
-        predict. Also, it will produce meaningless results on very small
-        datasets.
-        """
         check_is_fitted(self)
         return self._predict_proba(X)
 
     @available_if(_sklearn_NuSVC._check_proba)
+    @wraps(_sklearn_NuSVC.predict_log_proba, assigned=["__doc__"])
     def predict_log_proba(self, X):
-        """Compute log probabilities of possible outcomes for samples in X.
-
-        The model need to have probability information computed at training
-        time: fit with attribute `probability` set to True.
-
-        Parameters
-        ----------
-        X : array-like of shape (n_samples, n_features) or \
-                (n_samples_test, n_samples_train)
-            For kernel="precomputed", the expected shape of X is
-            (n_samples_test, n_samples_train).
-
-        Returns
-        -------
-        T : ndarray of shape (n_samples, n_classes)
-            Returns the log-probabilities of the sample for each class in
-            the model. The columns correspond to the classes in sorted
-            order, as they appear in the attribute :term:`classes_`.
-
-        Notes
-        -----
-        The probability model is created using cross validation, so
-        the results can be slightly different than those obtained by
-        predict. Also, it will produce meaningless results on very small
-        datasets.
-        """
         xp, _ = get_namespace(X)
 
         return xp.log(self.predict_proba(X))


### PR DESCRIPTION
## Description

As a follow-up from previous PR: https://github.com/uxlfoundation/scikit-learn-intelex/pull/2346

This PR removes copy-pastes of some sklearn docstrings in the sklearnex module, making them instead take the docstrings from sklearn at runtime.

There still some cases in daal4py.sklearn that look copy-pasted, but those don't have the same kind of logic for inheritance so I'm not modifying them here.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
