### PR TITLE
Update ubuntu CI image to 24.04

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -46,7 +46,7 @@ variables:
 jobs:
 - job: Lint
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-24.04'
   steps:
   - template: linting.yml
 - job: LinuxCondaRecipe
@@ -58,7 +58,7 @@ jobs:
         PYTHON_VERSION: '3.12'
         NUMPY_VERSION: '2.1'
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-24.04'
   steps:
   - template: conda-recipe-lnx.yml
 - job: WindowsCondaRecipe
@@ -96,7 +96,7 @@ jobs:
         PYTHON_VERSION: '3.13'
         SKLEARN_VERSION: '1.6'
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-24.04'
   steps:
   - template: build-and-test-lnx.yml
   - template: codecov-lnx.yml

--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -53,7 +53,7 @@ variables:
 jobs:
 - job: Docs
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-24.04'
   steps:
   - script: |
       bash .ci/scripts/describe_system.sh

--- a/.ci/pipeline/linting.yml
+++ b/.ci/pipeline/linting.yml
@@ -15,7 +15,7 @@
 #===============================================================================
 steps:
   - script: |
-      python -m pip install --upgrade pip pre-commit==4.0.1
+      python -m pip install --upgrade pip pre-commit==4.2.0
       pre-commit install
       pre-commit run --all-files --show-diff-on-failure
     displayName: 'Linting'

--- a/.ci/pipeline/linting.yml
+++ b/.ci/pipeline/linting.yml
@@ -15,7 +15,7 @@
 #===============================================================================
 steps:
   - script: |
-      python -m pip install --upgrade pip pre-commit==4.2.0
+      python -m pip install --upgrade pip pre-commit==4.0.1
       pre-commit install
       pre-commit run --all-files --show-diff-on-failure
     displayName: 'Linting'

--- a/.ci/pipeline/nightly.yml
+++ b/.ci/pipeline/nightly.yml
@@ -34,7 +34,7 @@ variables:
 jobs:
 - job: Coverity
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-24.04'
   steps:
   - script: |
       cd $(Agent.BuildDirectory)
@@ -58,7 +58,7 @@ jobs:
 - job: Jupyter
   timeoutInMinutes: 0
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-24.04'
   steps:
   - script: |
       conda config --show channels
@@ -100,7 +100,7 @@ jobs:
         PYTHON_VERSION: '3.11'
         SKLEARN_VERSION: 'main'
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-24.04'
   steps:
   - template: build-and-test-lnx.yml
 - job: WindowsNightly

--- a/.ci/scripts/gen_release_jobs.py
+++ b/.ci/scripts/gen_release_jobs.py
@@ -56,7 +56,7 @@ def collect_azp_CI_OS_images(file=f".ci{os.sep}pipeline{os.sep}ci.yml"):
     """Attempt to centralize the supported version from the azp CI pipeline, which
     represents the currently tested versions in Azure Pipelines."""
     regex = r"(?<=vmImage: ').*(?=')"
-    sysdefaults = ["ubuntu-22.04", "windows-2022"]
+    sysdefaults = ["ubuntu-24.04", "windows-2022"]
     if os.path.isfile(file):
         with open(file, "r") as f:
             # find unique values with set

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,10 @@ repos:
     rev: 24.10.0
     hooks:
       - id: black
-        language_version: python3.10
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:
       - id: isort
-        language_version: python3.10
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v14.0.6
     hooks:


### PR DESCRIPTION
## Description

- Update ubuntu image in CI, Releases and Nightly Azure pipelines from 22.04 to 24.04
- Unpin exact python version in pre-commit configuration to use default one available in the environment

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

N/A
