### PR TITLE
[CI] temporarily deselect ```test_dbscan_params_validation``` for green CI

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -317,6 +317,10 @@ deselected_tests:
   # are respected.
   - tests/test_common.py::test_valid_tag_types <1.6
 
+  # Parameter validation test dbscan only in sklearn 1.1, this is temporary deselected before update
+  # to CI parameters, as parameter validation is globally handeled in sklearn version 1.2 onward
+  - cluster/tests/test_dbscan.py::test_dbscan_params_validation
+
   # --------------------------------------------------------
   # No need to test daal4py patching
 reduced_tests:

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -318,7 +318,7 @@ deselected_tests:
   - tests/test_common.py::test_valid_tag_types <1.6
 
   # Parameter validation test dbscan only in sklearn 1.1, this is temporary deselected before update
-  # to CI parameters, as parameter validation is globally handeled in sklearn version 1.2 onward
+  # to CI parameters, as parameter validation is globally handled in sklearn version 1.2 onward
   - cluster/tests/test_dbscan.py::test_dbscan_params_validation
 
   # --------------------------------------------------------


### PR DESCRIPTION
## Description

This test ```test_dbscan_params_validation``` is only available in sklearn 1.1 (https://github.com/scikit-learn/scikit-learn/blob/1.1.X/sklearn/cluster/tests/test_dbscan.py#L457, a no-longer sklearnex-supported sklearn version). This test validates a capability for DBSCAN which is available in 1.1 before the sklearn introduction of parameter_constraints in all estimators in sklearn 1.2 (and therefore this test is removed in 1.2).  This deselects the test before updating the github actions CI test matrix (which will occur in #2495) in order to get a green CI. 

No performance benchmarks necessary.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
