### PR TITLE
FIX: Specify namespace for std types

### DIFF
--- a/src/daal4py.cpp
+++ b/src/daal4py.cpp
@@ -229,20 +229,20 @@ PyObject * make_nda(daal::data_management::NumericTablePtr * ptr)
         if ((res = _make_nda_from_csr<float, NPY_FLOAT32>(ptr)) != NULL) return res;
         break;
     case daal::data_management::data_feature_utils::DAAL_INT32_S:
-        if ((res = _make_nda_from_homogen<int32_t, NPY_INT32>(ptr)) != NULL) return res;
-        if ((res = _make_nda_from_csr<int32_t, NPY_INT32>(ptr)) != NULL) return res;
+        if ((res = _make_nda_from_homogen<std::int32_t, NPY_INT32>(ptr)) != NULL) return res;
+        if ((res = _make_nda_from_csr<std::int32_t, NPY_INT32>(ptr)) != NULL) return res;
         break;
     case daal::data_management::data_feature_utils::DAAL_INT32_U:
-        if ((res = _make_nda_from_homogen<uint32_t, NPY_UINT32>(ptr)) != NULL) return res;
-        if ((res = _make_nda_from_csr<uint32_t, NPY_UINT32>(ptr)) != NULL) return res;
+        if ((res = _make_nda_from_homogen<std::uint32_t, NPY_UINT32>(ptr)) != NULL) return res;
+        if ((res = _make_nda_from_csr<std::uint32_t, NPY_UINT32>(ptr)) != NULL) return res;
         break;
     case daal::data_management::data_feature_utils::DAAL_INT64_S:
-        if ((res = _make_nda_from_homogen<int64_t, NPY_INT64>(ptr)) != NULL) return res;
-        if ((res = _make_nda_from_csr<int64_t, NPY_INT64>(ptr)) != NULL) return res;
+        if ((res = _make_nda_from_homogen<std::int64_t, NPY_INT64>(ptr)) != NULL) return res;
+        if ((res = _make_nda_from_csr<std::int64_t, NPY_INT64>(ptr)) != NULL) return res;
         break;
     case daal::data_management::data_feature_utils::DAAL_INT64_U:
-        if ((res = _make_nda_from_homogen<uint64_t, NPY_UINT64>(ptr)) != NULL) return res;
-        if ((res = _make_nda_from_csr<uint64_t, NPY_UINT64>(ptr)) != NULL) return res;
+        if ((res = _make_nda_from_homogen<std::uint64_t, NPY_UINT64>(ptr)) != NULL) return res;
+        if ((res = _make_nda_from_csr<std::uint64_t, NPY_UINT64>(ptr)) != NULL) return res;
         break;
     }
     // Falling back to using block-desriptors and converting to double
@@ -706,16 +706,16 @@ daal::data_management::DataCollectionPtr make_datacoll(PyObject * input)
     return daal::data_management::DataCollectionPtr();
 }
 
-static int64_t getval_(const std::string & str, const str2i_map_t & strmap)
+static std::int64_t getval_(const std::string & str, const str2i_map_t & strmap)
 {
     auto i = strmap.find(str);
     if (i == strmap.end()) throw std::invalid_argument(std::string("Encountered unexpected string-identifier '") + str + std::string("'"));
     return i->second;
 }
 
-int64_t string2enum(const std::string & str, str2i_map_t & strmap)
+std::int64_t string2enum(const std::string & str, str2i_map_t & strmap)
 {
-    int64_t r = 0;
+    std::int64_t r = 0;
     std::size_t current, previous = 0;
     while ((current = str.find('|', previous)) != std::string::npos)
     {

--- a/src/daal4py.h
+++ b/src/daal4py.h
@@ -38,6 +38,7 @@ using daal::services::LibraryVersionInfo;
 #include <limits>
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
@@ -72,8 +73,8 @@ extern "C"
 using daal::data_management::NumericTablePtr;
 typedef daal::services::SharedPtr<std::vector<std::vector<daal::byte> > > BytesArray;
 typedef std::string std_string;
-typedef std::unordered_map<std::string, int64_t> str2i_map_t;
-typedef std::unordered_map<int64_t, std::string> i2str_map_t;
+typedef std::unordered_map<std::string, std::int64_t> str2i_map_t;
+typedef std::unordered_map<std::int64_t, std::string> i2str_map_t;
 
 template <typename T>
 bool use_default(const daal::services::SharedPtr<T> * attr)
@@ -214,7 +215,7 @@ void * get_nt_data_ptr(const daal::data_management::NumericTablePtr * ptr)
     return dptr ? reinterpret_cast<void *>(dptr->getArraySharedPtr().get()) : NULL;
 }
 
-extern int64_t string2enum(const std::string & str, str2i_map_t & strmap);
+extern std::int64_t string2enum(const std::string & str, str2i_map_t & strmap);
 
 static std::string to_std_string(PyObject * o)
 {

--- a/src/transceiver.h
+++ b/src/transceiver.h
@@ -284,32 +284,32 @@ struct from_std<bool>
     static const transceiver_iface::type_type typ = transceiver_iface::BOOL;
 };
 template <>
-struct from_std<int8_t>
+struct from_std<std::int8_t>
 {
     static const transceiver_iface::type_type typ = transceiver_iface::INT8;
 };
 template <>
-struct from_std<uint8_t>
+struct from_std<std::uint8_t>
 {
     static const transceiver_iface::type_type typ = transceiver_iface::UINT8;
 };
 template <>
-struct from_std<int32_t>
+struct from_std<std::int32_t>
 {
     static const transceiver_iface::type_type typ = transceiver_iface::INT32;
 };
 template <>
-struct from_std<uint32_t>
+struct from_std<std::uint32_t>
 {
     static const transceiver_iface::type_type typ = transceiver_iface::UINT32;
 };
 template <>
-struct from_std<int64_t>
+struct from_std<std::int64_t>
 {
     static const transceiver_iface::type_type typ = transceiver_iface::INT64;
 };
 template <>
-struct from_std<uint64_t>
+struct from_std<std::uint64_t>
 {
     static const transceiver_iface::type_type typ = transceiver_iface::UINT64;
 };


### PR DESCRIPTION
## Description

This PR adds the necessary `std::` namespace prefix for references to types from this namespace in the daal4py source files. It looks like some update in the compiler somehow ended up making these not be in the global namespace by the time it tries to compile these files.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
