### PR TITLE
fix: add cstdint include to transceiver for public CI

### DIFF
--- a/src/transceiver.h
+++ b/src/transceiver.h
@@ -40,6 +40,7 @@
 #include <memory>
 #include <iostream>
 #include <cassert>
+#include <cstdint>
 #include "daal4py_defines.h"
 
 // Abstract class with minimal functionality needed for communicating between processes.


### PR DESCRIPTION
## Description

Fixes public CI Linux Conda Recipe error: 'uint8_t' was not declared in this scope (amongst others). Exact origin of this is unclear, but this fixes.

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.
