### PR TITLE
[CI] fix CI for green due to changes in sklearn 1.7 for CondaRecipe CI jobs

### DIFF
--- a/daal4py/sklearn/metrics/_pairwise.py
+++ b/daal4py/sklearn/metrics/_pairwise.py
@@ -17,6 +17,7 @@
 import warnings
 from functools import partial
 
+from joblib import effective_n_jobs
 import numpy as np
 from sklearn.exceptions import DataConversionWarning
 from sklearn.metrics import pairwise_distances as pairwise_distances_original
@@ -28,7 +29,6 @@ from sklearn.metrics.pairwise import (
     _parallel_pairwise,
     check_pairwise_arrays,
 )
-from sklearn.utils._joblib import effective_n_jobs
 from sklearn.utils.validation import check_non_negative
 
 try:


### PR DESCRIPTION
## Description

For all supported sklearn versions, ```sklearn.utils._joblib``` imports ```effective_n_jobs``` directly from joblib.  While this file is removed in sklearn1.7, we can instead import it from ```joblib``` directly.

This has overlap with #2451, but as that PR is not in a mergable state, this will get CI green in a timely manner for continued development.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
