### PR TITLE
[Fix] [Array API] Raise AttributeError for non-homogen tables in __sycl_usm_array_interface__ to comply with Python interop expectations

### DIFF
--- a/onedal/datatypes/sycl_usm/data_conversion.cpp
+++ b/onedal/datatypes/sycl_usm/data_conversion.cpp
@@ -156,7 +156,8 @@ py::dict construct_sua_iface(const dal::table& input) {
     // for constructing DPCTL usm_ndarray or DPNP ndarray with zero-copy on python level.
     const auto kind = input.get_kind();
     if (kind != dal::homogen_table::kind())
-        throw py::attribute_error("__sycl_usm_array_interface__ not available: only homogen tables are supported");
+        throw py::attribute_error(
+            "__sycl_usm_array_interface__ not available: only homogen tables are supported");
 
     const auto& homogen_input = reinterpret_cast<const dal::homogen_table&>(input);
 

--- a/onedal/datatypes/sycl_usm/data_conversion.cpp
+++ b/onedal/datatypes/sycl_usm/data_conversion.cpp
@@ -156,7 +156,7 @@ py::dict construct_sua_iface(const dal::table& input) {
     // for constructing DPCTL usm_ndarray or DPNP ndarray with zero-copy on python level.
     const auto kind = input.get_kind();
     if (kind != dal::homogen_table::kind())
-        report_problem_to_sua_iface(": only homogen tables are supported");
+        throw py::attribute_error("__sycl_usm_array_interface__ not available: only homogen tables are supported");
 
     const auto& homogen_input = reinterpret_cast<const dal::homogen_table&>(input);
 


### PR DESCRIPTION
## Raise AttributeError for non-homogen tables in __sycl_usm_array_interface__ to comply with Python interop expectations

This PR updates the behavior of the __sycl_usm_array_interface__ property for oneDAL table objects to improve compatibility with Python SYCL-aware libraries (e.g. dpctl, dpnp, numba-dpex). 

Previously, the property handler used report_problem_to_sua_iface(": only homogen tables are supported");
to signal unsupported table types (e.g., sparse or non-homogen tables). However, this results in a non attribute related error being raised, which breaks compatibility with Python’s hasattr() behavior, and can surface as runtime errors in downstream libraries that probe for SYCL USM compatibility. 

The fix aligns with Python data protocol conventions (e.g., __array_interface__, __cuda_array_interface__), which require AttributeError to signal absence.

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [X] I have reviewed my changes thoroughly before submitting this pull request.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [X] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [X] I have added a respective label(s) to PR if I have a permission for that.
- [X] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [X] I have run it locally and tested the changes extensively.
- [X] All CI jobs are green or I have provided justification why they aren't.
- [X] I have extended testing suite if new functionality was introduced in this PR.


