### PR TITLE
DOC: Fix incorrect italics formatting

### DIFF
--- a/doc/sources/quick-start.rst
+++ b/doc/sources/quick-start.rst
@@ -34,7 +34,7 @@ Patching
 **********************
 
 Once you install the |sklearnex|, you can replace estimator classes (algorithms) that exist in the ``sklearn`` module from |sklearn| with their optimized versions from the extension.
-This action is called `patching` or `monkey patching <https://en.wikipedia.org/wiki/Monkey_patch>`__. This is not a permanent change so you can always undo the patching if necessary.
+This action is called *patching* or `monkey patching <https://en.wikipedia.org/wiki/Monkey_patch>`__. This is not a permanent change so you can always undo the patching if necessary.
 
 To patch |sklearn| with the |sklearnex|, the following methods can be used:
 
@@ -161,7 +161,7 @@ With global patching, you can:
 Unpatching
 **********************
 
-To undo the patch (also called `unpatching`) is to return the ``sklearn`` module to the original implementation and
+To undo the patch (also called *unpatching*) is to return the ``sklearn`` module to the original implementation and
 replace patched estimators with the stock |sklearn| estimators.
 
 To unpatch successfully, you must reimport the ``sklearn`` module(s)::


### PR DESCRIPTION
## Description

After previous PR: https://github.com/uxlfoundation/scikit-learn-intelex/pull/2466

Backticks in docs are now configured to render as code instead of italics in order to render docstrings inherited from sklearn correctly (since they use that setting too), but some pages throughout docs were using single backticks to format as italics, which is now rendering as code.

This PR fixes those cases to use asterisks, in order to ensure that they render as italics when they were meant to.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
