### PR TITLE
FIX: Don't forcibly add `-s` to debug builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -309,9 +309,13 @@ def get_build_options():
         ela.append("-Wl,-rpath,@loader_path/../../../")
     elif IS_WIN:
         ela.append("-IGNORE:4197")
-    elif IS_LIN and not any(
-        x in os.environ and "-g" in os.environ[x]
-        for x in ["CPPFLAGS", "CFLAGS", "LDFLAGS"]
+    elif (
+        IS_LIN
+        and not any(
+            x in os.environ and "-g" in os.environ[x]
+            for x in ["CPPFLAGS", "CFLAGS", "CXXFLAGS", "CC", "CXX", "LDFLAGS"]
+        )
+        and not USE_ABS_RPATH
     ):
         ela.append("-s")
     if IS_LIN:


### PR DESCRIPTION
## Description

This PR avoids adding the `-s` flag when `-g` is used, or when the modules are built with absolute rpaths for oneDAL, which is only in internal non-release builds.

Flag `-s` strips debug information, which makes it harder to investigate issues. There is currently a mechanism to detect `-g` flag and avoid adding `-s` if so, but it doesn't work correctly. This PR extends it to be able to work in more situations.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
