### PR TITLE
FIX: Don't force D4P compiler to ICX when building with DPC

### DIFF
--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -107,8 +107,9 @@ def custom_build_cmake_clib(
     # in order to propagate both potential user-passed arguments and flags, such as:
     #     CXX="ccache icpx"
     #     CXX="icpx -O0"
+    env_build = dict(os.environ)
     if cxx:
-        os.environ["CXX"] = cxx
+        env_build["CXX"] = cxx
     cmake_args = [
         "cmake",
         cmake_generator,
@@ -151,6 +152,6 @@ def custom_build_cmake_clib(
         abs_build_temp_path,
     ]
 
-    subprocess.check_call(cmake_args)
-    subprocess.check_call(make_args)
-    subprocess.check_call(make_install_args)
+    subprocess.check_call(cmake_args, env=env_build)
+    subprocess.check_call(make_args, env=env_build)
+    subprocess.check_call(make_install_args, env=env_build)

--- a/setup.py
+++ b/setup.py
@@ -283,7 +283,7 @@ def get_build_options():
         '-DD4P_VERSION="' + sklearnex_version + '"',
         "-DNPY_ALLOW_THREADS=1",
     ]
-    ela = ["-no-intel-lib"] if using_intel else []
+    ela = []
 
     if using_intel and IS_WIN:
         include_dir_plat.append(

--- a/setup.py
+++ b/setup.py
@@ -283,7 +283,7 @@ def get_build_options():
         '-DD4P_VERSION="' + sklearnex_version + '"',
         "-DNPY_ALLOW_THREADS=1",
     ]
-    ela = []
+    ela = ["-no-intel-libs"] if using_intel else []
 
     if using_intel and IS_WIN:
         include_dir_plat.append(

--- a/setup.py
+++ b/setup.py
@@ -283,7 +283,7 @@ def get_build_options():
         '-DD4P_VERSION="' + sklearnex_version + '"',
         "-DNPY_ALLOW_THREADS=1",
     ]
-    ela = ["-no-intel-libs"] if using_intel else []
+    ela = ["-no-intel-lib"] if using_intel else []
 
     if using_intel and IS_WIN:
         include_dir_plat.append(


### PR DESCRIPTION
## Description

Perhaps an alternative to previous PR: https://github.com/uxlfoundation/scikit-learn-intelex/pull/2437

This PR changes the logic to avoid building the daal4py extension with ICX when building the whole package with DPC enabled, since it's not needed; and adds a flag not to link the daal4py part to intel libraries when using ICX.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
