### PR TITLE
Migrate to modern NumPy interface

### DIFF
--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -93,7 +93,7 @@ def _compute_class_weight(class_weight, classes, y):
 
         le = LabelEncoder()
         y_ind = le.fit_transform(y_)
-        if not all(np.isin(classes, le.classes_)):
+        if not np.isin(classes, le.classes_).all():
             raise ValueError("classes should have valid labels that are in y")
 
         y_bin = np.bincount(y_ind).astype(np.float64)

--- a/onedal/utils/validation.py
+++ b/onedal/utils/validation.py
@@ -93,7 +93,7 @@ def _compute_class_weight(class_weight, classes, y):
 
         le = LabelEncoder()
         y_ind = le.fit_transform(y_)
-        if not all(np.in1d(classes, le.classes_)):
+        if not all(np.isin(classes, le.classes_)):
             raise ValueError("classes should have valid labels that are in y")
 
         y_bin = np.bincount(y_ind).astype(np.float64)

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -233,7 +233,7 @@ class BaseSVC(BaseSVM):
 
         le = LabelEncoder()
         y_ind = le.fit_transform(y_)
-        if not all(np.isin(classes, le.classes_)):
+        if not np.isin(classes, le.classes_).all():
             raise ValueError("classes should have valid labels that are in y")
 
         recip_freq = len(y_) / (len(le.classes_) * np.bincount(y_ind).astype(np.float64))

--- a/sklearnex/svm/_common.py
+++ b/sklearnex/svm/_common.py
@@ -233,7 +233,7 @@ class BaseSVC(BaseSVM):
 
         le = LabelEncoder()
         y_ind = le.fit_transform(y_)
-        if not all(np.in1d(classes, le.classes_)):
+        if not all(np.isin(classes, le.classes_)):
             raise ValueError("classes should have valid labels that are in y")
 
         recip_freq = len(y_) / (len(le.classes_) * np.bincount(y_ind).astype(np.float64))


### PR DESCRIPTION
## Description
This small PR resolves deprecation warnings caused by the use of `numpy.in1d`:
```python
DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
```
Please note that `in1d` is deprecated from NumPy 1.19.0 and removed in 2.0.0. `isin` available since Python 1.13.0.


---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
