### PR TITLE
sklearn 1.7.0 for doc reqs

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -49,7 +49,7 @@ PyYAML==6.0.2
 pyzmq==27.0.0
 requests==2.32.4
 six==1.17.0
-scikit-learn==1.7.0
+scikit-learn==1.7.0 # version needed due to issue with 1.7.1, remove when sklearn 1.8 drops
 snowballstemmer==3.0.1
 soupsieve==2.7
 Sphinx==8.2.3

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -49,7 +49,7 @@ PyYAML==6.0.2
 pyzmq==27.0.0
 requests==2.32.4
 six==1.17.0
-scikit-learn
+scikit-learn==1.7.0
 snowballstemmer==3.0.1
 soupsieve==2.7
 Sphinx==8.2.3


### PR DESCRIPTION
## Description

Replaces: https://github.com/uxlfoundation/scikit-learn-intelex/pull/2625
For successful docbuild, sklearn 1.7.1 cannot be used

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.
