### PR TITLE
FIX: Fix double division of logistic model regularization by sum of weights

### DIFF
--- a/daal4py/sklearn/linear_model/logistic_loss.py
+++ b/daal4py/sklearn/linear_model/logistic_loss.py
@@ -61,8 +61,8 @@ def _daal4py_logistic_loss_extra_args(
         fptype=getFPType(X),
         method="defaultDense",
         interceptFlag=fit_intercept,
-        penaltyL1=l1 / n,
-        penaltyL2=l2 / n,
+        penaltyL1=l1,
+        penaltyL2=l2,
         resultsToCompute=results_to_compute,
     )
     objective_function_algorithm_instance.setup(X, y, beta)
@@ -99,8 +99,8 @@ def _daal4py_cross_entropy_loss_extra_args(
             fptype=getFPType(X),
             method="defaultDense",
             interceptFlag=fit_intercept,
-            penaltyL1=l1 / n,
-            penaltyL2=l2 / n,
+            penaltyL1=l1,
+            penaltyL2=l2,
             resultsToCompute=results_to_compute,
         )
     )

--- a/sklearnex/linear_model/tests/test_logreg.py
+++ b/sklearnex/linear_model/tests/test_logreg.py
@@ -19,7 +19,8 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 from scipy.sparse import csr_matrix
 from sklearn.datasets import load_breast_cancer, load_iris, make_classification
-from sklearn.metrics import accuracy_score
+from sklearn.linear_model import LogisticRegression as origLogisticRegression
+from sklearn.metrics import accuracy_score, log_loss
 from sklearn.model_selection import train_test_split
 
 from daal4py.sklearn._utils import daal_check_version
@@ -132,3 +133,31 @@ if daal_check_version((2024, "P", 700)):
         assert_allclose(prob, prob_sp, rtol=rtol)
         assert_allclose(model.coef_, model_sp.coef_, rtol=rtol)
         assert_allclose(model.intercept_, model_sp.intercept_, rtol=rtol)
+
+
+def test_logistic_regression_is_correct():
+    from sklearnex.linear_model import LogisticRegression
+
+    X = np.array([[-1, 0], [0, 1], [1, 1]])
+    y = np.array([0, 1, 1])
+    C = 3.0
+    model_sklearn = origLogisticRegression(C=C).fit(X, y)
+    model_sklearnex = LogisticRegression(C=C).fit(X, y)
+
+    try:
+        np.testing.assert_allclose(model_sklearnex.coef_, model_sklearn.coef_)
+        np.testing.assert_allclose(model_sklearnex.intercept_, model_sklearn.intercept_)
+    except AssertionError:
+
+        def logistic_model_function(predicted_probabilities, coefs):
+            neg_log_likelihood = X.shape[0] * log_loss(y, predicted_probabilities)
+            sum_squares_coefs = np.dot(coefs.reshape(-1), coefs.reshape(-1))
+            return C * neg_log_likelihood + 0.5 * sum_squares_coefs
+
+        fn_sklearn = logistic_model_function(
+            model_sklearn.predict_proba(X), model_sklearn.coef_
+        )
+        fn_sklearnex = logistic_model_function(
+            model_sklearnex.predict_proba(X), model_sklearnex.coef_
+        )
+        assert fn_sklearnex <= fn_sklearn

--- a/sklearnex/linear_model/tests/test_logreg.py
+++ b/sklearnex/linear_model/tests/test_logreg.py
@@ -135,6 +135,13 @@ if daal_check_version((2024, "P", 700)):
         assert_allclose(model.intercept_, model_sp.intercept_, rtol=rtol)
 
 
+# Note: this is adapted from a test in scikit-learn:
+# https://github.com/scikit-learn/scikit-learn/blob/9b7a86fb6d45905eec7b7afd01d3ae32643c8180/sklearn/linear_model/tests/test_logistic.py#L1494
+# Here we don't always expect them to match exactly due to differences in numerical precision
+# and how each library deals with large/small numbers, but oftentimes the results from oneDAL
+# end up being better in terms of resulting function values (for the objective function being
+# minimized), hence this test will try to look at function values if coefficients aren't
+# sufficiently similar.
 def test_logistic_regression_is_correct():
     from sklearnex.linear_model import LogisticRegression
 

--- a/sklearnex/linear_model/tests/test_logreg.py
+++ b/sklearnex/linear_model/tests/test_logreg.py
@@ -162,6 +162,34 @@ def test_logistic_regression_is_correct():
             return C * neg_log_likelihood + 0.5 * sum_squares_coefs
 
         fn_sklearn = logistic_model_function(
+            model_sklearn.predict_proba(X)[:, 1], model_sklearn.coef_
+        )
+        fn_sklearnex = logistic_model_function(
+            model_sklearnex.predict_proba(X)[:, 1], model_sklearnex.coef_
+        )
+        assert fn_sklearnex <= fn_sklearn
+
+
+def test_multinomial_logistic_regression_is_correct():
+    from sklearnex.linear_model import LogisticRegression
+
+    X = np.array([[-1, 0], [0, 1], [1, 1]])
+    y = np.array([2, 1, 0])
+    C = 3.0
+    model_sklearn = _sklearn_LogisticRegression(C=C, multi_class="multinomial").fit(X, y)
+    model_sklearnex = LogisticRegression(C=C, multi_class="multinomial").fit(X, y)
+
+    try:
+        np.testing.assert_allclose(model_sklearnex.coef_, model_sklearn.coef_)
+        np.testing.assert_allclose(model_sklearnex.intercept_, model_sklearn.intercept_)
+    except AssertionError:
+
+        def logistic_model_function(predicted_probabilities, coefs):
+            neg_log_likelihood = X.shape[0] * log_loss(y, predicted_probabilities)
+            sum_squares_coefs = np.dot(coefs.reshape(-1), coefs.reshape(-1))
+            return C * neg_log_likelihood + 0.5 * sum_squares_coefs
+
+        fn_sklearn = logistic_model_function(
             model_sklearn.predict_proba(X), model_sklearn.coef_
         )
         fn_sklearnex = logistic_model_function(

--- a/sklearnex/linear_model/tests/test_logreg.py
+++ b/sklearnex/linear_model/tests/test_logreg.py
@@ -19,7 +19,7 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 from scipy.sparse import csr_matrix
 from sklearn.datasets import load_breast_cancer, load_iris, make_classification
-from sklearn.linear_model import LogisticRegression as origLogisticRegression
+from sklearn.linear_model import LogisticRegression as _sklearn_LogisticRegression
 from sklearn.metrics import accuracy_score, log_loss
 from sklearn.model_selection import train_test_split
 
@@ -141,7 +141,7 @@ def test_logistic_regression_is_correct():
     X = np.array([[-1, 0], [0, 1], [1, 1]])
     y = np.array([0, 1, 1])
     C = 3.0
-    model_sklearn = origLogisticRegression(C=C).fit(X, y)
+    model_sklearn = _sklearn_LogisticRegression(C=C).fit(X, y)
     model_sklearnex = LogisticRegression(C=C).fit(X, y)
 
     try:


### PR DESCRIPTION
## Description

This PR fixes an issue in which the regularization of logistic regression models passed to oneDAL is incorrect due to being divided by the sum of weights (or number of rows when no weights are present) twice when used from `sklearnex.linear_model.LogisticRegression`.

Note: I am not sure here if the function being modified is otherwise also accessible from some daal4py class or similar or if this might break something in daal4py outside of sklearnex.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

