### PR TITLE
FIX: Fix incorrect processing of logistic regularization when passed to sklearn

### DIFF
--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -617,7 +617,7 @@ def __logistic_regression_path(
                     extra_args = (X, target, sample_weight, l2_reg_strength, n_threads)
                 else:
                     if not _dal_ready:
-                        extra_args = (X, target, C, sample_weight)
+                        extra_args = (X, target, 1.0 / C, sample_weight)
                     else:
                         extra_args = (X, target, 1.0 / (C * sw_sum), sample_weight)
 
@@ -688,7 +688,7 @@ def __logistic_regression_path(
                     args = (X, target, sample_weight, l2_reg_strength, n_threads)
                 else:
                     if not _dal_ready:
-                        args = (X, target, C, sample_weight)
+                        args = (X, target, 1.0 / C, sample_weight)
                     else:
                         args = (X, target, 1.0 / (C * sw_sum), sample_weight)
 

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -849,6 +849,10 @@ def daal4py_predict(self, X, resultsToEvaluate):
                     != "ovr",
                     f"selected multiclass option is not supported for n_classes > 2.",
                 ),
+                (
+                    not (self.classes_.size == 2 and self.multi_class == "multinomial"),
+                    "multi_class='multinomial' not supported with binary data",
+                ),
             ],
         )
 

--- a/daal4py/sklearn/linear_model/logistic_path.py
+++ b/daal4py/sklearn/linear_model/logistic_path.py
@@ -616,7 +616,10 @@ def __logistic_regression_path(
                     l2_reg_strength = 1.0 / (C * sw_sum)
                     extra_args = (X, target, sample_weight, l2_reg_strength, n_threads)
                 else:
-                    extra_args = (X, target, 1.0 / (C * sw_sum), sample_weight)
+                    if not _dal_ready:
+                        extra_args = (X, target, C, sample_weight)
+                    else:
+                        extra_args = (X, target, 1.0 / (C * sw_sum), sample_weight)
 
             iprint = [-1, 50, 1, 100, 101][
                 np.searchsorted(np.array([0, 1, 2, 3]), verbose)
@@ -684,7 +687,10 @@ def __logistic_regression_path(
                     l2_reg_strength = 1.0 / (C * sw_sum)
                     args = (X, target, sample_weight, l2_reg_strength, n_threads)
                 else:
-                    args = (X, target, 1.0 / (C * sw_sum), sample_weight)
+                    if not _dal_ready:
+                        args = (X, target, C, sample_weight)
+                    else:
+                        args = (X, target, 1.0 / (C * sw_sum), sample_weight)
 
                 w0, n_iter_i = _newton_cg(
                     hess, func, grad, w0, args=args, maxiter=max_iter, tol=tol

--- a/daal4py/sklearn/linear_model/tests/test_logreg.py
+++ b/daal4py/sklearn/linear_model/tests/test_logreg.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pytest
+from sklearn.linear_model import LogisticRegression as _sklearn_LogisticRegression
+
+from daal4py.sklearn._utils import sklearn_check_version
+from daal4py.sklearn.linear_model import LogisticRegression as _d4p_LogisticRegression
+
+
+# Adapted from this test:
+# https://github.com/scikit-learn/scikit-learn/blob/baf828ca126bcb2c0ad813226963621cafe38adb/sklearn/utils/estimator_checks.py#L963
+# Note: the logger of the daal4py estimator here might report that it falls back
+# to scikit-learn, but in many cases it does so by re-defining their code instead
+# of importing their classes, and passing arguments as needed. The aim of this
+# test is to verify that those still work correctly, as they are not a direct
+# fallback the same way it works elsewhere.
+# Since the logger will report a fallback and this test is run under a hook that
+# makes it fail on fallbacks from patched classes, the test here imports the
+# module with an underscore to bypass the check. It doesn't appear to work
+# if putting it under 'sklearnex' as by then the patched class will already be
+# imported and checked.
+@pytest.mark.parametrize(
+    "solver",
+    ["lbfgs", "newton-cg", "sag", "liblinear"]
+    + (["newton-cholesky"] if sklearn_check_version("1.2") else []),
+)
+def test_logistic_regression_is_correct_with_weights(solver):
+    X = np.array(
+        [
+            [1, 3],
+            [1, 3],
+            [1, 3],
+            [1, 3],
+            [2, 1],
+            [2, 1],
+            [2, 1],
+            [2, 1],
+            [3, 3],
+            [3, 3],
+            [3, 3],
+            [3, 3],
+            [4, 1],
+            [4, 1],
+            [4, 1],
+            [4, 1],
+        ],
+        dtype=np.float64,
+    )
+    y = np.array([1, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1, 1, 2, 2, 2, 2], dtype=int)
+    w = np.arange(X.shape[0])
+
+    model_sklearnex = _d4p_LogisticRegression(solver=solver, random_state=123).fit(
+        X, y, w
+    )
+    model_sklearn = _sklearn_LogisticRegression(solver=solver, random_state=123).fit(
+        X, y, w
+    )
+
+    np.testing.assert_allclose(
+        model_sklearnex.coef_,
+        model_sklearn.coef_,
+    )

--- a/daal4py/sklearn/linear_model/tests/test_logreg.py
+++ b/daal4py/sklearn/linear_model/tests/test_logreg.py
@@ -40,7 +40,8 @@ from daal4py.sklearn.linear_model import LogisticRegression as _d4p_LogisticRegr
     + (["newton-cholesky"] if sklearn_check_version("1.2") else []),
 )
 @pytest.mark.parametrize("fit_intercept", [False, True])
-def test_logistic_regression_is_correct_with_weights(solver, fit_intercept):
+@pytest.mark.parametrize("C", [1, 0.1])
+def test_logistic_regression_is_correct_with_weights(solver, fit_intercept, C):
     X = np.array(
         [
             [1, 3],
@@ -66,20 +67,22 @@ def test_logistic_regression_is_correct_with_weights(solver, fit_intercept):
     w = np.arange(X.shape[0])
 
     model_sklearnex = _d4p_LogisticRegression(
-        solver=solver, fit_intercept=fit_intercept, random_state=123
+        C=C, solver=solver, fit_intercept=fit_intercept, random_state=123
     ).fit(X, y, w)
     model_sklearn = _sklearn_LogisticRegression(
-        solver=solver, fit_intercept=fit_intercept, random_state=123
+        C=C, solver=solver, fit_intercept=fit_intercept, random_state=123
     ).fit(X, y, w)
 
     np.testing.assert_allclose(
         model_sklearnex.coef_,
         model_sklearn.coef_,
+        atol=1e-5,
     )
     if fit_intercept:
         np.testing.assert_allclose(
             model_sklearnex.intercept_,
             model_sklearn.intercept_,
+            atol=1e-5,
         )
 
 
@@ -89,7 +92,10 @@ def test_logistic_regression_is_correct_with_weights(solver, fit_intercept):
     + (["newton-cholesky"] if sklearn_check_version("1.2") else []),
 )
 @pytest.mark.parametrize("fit_intercept", [False, True])
-def test_multinomial_logistic_regression_is_correct_with_weights(solver, fit_intercept):
+@pytest.mark.parametrize("C", [1, 0.1])
+def test_multinomial_logistic_regression_is_correct_with_weights(
+    solver, fit_intercept, C
+):
     X = np.array(
         [
             [1, 3],
@@ -115,10 +121,10 @@ def test_multinomial_logistic_regression_is_correct_with_weights(solver, fit_int
     w = np.arange(X.shape[0])
 
     model_sklearnex = _d4p_LogisticRegression(
-        solver=solver, fit_intercept=fit_intercept, random_state=123
+        C=C, solver=solver, fit_intercept=fit_intercept, random_state=123
     ).fit(X, y, w)
     model_sklearn = _sklearn_LogisticRegression(
-        solver=solver, fit_intercept=fit_intercept, random_state=123
+        C=C, solver=solver, fit_intercept=fit_intercept, random_state=123
     ).fit(X, y, w)
 
     np.testing.assert_allclose(

--- a/daal4py/sklearn/linear_model/tests/test_logreg.py
+++ b/daal4py/sklearn/linear_model/tests/test_logreg.py
@@ -1,3 +1,19 @@
+# ==============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 import numpy as np
 import pytest
 from sklearn.linear_model import LogisticRegression as _sklearn_LogisticRegression

--- a/daal4py/sklearn/linear_model/tests/test_logreg.py
+++ b/daal4py/sklearn/linear_model/tests/test_logreg.py
@@ -21,6 +21,30 @@ from sklearn.linear_model import LogisticRegression as _sklearn_LogisticRegressi
 from daal4py.sklearn._utils import sklearn_check_version
 from daal4py.sklearn.linear_model import LogisticRegression as _d4p_LogisticRegression
 
+X = np.array(
+    [
+        [1, 3],
+        [1, 3],
+        [1, 3],
+        [1, 3],
+        [2, 1],
+        [2, 1],
+        [2, 1],
+        [2, 1],
+        [3, 3],
+        [3, 3],
+        [3, 3],
+        [3, 3],
+        [4, 1],
+        [4, 1],
+        [4, 1],
+        [4, 1],
+    ],
+    dtype=np.float64,
+)
+y_binary = np.array([1, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1, 1, 2, 2, 2, 2], dtype=int)
+y_multiclass = np.array([1, 1, 1, 1, 2, 2, 2, 2, 1, 3, 3, 1, 2, 2, 2, 2], dtype=int)
+
 
 # Adapted from this test:
 # https://github.com/scikit-learn/scikit-learn/blob/baf828ca126bcb2c0ad813226963621cafe38adb/sklearn/utils/estimator_checks.py#L963
@@ -42,36 +66,14 @@ from daal4py.sklearn.linear_model import LogisticRegression as _d4p_LogisticRegr
 @pytest.mark.parametrize("fit_intercept", [False, True])
 @pytest.mark.parametrize("C", [1, 0.1])
 def test_logistic_regression_is_correct_with_weights(solver, fit_intercept, C):
-    X = np.array(
-        [
-            [1, 3],
-            [1, 3],
-            [1, 3],
-            [1, 3],
-            [2, 1],
-            [2, 1],
-            [2, 1],
-            [2, 1],
-            [3, 3],
-            [3, 3],
-            [3, 3],
-            [3, 3],
-            [4, 1],
-            [4, 1],
-            [4, 1],
-            [4, 1],
-        ],
-        dtype=np.float64,
-    )
-    y = np.array([1, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1, 1, 2, 2, 2, 2], dtype=int)
     w = np.arange(X.shape[0])
 
     model_sklearnex = _d4p_LogisticRegression(
         C=C, solver=solver, fit_intercept=fit_intercept, random_state=123
-    ).fit(X, y, w)
+    ).fit(X, y_binary, w)
     model_sklearn = _sklearn_LogisticRegression(
         C=C, solver=solver, fit_intercept=fit_intercept, random_state=123
-    ).fit(X, y, w)
+    ).fit(X, y_binary, w)
 
     np.testing.assert_allclose(
         model_sklearnex.coef_,
@@ -96,36 +98,14 @@ def test_logistic_regression_is_correct_with_weights(solver, fit_intercept, C):
 def test_multinomial_logistic_regression_is_correct_with_weights(
     solver, fit_intercept, C
 ):
-    X = np.array(
-        [
-            [1, 3],
-            [1, 3],
-            [1, 3],
-            [1, 3],
-            [2, 1],
-            [2, 1],
-            [2, 1],
-            [2, 1],
-            [3, 3],
-            [3, 3],
-            [3, 3],
-            [3, 3],
-            [4, 1],
-            [4, 1],
-            [4, 1],
-            [4, 1],
-        ],
-        dtype=np.float64,
-    )
-    y = np.array([1, 1, 1, 1, 2, 2, 2, 2, 1, 3, 3, 1, 2, 2, 2, 2], dtype=int)
     w = np.arange(X.shape[0])
 
     model_sklearnex = _d4p_LogisticRegression(
         C=C, solver=solver, fit_intercept=fit_intercept, random_state=123
-    ).fit(X, y, w)
+    ).fit(X, y_multiclass, w)
     model_sklearn = _sklearn_LogisticRegression(
         C=C, solver=solver, fit_intercept=fit_intercept, random_state=123
-    ).fit(X, y, w)
+    ).fit(X, y_multiclass, w)
 
     np.testing.assert_allclose(
         model_sklearnex.coef_,
@@ -138,3 +118,24 @@ def test_multinomial_logistic_regression_is_correct_with_weights(
             model_sklearn.intercept_,
             atol=1e-3,
         )
+
+
+# Here, scikit-learn does a theoretically incorrect calculation in which
+# they set the predictions for the 'negative' class as the negative of the
+# predictions for the positive class instead of all-zeros. The idea is to
+# match theirs, which is done by falling back. This test ensures that the
+# predictions match with sklearn in case it isn't done during conformance tests.
+@pytest.mark.parametrize("fit_intercept", [False, True])
+@pytest.mark.parametrize("C", [1, 0.1])
+def test_binary_multinomial_probabilities(fit_intercept, C):
+    model_sklearnex = _d4p_LogisticRegression(
+        C=C, fit_intercept=fit_intercept, multi_class="multinomial"
+    ).fit(X, y_binary)
+    model_sklearn = _sklearn_LogisticRegression(
+        C=C, fit_intercept=fit_intercept, multi_class="multinomial"
+    ).fit(X, y_binary)
+    np.testing.assert_allclose(
+        model_sklearnex.predict_proba(X),
+        model_sklearn.predict_proba(X),
+        atol=1e-4,
+    )

--- a/daal4py/sklearn/linear_model/tests/test_logreg.py
+++ b/daal4py/sklearn/linear_model/tests/test_logreg.py
@@ -137,5 +137,6 @@ def test_binary_multinomial_probabilities(fit_intercept, C):
     np.testing.assert_allclose(
         model_sklearnex.predict_proba(X),
         model_sklearn.predict_proba(X),
-        atol=1e-4,
+        rtol=1e-2,
+        atol=1e-3,
     )

--- a/daal4py/sklearn/linear_model/tests/test_logreg.py
+++ b/daal4py/sklearn/linear_model/tests/test_logreg.py
@@ -23,7 +23,8 @@ from daal4py.sklearn.linear_model import LogisticRegression as _d4p_LogisticRegr
     ["lbfgs", "newton-cg", "sag", "liblinear"]
     + (["newton-cholesky"] if sklearn_check_version("1.2") else []),
 )
-def test_logistic_regression_is_correct_with_weights(solver):
+@pytest.mark.parametrize("fit_intercept", [False, True])
+def test_logistic_regression_is_correct_with_weights(solver, fit_intercept):
     X = np.array(
         [
             [1, 3],
@@ -48,14 +49,70 @@ def test_logistic_regression_is_correct_with_weights(solver):
     y = np.array([1, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1, 1, 2, 2, 2, 2], dtype=int)
     w = np.arange(X.shape[0])
 
-    model_sklearnex = _d4p_LogisticRegression(solver=solver, random_state=123).fit(
-        X, y, w
-    )
-    model_sklearn = _sklearn_LogisticRegression(solver=solver, random_state=123).fit(
-        X, y, w
-    )
+    model_sklearnex = _d4p_LogisticRegression(
+        solver=solver, fit_intercept=fit_intercept, random_state=123
+    ).fit(X, y, w)
+    model_sklearn = _sklearn_LogisticRegression(
+        solver=solver, fit_intercept=fit_intercept, random_state=123
+    ).fit(X, y, w)
 
     np.testing.assert_allclose(
         model_sklearnex.coef_,
         model_sklearn.coef_,
     )
+    if fit_intercept:
+        np.testing.assert_allclose(
+            model_sklearnex.intercept_,
+            model_sklearn.intercept_,
+        )
+
+
+@pytest.mark.parametrize(
+    "solver",
+    ["lbfgs", "newton-cg", "sag", "liblinear"]
+    + (["newton-cholesky"] if sklearn_check_version("1.2") else []),
+)
+@pytest.mark.parametrize("fit_intercept", [False, True])
+def test_multinomial_logistic_regression_is_correct_with_weights(solver, fit_intercept):
+    X = np.array(
+        [
+            [1, 3],
+            [1, 3],
+            [1, 3],
+            [1, 3],
+            [2, 1],
+            [2, 1],
+            [2, 1],
+            [2, 1],
+            [3, 3],
+            [3, 3],
+            [3, 3],
+            [3, 3],
+            [4, 1],
+            [4, 1],
+            [4, 1],
+            [4, 1],
+        ],
+        dtype=np.float64,
+    )
+    y = np.array([1, 1, 1, 1, 2, 2, 2, 2, 1, 3, 3, 1, 2, 2, 2, 2], dtype=int)
+    w = np.arange(X.shape[0])
+
+    model_sklearnex = _d4p_LogisticRegression(
+        solver=solver, fit_intercept=fit_intercept, random_state=123
+    ).fit(X, y, w)
+    model_sklearn = _sklearn_LogisticRegression(
+        solver=solver, fit_intercept=fit_intercept, random_state=123
+    ).fit(X, y, w)
+
+    np.testing.assert_allclose(
+        model_sklearnex.coef_,
+        model_sklearn.coef_,
+        atol=1e-4,
+    )
+    if fit_intercept:
+        np.testing.assert_allclose(
+            model_sklearnex.intercept_,
+            model_sklearn.intercept_,
+            atol=1e-3,
+        )


### PR DESCRIPTION
## Description

This PR fixes an issue in which the regularization argument for logistic regression was being converted to oneDAL's required format, but passed like that to sklearn which does its own post-processing.

Along the way, it also fixes an unrelated issue in which sklearn is doing theoretically incorrect calculations for binary data with `multi_class='multinomial'` - leaving it in the same PR as it touches the same files and would lead to merge conflicts otherwise.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.
