### PR TITLE
[bugfix] fix array type issues in ```pca.inverse_transform``` without ```array_api_dispatch``` enabled 

### DIFF
--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -233,7 +233,7 @@ if daal_check_version((2024, "P", 100)):
                 # same device as the data (compute follows data).
                 components = xp.asarray(components, device=X.device)
                 mean = xp.asarray(mean, device=X.device)
-            print(type(mean),type(components))
+            print(type(mean), type(components))
             return X @ components + mean
 
         def _onedal_supported(self, method_name, X):

--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -224,7 +224,7 @@ if daal_check_version((2024, "P", 100)):
                 )
             else:
                 components = self.components_
-
+            print(_is_numpy_namespace(xp), type(X), type(mean), type(components))
             if not _is_numpy_namespace(xp):
                 # DPCtl and dpnp require inputs to be on the same device for
                 # matrix multiplication and division. The type and location
@@ -233,7 +233,7 @@ if daal_check_version((2024, "P", 100)):
                 # same device as the data (compute follows data).
                 components = xp.asarray(components, device=X.device)
                 mean = xp.asarray(mean, device=X.device)
-
+            print(type(mean),type(components))
             return X @ components + mean
 
         def _onedal_supported(self, method_name, X):

--- a/sklearnex/decomposition/pca.py
+++ b/sklearnex/decomposition/pca.py
@@ -213,9 +213,17 @@ if daal_check_version((2024, "P", 100)):
                 # Scikit-learn PCA["covariance_eigh"] was fit
                 return self._transform(X_fit, xp, x_is_centered=x_is_centered)
 
-        @wrap_output_data
         def inverse_transform(self, X):
-            xp, _ = get_namespace(X)
+            # sklearn does not properly input check inverse_transform using
+            # ``validate_data`` (as of sklearn 1.7). Yielding the namespace
+            # in this way will conform to sklearn and various inputs without
+            # causing issues with dimensionality checks, array api support,
+            # etc. evaluated in ``validate_data``. This is a special solution.
+            xp = (
+                func()
+                if (func := getattr(X, "__array_namespace__", None))
+                else get_namespace(X)[0]
+            )
 
             mean = self.mean_
             if self.whiten:
@@ -224,16 +232,12 @@ if daal_check_version((2024, "P", 100)):
                 )
             else:
                 components = self.components_
-            print(_is_numpy_namespace(xp), type(X), type(mean), type(components))
+
             if not _is_numpy_namespace(xp):
-                # DPCtl and dpnp require inputs to be on the same device for
-                # matrix multiplication and division. The type and location
-                # of the components and mean are dependent on the sklearn
-                # version, this makes sure it is of the same type and on the
-                # same device as the data (compute follows data).
+                # Force matching type to input data if possible
                 components = xp.asarray(components, device=X.device)
                 mean = xp.asarray(mean, device=X.device)
-            print(type(mean), type(components))
+
             return X @ components + mean
 
         def _onedal_supported(self, method_name, X):


### PR DESCRIPTION
## Description

Sklearn does not input check their ```PCA.inverse_transform``` method, making array_api support with and without ```array_api_dispatch``` enablement difficult. Unlike forcing all data to the cpu for evaluation, this takes the necessary components and matches it to the input data.  It will then use the native matrix multiplication infrastructure of the data framework to evaluate on device. This is a temporary fix as it will change with the rollout of array api support (namely #2106).

This was uncovered with an update to array_api_strict from 2.3.1 to 2.4.  ```wrap_output_data``` is  removed as it has no impact based on how the method is written.

This would also be solved easily using scikit-learn/scikit-learn#29310 had been reviewed and merged given it would add shape and type conformance to the estimator.

This should solve issues in LinuxCondaRecipe and WindowsCondaRecipe returning green CI.

No performance benchmarks necessary.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
