### PR TITLE
MAINT: Remove unreachable code section in model builders

### DIFF
--- a/daal4py/mb/tree_based_builders.py
+++ b/daal4py/mb/tree_based_builders.py
@@ -265,11 +265,6 @@ class GBTDAALBaseModel:
                 # unknown type error
                 raise
 
-        # fallback to calculation without `resultsToCompute`
-        predict_algo = d4p.gbt_regression_prediction(fptype=fptype)
-        predict_result = predict_algo.compute(X, self.daal_model_)
-        return predict_result.prediction.ravel()
-
     def _predict_regression_with_results_to_compute(
         self, X, fptype, pred_contribs=False, pred_interactions=False
     ):


### PR DESCRIPTION
## Description

This PR removes an unreachable part of the code in model builders.

This code became unreachable after the changes in the error catching logic in https://github.com/uxlfoundation/scikit-learn-intelex/pull/2419 - my understanding is that the old logic where this code section was reachable would have led it produce incorrect results for what was requested, but would be ideal to have a second opinion here.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

Not applicable.

**Performance**

Not applicable.
