### PR TITLE
fix(circleci): correct argument type for `--json-report-file`

### DIFF
--- a/.circleci/run_xpu_tests.py
+++ b/.circleci/run_xpu_tests.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--json-report-file",
         default=None,
-        action="store_true",
+        type=str,
         help="File path where to output a report of the test outcomes in JSON format",
     )
     parser.add_argument("--deselected_yml_file", action="append", type=str)


### PR DESCRIPTION
## Description

Updated `--json-report-file`  flag type to support an argument since its name implies one is expected (and the code below requires an argument).

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

