### PR TITLE
DOC: Configure single backticks to render as code to mimic sklearn

### DIFF
--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -129,6 +129,11 @@ rst_prolog = """
 .. |onedal| replace:: oneAPI Data Analytics Library
 """
 
+# Note: sklearn oftentimes uses single backticks to render code.
+# Some docstrings here are inherited from theirs, so this setting
+# is needed to render them the same way they do.
+default_role = "literal"
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
## Description

ref https://github.com/uxlfoundation/scikit-learn-intelex/pull/2455

Some docstrings in sklearnex are inherited from sklearn, and we'd like to have them rendered the same as sklearn's own docs.

But throughout many places, they use single backticks to format code, together with a non-default setting for Sphinx that makes it interpret them as such.

This PR changes the setting to mimic sklearn's, so that docstrings inherited from them would render correctly in our docs.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
