### PR TITLE
FIX: Allow weights as positional argument in BasicStatistics

### DIFF
--- a/sklearnex/basic_statistics/basic_statistics.py
+++ b/sklearnex/basic_statistics/basic_statistics.py
@@ -221,7 +221,7 @@ class BasicStatistics(ExtensionEstimator, BaseEstimator):
         self._save_attributes()
         self.n_features_in_ = X.shape[1] if len(X.shape) > 1 else 1
 
-    def fit(self, X, y=None, *, sample_weight=None):
+    def fit(self, X, y=None, sample_weight=None):
         """Calculate statistics of X.
 
         Parameters


### PR DESCRIPTION
## Description

The fitting method for BasicStatistics doesn't allow passing sample weights as positional argument, which differs from sklearn as every class there allows sample weights to be a positional argument. This PR fixes it.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
