### PR TITLE
[WIP, CI] remove dpctl dependency from onedal/tests/utils/_device_selection.py

### DIFF
--- a/onedal/tests/utils/_device_selection.py
+++ b/onedal/tests/utils/_device_selection.py
@@ -37,7 +37,7 @@ def get_queues(filter_="cpu,gpu": str) -> list[SyclQueue]:
     Returns
     -------
     list[SyclQueue]
-        The list of SycQueues.
+        The list of SyclQueues.
 
     Notes
     -----

--- a/onedal/tests/utils/_device_selection.py
+++ b/onedal/tests/utils/_device_selection.py
@@ -21,7 +21,7 @@ import pytest
 from onedal.utils._third_party import dpctl_available, SyclQueue
 
 # lru_cache is used to limit the number of SyclQueues generated
-@functools.lru_cache(maxsize=100)
+@functools.lru_cache()
 def get_queues(filter_="cpu,gpu": str) -> list[SyclQueue]:
     """Get available dpctl.SycQueues for testing.
 

--- a/onedal/tests/utils/_device_selection.py
+++ b/onedal/tests/utils/_device_selection.py
@@ -31,8 +31,8 @@ def get_queues(filter_="cpu,gpu": str) -> list[SyclQueue]:
     ----------
     filter_ : str, default="cpu,gpu"
         Configure output list with availabe SycQueues for testing.
-        SyclQueues are generated from a comma-separated string following
-        SYCL's ``filter_selector``.
+        SyclQueues are generated from a comma-separated string with
+        each element conforming to SYCL's ``filter_selector``.
 
     Returns
     -------

--- a/onedal/tests/utils/_device_selection.py
+++ b/onedal/tests/utils/_device_selection.py
@@ -30,7 +30,9 @@ def get_queues(filter_="cpu,gpu": str) -> list[SyclQueue]:
     Parameters
     ----------
     filter_ : str, default="cpu,gpu"
-        Configure output list with available dpctl.SycQueues for testing.
+        Configure output list with availabe SycQueues for testing.
+        SyclQueues are generated from a comma-separated string following
+        SYCL's ``filter_selector``.
 
     Returns
     -------
@@ -44,12 +46,11 @@ def get_queues(filter_="cpu,gpu": str) -> list[SyclQueue]:
     """
     queues = [None] if "cpu" in filter_ else []
 
-    for i in ["cpu", "gpu"]:
-        if i in filter_:
-            try:
-                queues.append(pytest.param(SyclQueue(i), id=f"SyclQueue_{i.upper()}"))
-            except [RuntimeError, ValueError]:
-                pass
+    for i in filter_.split(","):
+        try:
+            queues.append(pytest.param(SyclQueue(i), id=f"SyclQueue_{i.upper()}"))
+        except [RuntimeError, ValueError]:
+            pass
 
     return queues
 

--- a/onedal/tests/utils/_device_selection.py
+++ b/onedal/tests/utils/_device_selection.py
@@ -36,8 +36,8 @@ def get_queues(filter_="cpu,gpu": str) -> list[SyclQueue]:
 
     Returns
     -------
-    list[dpctl.SycQueue]
-        The list of dpctl.SycQueue.
+    list[SyclQueue]
+        The list of SycQueues.
 
     Notes
     -----

--- a/sklearnex/tests/test_config.py
+++ b/sklearnex/tests/test_config.py
@@ -21,7 +21,7 @@ import sklearn
 
 import onedal
 import sklearnex
-from onedal.tests.utils._device_selection import is_dpctl_device_available
+from onedal.tests.utils._device_selection import is_sycl_device_available
 
 
 def test_get_config_contains_sklearn_params():
@@ -128,7 +128,7 @@ def test_config_context_works():
 
 
 @pytest.mark.skipif(
-    not is_dpctl_device_available(["gpu"]), reason="Requires a gpu for fallback testing"
+    not is_sycl_device_available(["gpu"]), reason="Requires a gpu for fallback testing"
 )
 def test_fallback_to_host(caplog):
     # force a fallback to cpu with direct use of dispatch and PatchingConditionsChain

--- a/sklearnex/tests/test_memory_usage.py
+++ b/sklearnex/tests/test_memory_usage.py
@@ -33,7 +33,7 @@ from onedal.tests.utils._dataframes_support import (
     _convert_to_dataframe,
     get_dataframes_and_queues,
 )
-from onedal.tests.utils._device_selection import get_queues, is_dpctl_device_available
+from onedal.tests.utils._device_selection import get_queues, is_sycl_device_available
 from onedal.utils._array_api import _get_sycl_namespace
 from onedal.utils._dpep_helpers import dpctl_available, dpnp_available
 from sklearnex import config_context
@@ -296,7 +296,7 @@ def test_memory_leaks(estimator, dataframe, queue, order, data_shape):
 
 
 @pytest.mark.skipif(
-    os.getenv("ZES_ENABLE_SYSMAN") is None or not is_dpctl_device_available(["gpu"]),
+    os.getenv("ZES_ENABLE_SYSMAN") is None or not is_sycl_device_available(["gpu"]),
     reason="SYCL device memory leak check requires the level zero sysman",
 )
 @pytest.mark.parametrize("queue", get_queues("gpu"))


### PR DESCRIPTION
## Description

Work in progress. Generalize GPU testing to work when dpctl is unavailable, but a SYCL device is.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
