### PR TITLE
fix: Use last known good oneDAL Windows Nightly for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,16 @@ jobs:
           source venv/bin/activate
           source .github/scripts/activate_components.sh ${{ steps.set-env.outputs.DPCFLAG }}
           python setup.py install --single-version-externally-managed --record=record.txt
+      - name: Upload built daal4py
+        uses: actions/upload-artifact@v4
+        with:
+          name: daal4py-built
+          path: ${{ github.workspace }}\venv\Lib\site-packages\daal4py\
+      - name: Upload built scikit-learn-intelex
+        uses: actions/upload-artifact@v4
+        with:
+          name: sklearnex-built
+          path: ${{ github.workspace }}\venv\Lib\site-packages\sklearnex\
       - name: Install testing requirements
         run: |
           source venv/bin/activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,12 +270,12 @@ jobs:
       - name: Upload built daal4py
         uses: actions/upload-artifact@v4
         with:
-          name: daal4py-built
+          name: daal4py-built-lkg
           path: ${{ github.workspace }}\venv\Lib\site-packages\daal4py\
       - name: Upload built scikit-learn-intelex
         uses: actions/upload-artifact@v4
         with:
-          name: sklearnex-built
+          name: sklearnex-built-lkg
           path: ${{ github.workspace }}\venv\Lib\site-packages\sklearnex\
       - name: Install testing requirements
         shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           OTHER_REPO="uxlfoundation/oneDAL"
-          TEST_SHA=f5675593f18f95169ab386fab85878bdf7bf74b6
+          TEST_SHA=d24dff54e37e597e517bb924370a182370ca9d96
           echo "Getting run for hardcoded commit hash ${TEST_SHA}"
           WF_NAME="Nightly-build"
           JQ_QUERY="map(select(.event == \"workflow_dispatch\" or .event == \"schedule\" and .headSha == \"${TEST_SHA}\")) | .[0].databaseId"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,16 +118,6 @@ jobs:
           source venv/bin/activate
           source .github/scripts/activate_components.sh ${{ steps.set-env.outputs.DPCFLAG }}
           python setup.py install --single-version-externally-managed --record=record.txt
-      - name: Upload built daal4py
-        uses: actions/upload-artifact@v4
-        with:
-          name: daal4py-built
-          path: ${{ github.workspace }}\venv\Lib\site-packages\daal4py\
-      - name: Upload built scikit-learn-intelex
-        uses: actions/upload-artifact@v4
-        with:
-          name: sklearnex-built
-          path: ${{ github.workspace }}\venv\Lib\site-packages\sklearnex\
       - name: Install testing requirements
         run: |
           source venv/bin/activate
@@ -277,6 +267,16 @@ jobs:
           set PREFIX=.
           set PYTHON=python
           call .\conda-recipe\bld.bat
+      - name: Upload built daal4py
+        uses: actions/upload-artifact@v4
+        with:
+          name: daal4py-built
+          path: ${{ github.workspace }}\venv\Lib\site-packages\daal4py\
+      - name: Upload built scikit-learn-intelex
+        uses: actions/upload-artifact@v4
+        with:
+          name: sklearnex-built
+          path: ${{ github.workspace }}\venv\Lib\site-packages\sklearnex\
       - name: Install testing requirements
         shell: cmd
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,12 +287,6 @@ jobs:
         with:
           name: sklearnex-built
           path: ${{ github.workspace }}\venv\Lib\site-packages\sklearnex\
-      - name: TMP-DEBUG Test import
-        shell: cmd
-        run: |
-          call .\venv\Scripts\activate.bat
-          call .\.github\scripts\activate_components.bat ${{ steps.set-env.outputs.DPCFLAG }}
-          python -m "import daal4py" || echo IMPORT FAILED
 
       - name: Sklearnex testing
         shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,11 +267,11 @@ jobs:
           set PREFIX=.
           set PYTHON=python
           call .\conda-recipe\bld.bat
-      - name: Upload site-packages
+      - name: Upload venv
         uses: actions/upload-artifact@v4
         with:
-          name: daal4py-built-lkg
-          path: ${{ github.workspace }}\venv\Lib\site-packages-${{ matrix.PYTHON_VERSION }}
+          name: venv-${{ matrix.PYTHON_VERSION }}-${{ matrix.SKLEARN_VERSION }}
+          path: ${{ github.workspace }}\venv
       - name: Install testing requirements
         shell: cmd
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,9 +187,11 @@ jobs:
         shell: bash
         run: |
           OTHER_REPO="uxlfoundation/oneDAL"
+          TEST_SHA=20f5343b2448ac53d4a322c9fd73a4f2efee03d3
+          echo "Getting run for hardcoded commit hash ${TEST_SHA}"
           WF_NAME="Nightly-build"
-          JQ_QUERY='map(select(.event == "workflow_dispatch" or .event == "schedule")) | .[0].databaseId'
-          RUN_ID=$(gh run --repo ${OTHER_REPO} list --workflow "${WF_NAME}" --json databaseId,event --status success --jq "${JQ_QUERY}")
+          JQ_QUERY="map(select(.event == \"workflow_dispatch\" or .event == \"schedule\" and .headSha == \"${TEST_SHA}\")) | .[0].databaseId"
+          RUN_ID=$(gh run --repo ${OTHER_REPO} list --workflow "${WF_NAME}" --json databaseId,event,headSha --status success --jq "${JQ_QUERY}")
           echo "Detected latest run id of ${RUN_ID} for workflow ${WF_NAME}"
           echo "run-id=${RUN_ID}" >> "$GITHUB_OUTPUT"
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@
 name: CI
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   push:
     branches:
       - main
@@ -56,7 +56,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.PYTHON_VERSION }}  
+          python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Get run ID of "Nightly-build" workflow
         id: get-run-id
         run: |
@@ -251,7 +251,7 @@ jobs:
           pip install cpufeature clang-format pyyaml
           pip install -r dependencies-dev
           for /f "delims=" %%c in ('python -m pip freeze ^| grep numpy') do echo NUMPY_BUILD=%%c>> %GITHUB_ENV%
-      - name: System info 
+      - name: System info
         shell: cmd
         run: |
           call .\venv\Scripts\activate.bat
@@ -276,6 +276,24 @@ jobs:
           pip install %SCIPY_VERSION%
           if "${{ steps.set-env.outputs.DPCFLAG }}"=="" pip install dpctl==${{ env.DPCTL_VERSION }} dpnp==${{ env.DPNP_VERSION }}
           pip list
+
+      - name: Upload built daal4py
+        uses: actions/upload-artifact@v3
+        with:
+          name: daal4py-built
+          path: ${{ github.workspace }}\venv\Lib\site-packages\daal4py\
+      - name: Upload built scikit-learn-intelex
+        uses: actions/upload-artifact@v3
+        with:
+          name: sklearnex-built
+          path: ${{ github.workspace }}\venv\Lib\site-packages\sklearnex\
+      - name: TMP-DEBUG Test import
+        shell: cmd
+        run: |
+          call .\venv\Scripts\activate.bat
+          call .\.github\scripts\activate_components.bat ${{ steps.set-env.outputs.DPCFLAG }}
+          python -m "import daal4py" || echo IMPORT FAILED
+
       - name: Sklearnex testing
         shell: cmd
         run: |
@@ -304,7 +322,7 @@ jobs:
         with:
           name: coverage_win_Py${{ matrix.PYTHON_VERSION }}_${{ matrix.SKLEARN_VERSION }}
           path: |
-             *_win${{ matrix.PYTHON_VERSION }}_${{ matrix.SKLEARN_VERSION }}.info
+            *_win${{ matrix.PYTHON_VERSION }}_${{ matrix.SKLEARN_VERSION }}.info
       - name: Sklearn testing [preview]
         shell: cmd
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           OTHER_REPO="uxlfoundation/oneDAL"
-          TEST_SHA=1f61d7edeb7fbbaf2083f08b333607af7c79fbbc
+          TEST_SHA=232ae24df1391f2cf78a5f9b51fbbfea34626e82
           echo "Getting run for hardcoded commit hash ${TEST_SHA}"
           WF_NAME="Nightly-build"
           JQ_QUERY="map(select(.event == \"workflow_dispatch\" or .event == \"schedule\" and .headSha == \"${TEST_SHA}\")) | .[0].databaseId"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           OTHER_REPO="uxlfoundation/oneDAL"
-          TEST_SHA=a4be1f12eb1c9f773dba7035cbafb5cf20db7a1e
+          TEST_SHA=f5675593f18f95169ab386fab85878bdf7bf74b6
           echo "Getting run for hardcoded commit hash ${TEST_SHA}"
           WF_NAME="Nightly-build"
           JQ_QUERY="map(select(.event == \"workflow_dispatch\" or .event == \"schedule\" and .headSha == \"${TEST_SHA}\")) | .[0].databaseId"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,11 +187,9 @@ jobs:
         shell: bash
         run: |
           OTHER_REPO="uxlfoundation/oneDAL"
-          LAST_KNOWN_GOOD=d20d38a244127a3109f5b7587a0109cbad4cac37
-          echo "Getting run for hardcoded commit hash ${LAST_KNOWN_GOOD}"
           WF_NAME="Nightly-build"
-          JQ_QUERY="map(select(.event == \"workflow_dispatch\" or .event == \"schedule\" and .headSha == \"${LAST_KNOWN_GOOD}\")) | .[0].databaseId"
-          RUN_ID=$(gh run --repo ${OTHER_REPO} list --workflow "${WF_NAME}" --json databaseId,event,headSha --status success --jq "${JQ_QUERY}")
+          JQ_QUERY='map(select(.event == "workflow_dispatch" or .event == "schedule")) | .[0].databaseId'
+          RUN_ID=$(gh run --repo ${OTHER_REPO} list --workflow "${WF_NAME}" --json databaseId,event --status success --jq "${JQ_QUERY}")
           echo "Detected latest run id of ${RUN_ID} for workflow ${WF_NAME}"
           echo "run-id=${RUN_ID}" >> "$GITHUB_OUTPUT"
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           OTHER_REPO="uxlfoundation/oneDAL"
-          TEST_SHA=a64f81c6f091bb1e7843aaf1126f094eeb2138e2
+          TEST_SHA=7b80aea04d7c19d7b431117f4421a1f5ea113a3e
           echo "Getting run for hardcoded commit hash ${TEST_SHA}"
           WF_NAME="Nightly-build"
           JQ_QUERY="map(select(.event == \"workflow_dispatch\" or .event == \"schedule\" and .headSha == \"${TEST_SHA}\")) | .[0].databaseId"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
-      - name: FIXME Get run ID of "Nightly-build" workflow
+      - name: Get run ID of "Nightly-build" workflow
         id: get-run-id
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,16 +267,11 @@ jobs:
           set PREFIX=.
           set PYTHON=python
           call .\conda-recipe\bld.bat
-      - name: Upload built daal4py
+      - name: Upload site-packages
         uses: actions/upload-artifact@v4
         with:
           name: daal4py-built-lkg
-          path: ${{ github.workspace }}\venv\Lib\site-packages\daal4py\
-      - name: Upload built scikit-learn-intelex
-        uses: actions/upload-artifact@v4
-        with:
-          name: sklearnex-built-lkg
-          path: ${{ github.workspace }}\venv\Lib\site-packages\sklearnex\
+          path: ${{ github.workspace }}\venv\Lib\site-packages-${{ matrix.PYTHON_VERSION }}
       - name: Install testing requirements
         shell: cmd
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           OTHER_REPO="uxlfoundation/oneDAL"
-          TEST_SHA=20f5343b2448ac53d4a322c9fd73a4f2efee03d3
+          TEST_SHA=1f61d7edeb7fbbaf2083f08b333607af7c79fbbc
           echo "Getting run for hardcoded commit hash ${TEST_SHA}"
           WF_NAME="Nightly-build"
           JQ_QUERY="map(select(.event == \"workflow_dispatch\" or .event == \"schedule\" and .headSha == \"${TEST_SHA}\")) | .[0].databaseId"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,14 +182,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
-      - name: Get run ID of "Nightly-build" workflow
+      - name: FIXME Get run ID of "Nightly-build" workflow
         id: get-run-id
         shell: bash
         run: |
           OTHER_REPO="uxlfoundation/oneDAL"
+          LAST_KNOWN_GOOD=d20d38a244127a3109f5b7587a0109cbad4cac37
+          echo "Getting run for hardcoded commit hash ${LAST_KNOWN_GOOD}"
           WF_NAME="Nightly-build"
-          JQ_QUERY='map(select(.event == "workflow_dispatch" or .event == "schedule")) | .[0].databaseId'
-          RUN_ID=`gh run --repo ${OTHER_REPO} list --workflow "${WF_NAME}" --json databaseId,event --status success --jq "${JQ_QUERY}"`
+          JQ_QUERY="map(select(.event == \"workflow_dispatch\" or .event == \"schedule\" and .headSha == \"${LAST_KNOWN_GOOD}\")) | .[0].databaseId"
+          RUN_ID=$(gh run --repo ${OTHER_REPO} list --workflow "${WF_NAME}" --json databaseId,event,headSha --status success --jq "${JQ_QUERY}")
           echo "Detected latest run id of ${RUN_ID} for workflow ${WF_NAME}"
           echo "run-id=${RUN_ID}" >> "$GITHUB_OUTPUT"
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,11 @@ jobs:
         with:
           name: sklearnex-built
           path: ${{ github.workspace }}\venv\Lib\site-packages\sklearnex\
+      - name: Import test
+        shell: cmd
+        run: |
+          call .\venv\Scripts\activate.bat
+          python -c "from sklearnex import patch_sklearn;patch_sklearn()"
 
       - name: Sklearnex testing
         shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,24 +278,6 @@ jobs:
           pip install %SCIPY_VERSION%
           if "${{ steps.set-env.outputs.DPCFLAG }}"=="" pip install dpctl==${{ env.DPCTL_VERSION }} dpnp==${{ env.DPNP_VERSION }}
           pip list
-
-      - name: Upload built daal4py
-        uses: actions/upload-artifact@v4
-        with:
-          name: daal4py-built
-          path: ${{ github.workspace }}\venv\Lib\site-packages\daal4py\
-      - name: Upload built scikit-learn-intelex
-        uses: actions/upload-artifact@v4
-        with:
-          name: sklearnex-built
-          path: ${{ github.workspace }}\venv\Lib\site-packages\sklearnex\
-      - name: Import test
-        shell: cmd
-        run: |
-          call .\venv\Scripts\activate.bat
-          cd ..
-          python -c "from sklearnex import patch_sklearn;patch_sklearn()"
-
       - name: Sklearnex testing
         shell: cmd
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           OTHER_REPO="uxlfoundation/oneDAL"
-          TEST_SHA=232ae24df1391f2cf78a5f9b51fbbfea34626e82
+          TEST_SHA=40377a345d2efd9b455411d973589e820f95786d
           echo "Getting run for hardcoded commit hash ${TEST_SHA}"
           WF_NAME="Nightly-build"
           JQ_QUERY="map(select(.event == \"workflow_dispatch\" or .event == \"schedule\" and .headSha == \"${TEST_SHA}\")) | .[0].databaseId"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,7 @@ jobs:
         shell: cmd
         run: |
           call .\venv\Scripts\activate.bat
+          cd ..
           python -c "from sklearnex import patch_sklearn;patch_sklearn()"
 
       - name: Sklearnex testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           OTHER_REPO="uxlfoundation/oneDAL"
-          TEST_SHA=d24dff54e37e597e517bb924370a182370ca9d96
+          TEST_SHA=a64f81c6f091bb1e7843aaf1126f094eeb2138e2
           echo "Getting run for hardcoded commit hash ${TEST_SHA}"
           WF_NAME="Nightly-build"
           JQ_QUERY="map(select(.event == \"workflow_dispatch\" or .event == \"schedule\" and .headSha == \"${TEST_SHA}\")) | .[0].databaseId"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           OTHER_REPO="uxlfoundation/oneDAL"
-          TEST_SHA=90231e8a58f9db9cc7a5f68d396ae69bbb6eb85e
+          TEST_SHA=a4be1f12eb1c9f773dba7035cbafb5cf20db7a1e
           echo "Getting run for hardcoded commit hash ${TEST_SHA}"
           WF_NAME="Nightly-build"
           JQ_QUERY="map(select(.event == \"workflow_dispatch\" or .event == \"schedule\" and .headSha == \"${TEST_SHA}\")) | .[0].databaseId"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         shell: bash
         run: |
           OTHER_REPO="uxlfoundation/oneDAL"
-          TEST_SHA=40377a345d2efd9b455411d973589e820f95786d
+          TEST_SHA=90231e8a58f9db9cc7a5f68d396ae69bbb6eb85e
           echo "Getting run for hardcoded commit hash ${TEST_SHA}"
           WF_NAME="Nightly-build"
           JQ_QUERY="map(select(.event == \"workflow_dispatch\" or .event == \"schedule\" and .headSha == \"${TEST_SHA}\")) | .[0].databaseId"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,12 +278,12 @@ jobs:
           pip list
 
       - name: Upload built daal4py
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: daal4py-built
           path: ${{ github.workspace }}\venv\Lib\site-packages\daal4py\
       - name: Upload built scikit-learn-intelex
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sklearnex-built
           path: ${{ github.workspace }}\venv\Lib\site-packages\sklearnex\

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -59,7 +59,7 @@ try:
         _get__daal_run_version__,
         _get__version__,
     )
-except ImportError as e:
+except Exception as e:
     import sys
 
     sys.stderr.write("AHUBER HELLO")

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -35,7 +35,7 @@ if "Windows" in platform.system():
             dal_root = os.environ["DALROOT"]
             #print(f"DALROOT: {dal_root}")
             dal_root_redist = os.path.join(dal_root, "redist", arch_dir)
-            print(f"Investigating {dal_root_redist}")
+            #print(f"Investigating {dal_root_redist}")
             if os.path.exists(dal_root_redist):
                 print(f"Dir exists, adding to PATH")
                 # List all the files

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -16,7 +16,6 @@
 # ==============================================================================
 
 import platform
-import traceback
 
 if "Windows" in platform.system():
     import os
@@ -59,12 +58,7 @@ try:
         _get__daal_run_version__,
         _get__version__,
     )
-except Exception as e:
-    import sys
-
-    sys.stderr.write("AHUBER HELLO")
-    traceback.print_exc(file=sys.stderr)
-    sys.stderr.flush()
+except ImportError as e:
     s = str(e)
     if "libfabric" in s:
         raise ImportError(

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -29,22 +29,13 @@ if "Windows" in platform.system():
     current_path = os.path.dirname(__file__)
     path_to_env = site.getsitepackages()[0]
     path_to_libs = os.path.join(path_to_env, "Library", "bin")
-    #print(f"PATH to libs: {path_to_libs}")
     if sys.version_info.minor >= 8:
         if "DALROOT" in os.environ:
             dal_root = os.environ["DALROOT"]
-            #print(f"DALROOT: {dal_root}")
             dal_root_redist = os.path.join(dal_root, "redist", arch_dir)
-            #print(f"Investigating {dal_root_redist}")
             if os.path.exists(dal_root_redist):
-                #print(f"Dir exists, adding to PATH")
-                # List all the files
-                #print("Files in dir: ", os.listdir(dal_root_redist))
-                #os.listdir(dal_root_redist)
                 os.add_dll_directory(dal_root_redist)
                 os.environ["PATH"] = dal_root_redist + os.pathsep + os.environ["PATH"]
-            #else:
-            #    print(f"Dir does not exist, skipping")
         if "TBBROOT" in os.environ:
             tbb_root = os.environ["TBBROOT"]
             tbb_root_redist = os.path.join(tbb_root, "bin")

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -29,13 +29,19 @@ if "Windows" in platform.system():
     current_path = os.path.dirname(__file__)
     path_to_env = site.getsitepackages()[0]
     path_to_libs = os.path.join(path_to_env, "Library", "bin")
+    print(f"PATH to libs: {path_to_libs}")
     if sys.version_info.minor >= 8:
         if "DALROOT" in os.environ:
             dal_root = os.environ["DALROOT"]
+            print(f"DALROOT: {dal_root}")
             dal_root_redist = os.path.join(dal_root, "redist", arch_dir)
+            print(f"Investigating {dal_root_redist}")
             if os.path.exists(dal_root_redist):
+                print(f"Dir exists, adding to PATH")
                 os.add_dll_directory(dal_root_redist)
                 os.environ["PATH"] = dal_root_redist + os.pathsep + os.environ["PATH"]
+            else:
+                print(f"Dir does not exist, skipping")
         if "TBBROOT" in os.environ:
             tbb_root = os.environ["TBBROOT"]
             tbb_root_redist = os.path.join(tbb_root, "bin")

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -29,7 +29,7 @@ if "Windows" in platform.system():
     current_path = os.path.dirname(__file__)
     path_to_env = site.getsitepackages()[0]
     path_to_libs = os.path.join(path_to_env, "Library", "bin")
-    print(f"PATH to libs: {path_to_libs}")
+    #print(f"PATH to libs: {path_to_libs}")
     if sys.version_info.minor >= 8:
         if "DALROOT" in os.environ:
             dal_root = os.environ["DALROOT"]

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -38,6 +38,9 @@ if "Windows" in platform.system():
             print(f"Investigating {dal_root_redist}")
             if os.path.exists(dal_root_redist):
                 print(f"Dir exists, adding to PATH")
+                # List all the files
+                print("Files in dir: ", os.listdir(dal_root_redist))
+                os.listdir(dal_root_redist)
                 os.add_dll_directory(dal_root_redist)
                 os.environ["PATH"] = dal_root_redist + os.pathsep + os.environ["PATH"]
             else:

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -43,8 +43,8 @@ if "Windows" in platform.system():
                 os.listdir(dal_root_redist)
                 os.add_dll_directory(dal_root_redist)
                 os.environ["PATH"] = dal_root_redist + os.pathsep + os.environ["PATH"]
-            else:
-                print(f"Dir does not exist, skipping")
+            #else:
+            #    print(f"Dir does not exist, skipping")
         if "TBBROOT" in os.environ:
             tbb_root = os.environ["TBBROOT"]
             tbb_root_redist = os.path.join(tbb_root, "bin")

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -33,7 +33,7 @@ if "Windows" in platform.system():
     if sys.version_info.minor >= 8:
         if "DALROOT" in os.environ:
             dal_root = os.environ["DALROOT"]
-            print(f"DALROOT: {dal_root}")
+            #print(f"DALROOT: {dal_root}")
             dal_root_redist = os.path.join(dal_root, "redist", arch_dir)
             print(f"Investigating {dal_root_redist}")
             if os.path.exists(dal_root_redist):

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -37,10 +37,10 @@ if "Windows" in platform.system():
             dal_root_redist = os.path.join(dal_root, "redist", arch_dir)
             #print(f"Investigating {dal_root_redist}")
             if os.path.exists(dal_root_redist):
-                print(f"Dir exists, adding to PATH")
+                #print(f"Dir exists, adding to PATH")
                 # List all the files
-                print("Files in dir: ", os.listdir(dal_root_redist))
-                os.listdir(dal_root_redist)
+                #print("Files in dir: ", os.listdir(dal_root_redist))
+                #os.listdir(dal_root_redist)
                 os.add_dll_directory(dal_root_redist)
                 os.environ["PATH"] = dal_root_redist + os.pathsep + os.environ["PATH"]
             #else:

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -16,6 +16,7 @@
 # ==============================================================================
 
 import platform
+import traceback
 
 if "Windows" in platform.system():
     import os
@@ -59,15 +60,17 @@ try:
         _get__version__,
     )
 except ImportError as e:
+    import sys
+
+    sys.stderr.write("AHUBER HELLO")
+    traceback.print_exc(file=sys.stderr)
+    sys.stderr.flush()
     s = str(e)
     if "libfabric" in s:
         raise ImportError(
             s + "\n\nActivating your conda environment or sourcing mpivars."
             "[c]sh/psxevars.[c]sh may solve the issue.\n"
         )
-    import traceback
-
-    traceback.print_exc()
 
     raise
 

--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -65,6 +65,9 @@ except ImportError as e:
             s + "\n\nActivating your conda environment or sourcing mpivars."
             "[c]sh/psxevars.[c]sh may solve the issue.\n"
         )
+    import traceback
+
+    traceback.print_exc()
 
     raise
 

--- a/daal4py/sklearn/monkeypatch/tests/test_patching.py
+++ b/daal4py/sklearn/monkeypatch/tests/test_patching.py
@@ -37,17 +37,33 @@ def get_branch(s):
 
 
 def run_parse(mas, result):
-    name, dtype = mas[0].split()
+    print("\n[run_parse] mas:")
+    for idx, val in enumerate(mas):
+        print(f"  mas[{idx}] = {val!r}")
+
+    try:
+        name, dtype = mas[0].split()
+        print(f"[run_parse] Parsed name = {name}, dtype = {dtype}")
+    except ValueError as e:
+        print(f"[run_parse] ERROR while splitting mas[0]: {mas[0]!r}")
+        print(f"[run_parse] .split() gives: {mas[0].split()}")
+        raise
+
     temp = []
     INFO_POS = 6
     for i in range(1, len(mas)):
-        mas[i] = mas[i][INFO_POS:]  # remove 'INFO: '
+        print(f"[run_parse] Processing mas[{i}]: {mas[i]!r}")
+        mas[i] = mas[i][INFO_POS:]
+        print(f"[run_parse] After trimming INFO: {mas[i]!r}")
         if not mas[i].startswith("sklearn"):
             ind = name + " " + dtype + " " + mas[i]
-            result[ind] = get_branch(temp)
+            branch = get_branch(temp)
+            print(f"[run_parse] Adding result: {ind!r} => {branch}")
+            result[ind] = branch
             temp.clear()
         else:
             temp.append(mas[i])
+            print(f"[run_parse] Appended to temp: {temp!r}")
 
 
 def get_result_log():
@@ -61,13 +77,20 @@ def get_result_log():
             ]
         )
     except subprocess.CalledProcessError as e:
+        print("[get_result_log] Subprocess failed:")
         print(e)
         exit(1)
 
     mas = []
     result = {}
-    for i in process.decode().split("\n"):
+    decoded = process.decode().split("\n")
+    print("[get_result_log] Process output:")
+    for line in decoded:
+        print(f"  {line!r}")
+
+    for i in decoded:
         if not i.startswith("INFO") and len(mas) != 0:
+            print(f"[get_result_log] Switching block at line: {i!r}")
             run_parse(mas, result)
             mas.clear()
             mas.append(i.strip())


### PR DESCRIPTION
While investigating the Windows CI fails, likely introduced by https://github.com/uxlfoundation/oneDAL/pull/3155, use a last known good commit hash for checks in this repository.