### PR TITLE
MAINT: Add back catboost to conda jobs

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -88,9 +88,8 @@ test:
     - pandas
     - xgboost
     - lightgbm
-    # TODO: re-enable shap and catboost when conda-forge packages has a numpy 2.* compatibility
-    # - shap
-    # - catboost
+    - shap
+    - catboost
     - array-api-compat
     - array-api-strict
   source_files:


### PR DESCRIPTION
## Description

The .yaml file for conda builds had removed catboost and shap as a test dependencies due to not working with numpy>=2. By now, the latest releases of both of those packages in conda-forge work with numpy>=2, so they can be added back as it says in the TODO line.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
