### PR TITLE
Fix: Find libs in $DALROOT with conda-style paths

### DIFF
--- a/scripts/version.py
+++ b/scripts/version.py
@@ -80,9 +80,8 @@ def find_library_custom_paths(alias: str, dal_root: str, is_win: bool) -> bool:
         else [jp(dal_root, "lib", "intel64"), jp(dal_root, "lib")]
     )
     for path in paths_from_dal_root:
-        if os.path.exists(path):
-            if os.path.isfile(jp(path, alias)):
-                return True
+        if os.path.isfile(jp(path, alias)):
+            return True
     return False
 
 

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -74,11 +74,15 @@ def get_onedal_version(dal_root, version_type="release"):
 def find_library_custom_paths(alias: str, dal_root: str, is_win: bool) -> bool:
     if find_library(alias):
         return True
-    path_from_dal_root = (
-        jp(dal_root, "Library", "bin") if is_win else jp(dal_root, "lib", "intel64")
+    paths_from_dal_root = (
+        [jp(dal_root, "Library", "bin")]
+        if is_win
+        else [jp(dal_root, "lib", "intel64"), jp(dal_root, "lib")]
     )
-    if os.path.exists(path_from_dal_root):
-        return alias in os.listdir(path_from_dal_root)
+    for path in paths_from_dal_root:
+        if os.path.exists(path):
+            if os.path.isfile(jp(path, alias)):
+                return True
     else:
         return False
 

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -83,8 +83,7 @@ def find_library_custom_paths(alias: str, dal_root: str, is_win: bool) -> bool:
         if os.path.exists(path):
             if os.path.isfile(jp(path, alias)):
                 return True
-    else:
-        return False
+    return False
 
 
 def get_onedal_shared_libs(dal_root: str, is_win: bool) -> list[str]:


### PR DESCRIPTION
## Description

This PR modifies the library finding logic to be able to find oneDAL libraries from `$DALROOT` that are installed in a conda-style folder structure, where the files are directly under `/lib`.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.