### PR TITLE
Add check warning to build-doc.sh

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Set Up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
-        python-version: "3.11"
+        python-version: "3.13"
 
     - name: Install System Dependencies
       run: sudo apt-get update && sudo apt-get install -y clang-format pandoc

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Set Up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
-        python-version: "3.13"
+        python-version: "3.11"
 
     - name: Install System Dependencies
       run: sudo apt-get update && sudo apt-get install -y clang-format pandoc

--- a/doc/build-doc.sh
+++ b/doc/build-doc.sh
@@ -48,7 +48,7 @@ if [[ "$*" == *"--gh-pages"* ]]; then
     export BUILDDIR=_build
     export SOURCEDIR=sources
 
-    sphinx-build -b html $SOURCEDIR $BUILDDIR/$SPHINXPROJ/$DOC_VERSION
+    sphinx-build -b html $SPHINXOPTS $SOURCEDIR $BUILDDIR/$SPHINXPROJ/$DOC_VERSION
     echo "<meta http-equiv=\"refresh\" content=\"0; URL='/$SPHINXPROJ/$DOC_VERSION/'\" / >" >> $BUILDDIR/$SPHINXPROJ/index.html
 else
     make html


### PR DESCRIPTION
## Description

One line change to build-doc.sh to add missing warning check flag

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.