### PR TITLE
ENH: Allow passing additional arguments to pytest in conformance tests

### DIFF
--- a/.ci/scripts/run_sklearn_tests.py
+++ b/.ci/scripts/run_sklearn_tests.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
         help="device name",
         choices=["none", "cpu", "gpu"],
     )
-    args = parser.parse_args()
+    args, extra_args = parser.parse_known_args()
 
     sklearn_file_dir = os.path.dirname(sklearn.__file__)
     os.chdir(sklearn_file_dir)
@@ -67,6 +67,9 @@ if __name__ == "__main__":
 
     while "" in pytest_args:
         pytest_args.remove("")
+
+    if extra_args:
+        pytest_args += extra_args
 
     if args.device != "none":
         with sklearn.config_context(target_offload=args.device):

--- a/scikit-learn-tests.md
+++ b/scikit-learn-tests.md
@@ -37,6 +37,11 @@ SELECTED_TESTS=all DESELECTED_TESTS="" python .ci/scripts/run_sklearn_tests.py
 
 _**Note:** If building the extension modules in-place [per the instructions here](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/INSTALL.md#build-intelr-extension-for-scikit-learn), it requires also setting `$PYTHONPATH` for this script._
 
+Further arguments to pytest can be supplied by passing them as arguments to the `.py` runner - for example
+```shell
+SELECTED_TESTS=all DESELECTED_TESTS="" python .ci/scripts/run_sklearn_tests.py -x
+```
+
 The tests can also be made to run on GPU, either by passing argument `gpu` to `run_sklearn_tests.sh`, or by passing argument `--device <device name>` to  `run_sklearn_tests.py` - example:
 ```shell
 ./.ci/scripts/run_sklearn_tests.sh gpu


### PR DESCRIPTION
## Description

This PR opens the possibility of forwarding arguments from the conformance test runner to pytest by passing them to the runner as additional arguments.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.
