### PR TITLE
[WIP, enhancement] enable array_api return values from ```from_table```

### DIFF
--- a/onedal/common/sycl_interfaces.hpp
+++ b/onedal/common/sycl_interfaces.hpp
@@ -49,6 +49,7 @@ sycl::queue get_queue_from_python(const py::object& syclobj);
 
 using dp_policy_t = detail::data_parallel_policy;
 
+std::uint32_t get_device_id(const sycl::queue& queue);
 std::uint32_t get_device_id(const dp_policy_t& policy);
 std::size_t get_used_memory(const py::object& syclobj);
 std::string get_device_name(const dp_policy_t& policy);

--- a/onedal/datatypes/_data_conversion.py
+++ b/onedal/datatypes/_data_conversion.py
@@ -34,84 +34,64 @@ def to_table(*args, queue=None):
     """Create oneDAL tables from scalars and/or arrays.
 
     Note: this implementation can be used with scipy.sparse, numpy ndarrays,
-    DPCTL/DPNP usm_ndarrays and scalars. Tables will use pointers to the
-    original array data. Scalars and non-contiguous arrays will be copies.
-    Arrays may be modified in-place by oneDAL during computation. This works
-    for data located on CPU and SYCL-enabled Intel GPUs. Each array may only
-    be of a single datatype (i.e. each must be homogeneous).
+    dpctl/dpnp usm_ndarrays, array API standard arrays, and scalars. Tables
+    will use pointers to the original array data. Scalars and non-contiguous
+    arrays will be copies. Arrays may be modified in-place by oneDAL during
+    computation. This works for data located on CPU and SYCL-enabled Intel GPUs.
+    Each array may only be of a single datatype (i.e. each must be homogeneous).
 
     Parameters
     ----------
-    *args : {scalar, numpy array, sycl_usm_ndarray, csr_matrix, or csr_array}
+    *args : scalar, numpy array, sycl_usm_ndarray, array API standard array,
+        csr_matrix, or csr_array
         arg1, arg2... The arrays should be given as arguments.
+
+    queue : SyclQueue or None, default=None
+        A dpctl or oneDAL backend python representation of a SYCL Queue or None
 
     Returns
     -------
-    tables: {oneDAL homogeneous tables}
+    tables: oneDAL homogeneous tables
     """
     return _apply_and_pass(_convert_one_to_table, *args, queue=queue)
 
 
-if backend.is_dpc:
+def from_table(*args, array=None):
+    """Create 2 dimensional arrays from oneDAL tables.
 
-    try:
-        # try/catch is used here instead of dpep_helpers because
-        # of circular import issues of _data_conversion.py and
-        # utils/validation.py. This is a temporary fix until the
-        # issue with dpnp is addressed, at which point this can
-        # be removed entirely.
-        import dpnp
+    Note: this implementation will convert any table to numpy ndarrays,
+    dpctl/dpnp usm_ndarrays, and array API standard arrays of designated
+    type. By default, from_table will return numpy arrays and can only
+    return other types when necessary object attributes exist (i.e.
+    ``__sycl_usm_array_interface__`` or ``__array_namespace__``).
 
-        def _table_to_array(table, xp=None):
-            # By default DPNP ndarray created with a copy.
-            # TODO:
-            # investigate why dpnp.array(table, copy=False) doesn't work.
-            # Work around with using dpctl.tensor.asarray.
-            if xp == dpnp:
-                return dpnp.array(dpnp.dpctl.tensor.asarray(table), copy=False)
-            else:
-                return xp.asarray(table)
+    Parameters
+    ----------
+    *args : single or multiple python oneDAL tables
+        arg1, arg2... The arrays should be given as arguments.
 
-    except ImportError:
+    array : array-like or None, default=None
+        python object representing return type. Accessed for conversion
+        namespace when sycl_usm_array type or array API standard type
 
-        def _table_to_array(table, xp=None):
-            return xp.asarray(table)
+    Returns
+    -------
+    arrays: numpy arrays, sycl_usm_ndarrays, or array API standard arrays
+    """
 
-    def convert_one_from_table(table, sycl_queue=None, sua_iface=None, xp=None):
-        # Currently only `__sycl_usm_array_interface__` protocol used to
-        # convert into dpnp/dpctl tensors.
-        if sua_iface:
-            if (
-                sycl_queue
-                and sycl_queue.sycl_device.is_cpu
-                and table.__sycl_usm_array_interface__["syclobj"] is None
-            ):
-                # oneDAL returns tables with None sycl queue for CPU sycl queue inputs.
-                # This workaround is necessary for the functional preservation
-                # of the compute-follows-data execution.
-                # Host tables first converted into numpy.narrays and then to array from xp
-                # namespace.
-                return xp.asarray(
-                    backend.from_table(table), usm_type="device", sycl_queue=sycl_queue
-                )
-            else:
-                return _table_to_array(table, xp=xp)
-
-        return backend.from_table(table)
-
-else:
-
-    def convert_one_from_table(table, sycl_queue=None, sua_iface=None, xp=None):
-        # Currently only `__sycl_usm_array_interface__` protocol used to
-        # convert into dpnp/dpctl tensors.
-        if sua_iface:
-            raise RuntimeError(
-                "SYCL usm array conversion from table requires the DPC backend"
-            )
-        return backend.from_table(table)
-
-
-def from_table(*args, sycl_queue=None, sua_iface=None, xp=None):
-    return _apply_and_pass(
-        convert_one_from_table, *args, sycl_queue=sycl_queue, sua_iface=sua_iface, xp=xp
-    )
+    func = backend.from_table
+    if isintance(array, np.ndarray):
+        pass
+    elif hasattr(array, "__sycl_usm_array_interface__"):
+        # oneDAL returns tables with None sycl queue for CPU sycl queue inputs.
+        # This workaround is necessary for the functional preservation
+        # of the compute-follows-data execution.
+        device = array.sycl_queue if array.sycl_device.is_cpu else None
+        if hasattr(array, "__array_namespace__"):
+            func = lambda x: array.__array_namespace__().asarray(x, device=device)
+        elif hasattr(array, "_create_from_usm_ndarray"):  # signifier of dpnp < 0.19
+            xp = array._array_obj.__array_namespace__()
+            func = lambda x: array._create_from_usm_ndarray(xp.asarray(x, device=device))
+    elif hasattr(array, "__array_namespace__"):
+        func = array.__array_namespace__().from_dlpack
+    return _apply_and_pass(func, *args)

--- a/onedal/datatypes/dlpack/data_conversion.cpp
+++ b/onedal/datatypes/dlpack/data_conversion.cpp
@@ -154,6 +154,105 @@ dal::table convert_to_table(py::object obj, py::object q_obj, bool recursed) {
     return res;
 }
 
+DLDevice get_dlpack_device(const dal::array<byte_t>& array) {
+    DLDevice device;
+#ifdef ONEDAL_DATA_PARALLEL
+    // std::optional<sycl::queue>
+    auto queue = array.get_queue();
+    device = queue.has_value()
+                 ? DLDevice{ kDLOneAPI, static_cast<std::int32_t>(get_device_id(queue.value())) }
+                 : DLDevice{ kDLCPU, std::int32_t(0) };
+#else
+    device = DLDevice{ kDLCPU, std::int32_t(0) };
+#endif //ONEDAL_DATA_PARALLEL
+    return device;
+}
+
+DLDevice get_dlpack_device(const dal::table& input) {
+    if (input.get_kind() == dal::homogen_table::kind()) {
+        auto homogen_input = reinterpret_cast<const dal::homogen_table&>(input);
+        dal::array<byte_t> array = dal::detail::get_original_data(homogen_input);
+        return get_dlpack_device(array);
+    }
+    else {
+        return DLDevice{ kDLCPU, std::int32_t(0) };
+    }
+}
+
+DLTensor construct_dlpack_tensor(const dal::array<byte_t>& array,
+                                 std::int64_t row_count,
+                                 std::int64_t column_count,
+                                 const dal::data_type& dtype,
+                                 const dal::data_layout& layout) {
+    DLTensor tensor;
+
+    // set data
+    tensor.data = const_cast<byte_t*>(array.get_data());
+    tensor.device = get_dlpack_device(array);
+    tensor.ndim = std::int32_t(2);
+    tensor.dtype = convert_dal_to_dlpack_type(dtype);
+
+    // set shape int64_t, which is the output type of a homogen table and for shape and strides
+    if (layout == dal::data_layout::row_major) {
+        tensor.shape =
+            new std::int64_t[4]{ row_count, column_count, column_count, std::int64_t(1) };
+    }
+    else {
+        tensor.shape = new std::int64_t[4]{ row_count, column_count, std::int64_t(1), row_count };
+    }
+
+    // take strategy from dpctl tensors in having a single array allocation by tensor.shape.
+    tensor.strides = &tensor.shape[2];
+    tensor.byte_offset = std::uint64_t(0);
+
+    return tensor;
+}
+
+static void free_capsule(PyObject* cap) {
+    DLManagedTensor* dlm = nullptr;
+    if (PyCapsule_IsValid(cap, "dltensor")) {
+        dlm = reinterpret_cast<DLManagedTensor*>(PyCapsule_GetPointer(cap, "dltensor"));
+        if (dlm->deleter) {
+            dlm->deleter(dlm);
+        }
+    }
+}
+
+py::capsule construct_dlpack(const dal::table& input) {
+    // DLManagedTensor is used instead of DLManagedTensorVersioned
+    // due to major frameworks not yet supporting the latter.
+    DLManagedTensor* dlm = new DLManagedTensor;
+
+    // check table type and expose oneDAL array
+    if (input.get_kind() != dal::homogen_table::kind())
+        throw pybind11::type_error("Unsupported table type for dlpack conversion");
+
+    auto homogen_input = reinterpret_cast<const dal::homogen_table&>(input);
+    dal::array<byte_t> array = dal::detail::get_original_data(homogen_input);
+    dlm->manager_ctx = static_cast<void*>(new dal::array<byte_t>(array));
+
+    // set tensor
+    dlm->dl_tensor = construct_dlpack_tensor(array,
+                                             homogen_input.get_row_count(),
+                                             homogen_input.get_column_count(),
+                                             homogen_input.get_metadata().get_data_type(0),
+                                             homogen_input.get_data_layout());
+
+    // generate tensor deleter
+    dlm->deleter = [](struct DLManagedTensor* self) -> void {
+        auto stored_array = static_cast<dal::array<byte_t>*>(self->manager_ctx);
+        if (stored_array) {
+            delete stored_array;
+        }
+        delete[] self->dl_tensor.shape;
+        delete self;
+    };
+
+    // create capsule
+    py::capsule capsule(reinterpret_cast<void*>(dlm), "dltensor", free_capsule);
+    return capsule;
+}
+
 py::object dlpack_memory_order(py::object obj) {
     DLManagedTensor* dlm;
     DLManagedTensorVersioned* dlmv;

--- a/onedal/datatypes/dlpack/data_conversion.hpp
+++ b/onedal/datatypes/dlpack/data_conversion.hpp
@@ -35,5 +35,8 @@ namespace py = pybind11;
 
 dal::table convert_to_table(py::object obj, py::object q_obj = py::none(), bool recursed = false);
 
+DLDevice get_dlpack_device(const dal::table& input);
+py::capsule construct_dlpack(const dal::table& input);
+
 py::object dlpack_memory_order(py::object obj);
 } // namespace oneapi::dal::python::dlpack

--- a/onedal/datatypes/sycl_usm/data_conversion.cpp
+++ b/onedal/datatypes/sycl_usm/data_conversion.cpp
@@ -150,6 +150,10 @@ dal::table convert_to_table(py::object obj) {
 
 // Create a dictionary for `__sycl_usm_array_interface__` protocol from oneDAL table properties.
 py::dict construct_sua_iface(const dal::table& input) {
+    // To enable native extensions to pass the memory allocated by a native SYCL library to SYCL-aware
+    // Python extension without making a copy, the class must provide `__sycl_usm_array_interface__`
+    // attribute representing USM allocations. The `__sycl_usm_array_interface__` attribute is used
+    // for constructing DPCTL usm_ndarray or DPNP ndarray with zero-copy on python level.
     const auto kind = input.get_kind();
     if (kind != dal::homogen_table::kind())
         report_problem_to_sua_iface(": only homogen tables are supported");
@@ -223,16 +227,6 @@ py::dict construct_sua_iface(const dal::table& input) {
     }
 
     return iface;
-}
-
-// Adding `__sycl_usm_array_interface__` attribute to python oneDAL table, that representing
-// USM allocations.
-void define_sycl_usm_array_property(py::class_<dal::table>& table_obj) {
-    // To enable native extensions to pass the memory allocated by a native SYCL library to SYCL-aware
-    // Python extension without making a copy, the class must provide `__sycl_usm_array_interface__`
-    // attribute representing USM allocations. The `__sycl_usm_array_interface__` attribute is used
-    // for constructing DPCTL usm_ndarray or DPNP ndarray with zero-copy on python level.
-    table_obj.def_property_readonly("__sycl_usm_array_interface__", &construct_sua_iface);
 }
 
 } // namespace oneapi::dal::python::sycl_usm

--- a/onedal/datatypes/table.cpp
+++ b/onedal/datatypes/table.cpp
@@ -77,6 +77,11 @@ ONEDAL_PY_INIT_MODULE(table) {
         // returns a numpy dtype, even if source was not from numpy
         return py::dtype(numpy::convert_dal_to_npy_type(t.get_metadata().get_data_type(0)));
     });
+    table_obj.def("__dlpack__", &dlpack::construct_dlpack);
+    table_obj.def("__dlpack_device__", [](const table& t) {
+        auto dlpack_device = dlpack::get_dlpack_device(t);
+        return py::make_tuple(dlpack_device.device_type, dlpack_device.device_id);
+    });
 
 #ifdef ONEDAL_DATA_PARALLEL
     sycl_usm::define_sycl_usm_array_property(table_obj);
@@ -103,6 +108,9 @@ ONEDAL_PY_INIT_MODULE(table) {
         return obj_ptr;
     });
     m.def("dlpack_memory_order", &dlpack::dlpack_memory_order);
+    py::enum_<DLDeviceType>(m, "DLDeviceType")
+        .value("kDLCPU", kDLCPU)
+        .value("kDLOneAPI", kDLOneAPI);
 }
 
 } // namespace oneapi::dal::python

--- a/onedal/datatypes/table.cpp
+++ b/onedal/datatypes/table.cpp
@@ -84,7 +84,7 @@ ONEDAL_PY_INIT_MODULE(table) {
     });
 
 #ifdef ONEDAL_DATA_PARALLEL
-    sycl_usm::define_sycl_usm_array_property(table_obj);
+    table_obj.def_property_readonly("__sycl_usm_array_interface__", &sycl_usm::construct_sua_iface);
 #endif // ONEDAL_DATA_PARALLEL
 
     m.def("to_table", [](py::object obj, py::object queue) {

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -574,3 +574,40 @@ def test_table_conversions_dlpack(dataframe, queue, order, data_shape, dtype):
     # oneDAL table construction sets 1d arrays to 2d arrays with 1 col
     # this is counter the numpy strategy, and requires numpy's squeeze
     assert_allclose(np.squeeze(X), np.squeeze(X_out))
+
+
+@pytest.mark.parametrize(
+    "dataframe,queue", get_dataframes_and_queues("dpctl,numpy,array_api", "cpu,gpu")
+)
+@pytest.mark.parametrize("order", ["F", "C"])
+@pytest.mark.parametrize("data_shape", data_shapes)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int32, np.int64])
+def test_table___dlpack__(dataframe, queue, order, data_shape, dtype):
+    """Test if __dlpack__ attribute can be properly consumed by other frameworks
+    This tests kDLOneAPI devices as well as kDLCPU devices.
+    """
+    rng = np.random.RandomState(0)
+    X = np.array(5 * rng.random_sample(data_shape), dtype=dtype)
+
+    X = ORDER_DICT[order](X)
+
+    X_df = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
+
+    X_table = to_table(X_df)
+    if hasattr(X_df, "__dlpack_device__"):
+        assert X_df.__dlpack_device__() == X_table.__dlpack_device__()
+
+    if xp := getattr(X_df, "__array_namespace__", lambda: None)():
+        X_out = xp.from_dlpack(X_table)
+        X_temp = xp.asnumpy(X_out) if hasattr(xp, "asnumpy") else np.asarray(X)
+        assert_allclose(np.squeeze(X_temp), np.squeeze(X))
+    else:
+        # only some numpy versions support array_api and from_dlpack
+        pytest.skip(f"{dataframe} does not have an __array_namespace__ attribute")
+
+    # test capsule deletion, should have no impact on underlying memory
+    # important for testing ``dlpack::free_capsule``
+    capsule = X_table.__dlpack__()
+    assert_allclose(np.squeeze(from_table(X_table)), np.squeeze(X))
+    del capsule
+    assert_allclose(np.squeeze(from_table(X_table)), np.squeeze(X))


### PR DESCRIPTION
## Description

NOTE: The initial support version for ```from_table``` is not general enough and highly coded for sycl usm inputs.  This changes the interface to mirror the type (and possibly queue) of the data.  Getting this integrated will begin the fight against the technical debt introduced with ```use_raw_inputs```. The core of this PR is simple, the changes needed associated with the technical debt will be brutal.

An open question exists for type persistence in incremental algorithms, which do not follow use_raw_inputs in the return types (probably for this reason).  Some sort of solution must be found and implemented, probably as a follow-up to this PR.  It is likely that a conversion function must be stored in the instance along with the queue for returning the proper value.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
