### PR TITLE
ENH: Enable model conversion from TreeLite

### DIFF
--- a/daal4py/mb/__init__.py
+++ b/daal4py/mb/__init__.py
@@ -29,8 +29,8 @@ def convert_model(model) -> "GBTDAALModel | LogisticDAALModel":
     prediction methods.
 
     It supports gradient-boosted decision tree ensembles (GBT) from the libraries
-    ``xgboost``, ``lightgbm``, and ``catboost``; and logistic regression (binary
-    and multinomial) models from scikit-learn.
+    ``xgboost``, ``lightgbm``, ``catboost``, and ``treelite``; and logistic regression
+    (binary and multinomial) models from scikit-learn.
 
     See the documentation of the classes :obj:`daal4py.mb.GBTDAALModel` and
     :obj:`daal4py.mb.LogisticDAALModel` for more details.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,5 +15,6 @@ xgboost==3.0.0 ; python_version >= '3.10'
 lightgbm==4.6.0
 catboost==1.2.8
 shap==0.47.2 ; python_version < '3.13'
+treelite==4.4.1
 array-api-compat==1.11.2
 array-api-strict==2.3.1


### PR DESCRIPTION
## Description

This PR extends the model builders module in daal4py to be able to convert from objects in TreeLite format.

By supporting this format, models from other libraries such as scikit-learn can be converted to daal4py using this as an intermediate, without having to support those libraries directly.

It also allows supporting dart boosters from xgboost and lightgbm along the way, since treelite already takes care of the right conversion into a format that is very similar to daal4py's.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

Not applicable.
