### PR TITLE
FIX: Fix incorrect type castings and mismatched operators

### DIFF
--- a/src/daal4py.cpp
+++ b/src/daal4py.cpp
@@ -69,34 +69,6 @@ private:
     PyArrayObject * _ndarray;
 };
 
-// define our own free functions for wrapping python objects holding our shared pointers
-void daalsp_free_cap(PyObject * cap)
-{
-    VSP * sp = static_cast<VSP *>(PyCapsule_GetPointer(cap, NULL));
-    if (sp)
-    {
-        delete sp;
-        sp = NULL;
-    }
-}
-
-// define our own free functions for wrapping python objects holding our raw pointers
-void rawp_free_cap(PyObject * cap)
-{
-    void * rp = PyCapsule_GetPointer(cap, NULL);
-    if (rp)
-    {
-        delete[] rp;
-        rp = NULL;
-    }
-}
-
-void set_rawp_base(PyArrayObject * ary, void * ptr)
-{
-    PyObject * cap = PyCapsule_New(ptr, NULL, rawp_free_cap);
-    PyArray_SetBaseObject(ary, cap);
-}
-
 inline void py_err_check()
 {
     if (PyErr_Occurred())

--- a/src/gettree.pyx
+++ b/src/gettree.pyx
@@ -27,7 +27,7 @@ cdef extern from "numpy/arrayobject.h":
     object PyArray_SimpleNewFromData(int nd, cnp.npy_intp* dims, int typenum, void* data)
 
 cdef extern from "daal4py.h":
-    cdef void set_rawp_base(cnp.ndarray, void *)
+    cdef void set_rawp_base[T](cnp.ndarray, T *)
 
 cdef extern from "tree_visitor.h":
     cdef struct skl_tree_node:
@@ -63,7 +63,7 @@ cdef class pyTreeState(object):
     cdef size_t leaf_count
     cdef size_t class_count
 
-    cdef cnp.ndarray _get_node_ndarray(self, void* nodes, size_t count):
+    cdef cnp.ndarray _get_node_ndarray(self, skl_tree_node* nodes, size_t count):
         """Wraps nodes as a NumPy struct array.
         The array keeps a reference to this Tree, which manages the underlying
         memory. Individual fields are publicly accessible as properties of the
@@ -82,7 +82,7 @@ cdef class pyTreeState(object):
         return arr
 
 
-    cdef cnp.ndarray _get_value_ndarray(self, void* values, size_t count, size_t outputs, size_t class_counts):
+    cdef cnp.ndarray _get_value_ndarray(self, double* values, size_t count, size_t outputs, size_t class_counts):
         cdef cnp.npy_intp shape[3]
         shape[0] = <cnp.npy_intp> count
         shape[1] = <cnp.npy_intp> 1
@@ -98,8 +98,8 @@ cdef class pyTreeState(object):
         self.node_count = treeState.node_count
         self.leaf_count = treeState.leaf_count
         self.class_count = treeState.class_count
-        self.node_ar = self._get_node_ndarray(<void*> treeState.node_ar, treeState.node_count)
-        self.value_ar = self._get_value_ndarray(<void*> treeState.value_ar, treeState.node_count, 1, treeState.class_count)
+        self.node_ar = self._get_node_ndarray(treeState.node_ar, treeState.node_count)
+        self.value_ar = self._get_value_ndarray(treeState.value_ar, treeState.node_count, 1, treeState.class_count)
 
 
     @property


### PR DESCRIPTION
## Description

This PR fixes some issues in the logic of daal4py objects in which pointers were being casted incorrectly and operator delete was used incorrectly.

Note that this only avoids running into undefined behavior, but **it does not fix memory leaks**, which are left for a follow-up PR.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
