### PR TITLE
MAINT: Enable black formatting for all python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@
 
 [tool.black]
 line-length = 90
-target-version = ['py39', 'py310', 'py311', 'py312']
 extend-ignore = 'E203'
 
 [tool.isort]


### PR DESCRIPTION
## Description

This PR updates  the settings for 'black' to apply to all python versions, not just to a manual list. The current list does not include python3.13, so this should enable 'black' to run with that version.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
