### PR TITLE
Fix multiclass SVM example failures on AVX2

### DIFF
--- a/examples/daal4py/svm_multiclass.py
+++ b/examples/daal4py/svm_multiclass.py
@@ -34,11 +34,12 @@ def main(readcsv=pd_read_csv):
     train_file = data_path / "svm_multi_class_train_dense.csv"
     train_data = readcsv(train_file, range(nFeatures))
     train_labels = readcsv(train_file, range(nFeatures, nFeatures + 1))
+    lin_kernel = d4p.kernel_function_linear()
 
     # Create and configure algorithm object
     algorithm = d4p.multi_class_classifier_training(
         nClasses=nClasses,
-        training=d4p.svm_training(method="thunder"),
+        training=d4p.svm_training(method="thunder", kernel=lin_kernel),
         prediction=d4p.svm_prediction(),
     )
 
@@ -56,7 +57,7 @@ def main(readcsv=pd_read_csv):
     # Create an algorithm object to predict multi-class SVM values
     algorithm = d4p.multi_class_classifier_prediction(
         nClasses,
-        training=d4p.svm_training(method="thunder"),
+        training=d4p.svm_training(method="thunder", kernel=lin_kernel),
         prediction=d4p.svm_prediction(),
     )
     # Pass data to prediction. Prediction result provides prediction


### PR DESCRIPTION
## Description

daal4py multiclass SVM example is modified to use float64 linear kernel to fix the failure that sporadically appears in oneDAL CI on AVX2 machines:
https://dev.azure.com/daal/DAAL/_build/results?buildId=45307&view=logs&j=a8904dfb-edc6-5d1f-0634-80e20164e44d&t=43785ab5-fe0c-5af6-408a-03e67dcd3abc&l=13649

---

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

not applicable.
