### PR TITLE
[CI] Centralize clang-format install to dependencies-dev

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #===============================================================================
 steps:
-  - script: sudo apt-get update && sudo apt-get install -y clang-format
+  - script: sudo apt-get update
     displayName: "apt-get"
   - script: |
       bash .ci/scripts/install_dpcpp.sh

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -16,7 +16,7 @@
 steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
-  - script: conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) impi-devel clang-format pyyaml
+  - script: conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) impi-devel pyyaml
     displayName: 'Create Anaconda environment'
   - script: |
       call activate CB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           echo "COVERAGE_RCFILE=$(readlink -f .coveragerc)" >> "$GITHUB_ENV"
           if [[ -z $DPCFLAG ]]; then echo "SKLEARNEX_GCOV=1" >> "$GITHUB_ENV"; fi
       - name: apt-get
-        run: sudo apt-get update && sudo apt-get install -y clang-format
+        run: sudo apt-get update
       - name: dpcpp installation
         run: |
           # This CI system yields oneAPI dependencies from the oneDAL repository
@@ -248,7 +248,7 @@ jobs:
           python -m venv venv
           call .\venv\Scripts\activate.bat
           pip install --upgrade setuptools
-          pip install cpufeature clang-format pyyaml
+          pip install cpufeature pyyaml
           pip install -r dependencies-dev
           for /f "delims=" %%c in ('python -m pip freeze ^| grep numpy') do echo NUMPY_BUILD=%%c>> %GITHUB_ENV%
       - name: System info 

--- a/dependencies-dev
+++ b/dependencies-dev
@@ -6,4 +6,4 @@ numpy==2.3.0 ; python_version >= '3.11'
 pybind11==2.13.6
 cmake==4.0.2
 setuptools==79.0.1
-clang-format==20.1.6
+clang-format==14.0.6

--- a/dependencies-dev
+++ b/dependencies-dev
@@ -6,3 +6,4 @@ numpy==2.3.0 ; python_version >= '3.11'
 pybind11==2.13.6
 cmake==4.0.2
 setuptools==79.0.1
+clang-format==20.1.6


### PR DESCRIPTION
## Description

Clang-format is a requirement for building daal4py and therefore sklearnex (https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/INSTALL.md#build-from-sources ), but as noted by @ahuber21 it isn't in our ```dependencies-dev``` list, which makes seamless environment creation to builds annoying.

Clang-format is available via PyPI (https://pypi.org/project/clang-format/) and should probably be taken from there instead.  We currently already acquire it for use in .pre-commit-config via PyPI.

One question to reviewers is whether we go always with the most modern version, or if we should set it to what is used in the pre-commit hook.

All other extractions (via conda etc) are removed from the non-CondaRecipes CI jobs. This will require a private CI run to verify impact there.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
