### PR TITLE
FIX: Install scikit-learn in doc deployment CI job

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -83,7 +83,7 @@ jobs:
         git branch
     - name: Install Python Dependencies
       run: |
-        pip install daal-devel impi-devel
+        pip install daal-devel impi-devel scikit-learn
         pip install -r dependencies-dev
         pip install -r requirements-doc.txt
     - name: Build daal4py/sklearnex


### PR DESCRIPTION
## Description

This PR manually installs scikit-learn as a necessary dependency in the CI job that builds and deploys docs for sklearnex, since it is not listed as a dev requirement, nor as a doc requirement.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
