### PR TITLE
FIX: Revert location of versions.json

### DIFF
--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -160,7 +160,7 @@ html_theme_options = {
 html_context = {
     "current_version": version,
     "project_name": "scikit-learn-intelex",
-    "switcher_url": "/scikit-learn-intelex/doc/versions.json",
+    "switcher_url": "/scikit-learn-intelex/versions.json",
 }
 
 


### PR DESCRIPTION
## Description

ref https://github.com/uxlfoundation/scikit-learn-intelex/pull/2471#issuecomment-2870977578

This PR moves the location of the version switcher json file to where older doc versions expect it to be, so that it would work on all versions.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
