### PR TITLE
[CI] swap uxl self-hosted runners to github hosted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
     if: github.repository == 'uxlfoundation/scikit-learn-intelex'
     needs: onedal_nightly
     name: LinuxNightly build Python${{ needs.onedal_nightly.outputs.uxl-python }}
-    runs-on: uxl-xlarge
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
 
     steps:
@@ -394,10 +394,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - OS: uxl-gpu-xlarge
-            FRAMEWORKS: "pytorch,numpy"
-            DEVICE: gpu
-          - OS: uxl-xlarge
+          - OS: ubuntu-24.04
             FRAMEWORKS: "pytorch,numpy"
             DEVICE: cpu
     needs: [onedal_nightly, build_uxl]


### PR DESCRIPTION
## Description

Due to infrastructure issues, the GPU runner is disabled and the uxl-xlarge is swapped to ubuntu-24.04.

No private CI or benchmarks are necessary

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
