### PR TITLE
[CI] force use of conda-forge as the conda default channel

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -25,9 +25,10 @@ steps:
       bash .ci/scripts/describe_system.sh
     displayName: "System info"
   - script: |
+      # remove defaults to guarantee use of conda-forge
+      echo "default_channels: []" >> ~/.condarc
       conda config --add channels conda-forge
       conda config --set channel_priority strict
-      conda config --remove-key default_channels
       conda update -y -q conda
       conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) mpich pyyaml
     displayName: "Conda create"

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -25,8 +25,8 @@ steps:
       bash .ci/scripts/describe_system.sh
     displayName: "System info"
   - script: |
-      # remove defaults to guarantee use of conda-forge
-      echo "default_channels: []" >> ~/.condarc
+      # set defaults to guarantee use of conda-forge
+      echo -e "default_channels:\n  - https://conda.anaconda.org/conda-forge" >> ~/.condarc
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -26,8 +26,8 @@ steps:
     displayName: "System info"
   - script: |
       # remove defaults to guarantee use of conda-forge
-      echo "default_channels: []" >> ~/.condarc
       conda config --add channels conda-forge
+      conda config --set default_channels []
       conda config --set channel_priority strict
       conda update -y -q conda
       conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) mpich pyyaml

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -26,8 +26,8 @@ steps:
     displayName: "System info"
   - script: |
       # remove defaults to guarantee use of conda-forge
+      echo "default_channels: []" >> ~/.condarc
       conda config --add channels conda-forge
-      conda config --set default_channels []
       conda config --set channel_priority strict
       conda update -y -q conda
       conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) mpich pyyaml

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -25,10 +25,9 @@ steps:
       bash .ci/scripts/describe_system.sh
     displayName: "System info"
   - script: |
-      conda config --remove channels r
-      conda config --remove channels main
       conda config --add channels conda-forge
       conda config --set channel_priority strict
+      conda config --remove-key default_channels
       conda update -y -q conda
       conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) mpich pyyaml
     displayName: "Conda create"

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -25,6 +25,8 @@ steps:
       bash .ci/scripts/describe_system.sh
     displayName: "System info"
   - script: |
+      conda config --remove channels r
+      conda config --remove channels main
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -16,7 +16,9 @@
 steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
-  - script: conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) impi-devel pyyaml
+  - script: |
+      echo default_channels: [] >> C:\Users\VssAdministrator\.condarc
+      conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) impi-devel pyyaml
     displayName: 'Create Anaconda environment'
   - script: |
       call activate CB

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -17,7 +17,7 @@ steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
   - script: |
-      conda config --set default_channels []
+      echo default_channels: [] >> C:\Users\VssAdministrator\.condarc
       conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) impi-devel pyyaml
     displayName: 'Create Anaconda environment'
   - script: |

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -17,7 +17,7 @@ steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
   - script: |
-      echo default_channels: [] >> C:\Users\VssAdministrator\.condarc
+      conda config --set default_channels []
       conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) impi-devel pyyaml
     displayName: 'Create Anaconda environment'
   - script: |

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -17,7 +17,7 @@ steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
   - script: |
-      echo default_channels: [] >> C:\Users\VssAdministrator\.condarc
+      (echo default_channels: & echo   - https://conda.anaconda.org/conda-forge) >> C:\Users\VssAdministrator\.condarc
       conda create -q -y -n CB -c conda-forge python=$(PYTHON_VERSION) impi-devel pyyaml
     displayName: 'Create Anaconda environment'
   - script: |

--- a/.ci/pipeline/conda-recipe-lnx.yml
+++ b/.ci/pipeline/conda-recipe-lnx.yml
@@ -15,8 +15,8 @@
 #===============================================================================
 steps:
   - script: |
-      echo "default_channels: []" >> ~/.condarc
       conda config --add channels conda-forge
+      conda config --set default_channels []
       conda config --set channel_priority strict
       conda update -y -q conda python
     displayName: "Conda update"

--- a/.ci/pipeline/conda-recipe-lnx.yml
+++ b/.ci/pipeline/conda-recipe-lnx.yml
@@ -15,6 +15,7 @@
 #===============================================================================
 steps:
   - script: |
+      echo "default_channels: []" >> ~/.condarc
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda python

--- a/.ci/pipeline/conda-recipe-lnx.yml
+++ b/.ci/pipeline/conda-recipe-lnx.yml
@@ -15,8 +15,8 @@
 #===============================================================================
 steps:
   - script: |
+      echo "default_channels: []" >> ~/.condarc
       conda config --add channels conda-forge
-      conda config --set default_channels []
       conda config --set channel_priority strict
       conda update -y -q conda python
     displayName: "Conda update"

--- a/.ci/pipeline/conda-recipe-lnx.yml
+++ b/.ci/pipeline/conda-recipe-lnx.yml
@@ -15,7 +15,7 @@
 #===============================================================================
 steps:
   - script: |
-      echo "default_channels: []" >> ~/.condarc
+      echo -e "default_channels:\n  - https://conda.anaconda.org/conda-forge" >> ~/.condarc
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda python

--- a/.ci/pipeline/conda-recipe-win.yml
+++ b/.ci/pipeline/conda-recipe-win.yml
@@ -17,8 +17,8 @@ steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
   - script: |
-      echo default_channels: [] >> C:\Users\VssAdministrator\.condarc
       conda config --add channels conda-forge
+      conda config --set default_channels []
       conda config --set channel_priority strict
       conda update -y -q conda python
     displayName: "Conda update"

--- a/.ci/pipeline/conda-recipe-win.yml
+++ b/.ci/pipeline/conda-recipe-win.yml
@@ -17,8 +17,8 @@ steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
   - script: |
+      echo default_channels: [] >> C:\Users\VssAdministrator\.condarc
       conda config --add channels conda-forge
-      conda config --set default_channels []
       conda config --set channel_priority strict
       conda update -y -q conda python
     displayName: "Conda update"

--- a/.ci/pipeline/conda-recipe-win.yml
+++ b/.ci/pipeline/conda-recipe-win.yml
@@ -17,7 +17,7 @@ steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
   - script: |
-      echo default_channels: [] >> C:\Users\VssAdministrator\.condarc
+      (echo default_channels: & echo   - https://conda.anaconda.org/conda-forge) >> C:\Users\VssAdministrator\.condarc
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda python

--- a/.ci/pipeline/conda-recipe-win.yml
+++ b/.ci/pipeline/conda-recipe-win.yml
@@ -17,6 +17,7 @@ steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
   - script: |
+      echo default_channels: [] >> C:\Users\VssAdministrator\.condarc
       conda config --add channels conda-forge
       conda config --set channel_priority strict
       conda update -y -q conda python


### PR DESCRIPTION
## Description

There is a new issue requiring signing the conda ToS for use of the default conda Channels:

```
CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels. Please accept or remove them before proceeding:
    � https://repo.anaconda.com/pkgs/main
    � https://repo.anaconda.com/pkgs/r
    � https://repo.anaconda.com/pkgs/msys2
```

This issue can be avoided by removing the default channels, which should not be used anyway in this repository.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
