### PR TITLE
MAINT: Set `-e` mode in doc CI to catch errors

### DIFF
--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -65,6 +65,7 @@ jobs:
   - script: sudo apt-get update && sudo apt-get install -y clang-format pandoc 
     displayName: 'apt-get'
   - script: |
+      set -e
       pip install daal-devel impi-devel
       pip install -r dependencies-dev
       pip install -r requirements-doc.txt


### PR DESCRIPTION
## Description

This PR makes the step that installs dependencies in the doc CI error out if the calls to `pip install` fail, so that it would catch errors like these earlier on:
https://dev.azure.com/daal/daal4py/_build/results?buildId=50005&view=logs&j=7e620c85-24a8-5ffa-8b1f-642bc9b1fc36&t=2febcae8-7f6a-51bb-45aa-d6e72c9ea7e2

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
