### PR TITLE
FIX: Backport fixes for model builders

### DIFF
--- a/doc/sources/daal4py.rst
+++ b/doc/sources/daal4py.rst
@@ -56,6 +56,7 @@ Documentation for model builders, which allow computing fast predictions from GB
 
 .. autoclass:: daal4py.mb.GBTDAALModel
   :members:
+  :exclude-members: is_classifier_, is_regressor_
 
 .. autoclass:: daal4py.mb.LogisticDAALModel
   :members:

--- a/doc/sources/model_builders.rst
+++ b/doc/sources/model_builders.rst
@@ -119,8 +119,11 @@ Limitations
 -----------
 
 - Models with categorical features are not supported.
+- Multi-class classification is only supported when the logic corresponds to multinomial logistic loss
+  instead of one-vs-rest.
 - Multioutput models are not supported.
-- SHAP values can be calculated for regression models only.
+- SHAP values cannot be calculated for multi-class classification models, nor for CatBoost regression models
+  from loss functions that involve link functions (e.g. can be calculated for 'RMSE', but not for 'Poisson').
 - Objectives that are not for regression nor classification (e.g. ranking) are not supported.
 
 Documentation


### PR DESCRIPTION
Backport of earlier PR: https://github.com/uxlfoundation/scikit-learn-intelex/pull/2419

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
