### PR TITLE
MAINT: Don't make inapplicable conditions block oneDAL usage in LogisticRegression

### DIFF
--- a/sklearnex/linear_model/logistic_regression.py
+++ b/sklearnex/linear_model/logistic_regression.py
@@ -208,12 +208,11 @@ if daal_check_version((2024, "P", 1)):
                     ),
                     (self.class_weight is None, "Class weight is not supported"),
                     (self.solver == "newton-cg", "Only newton-cg solver is supported."),
-                    (
-                        self.multi_class != "multinomial",
-                        "multi_class parameter is not supported.",
-                    ),
                     (self.warm_start == False, "Warm start is not supported."),
-                    (self.l1_ratio is None, "l1 ratio is not supported."),
+                    (
+                        self.l1_ratio is None or self.l1_ratio == 0,
+                        "l1 ratio is not supported.",
+                    ),
                     (sample_weight is None, "Sample weight is not supported."),
                     (
                         target_type == "binary",


### PR DESCRIPTION
## Description

This PR modifies the checks for whether oneDAL will be supported for logistic regression so as not to block its usage in the following scenarios:
* Passing multi_class strategy argument when the data is binary (argument is ignored).
* Passing an l1 ratio of zero instead of not changing it from the default (it means 'don't apply L1 regularization').

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
