### PR TITLE
FIX: Return correct shape of probabilities from GPU logreg

### DIFF
--- a/onedal/linear_model/logistic_regression.py
+++ b/onedal/linear_model/logistic_regression.py
@@ -217,6 +217,7 @@ class BaseLogisticRegression(metaclass=ABCMeta):
         result = result = self._infer(X)
         _, xp, _ = _get_sycl_namespace(X)
         y = from_table(result.probabilities, like=X)
+        y = xp.reshape(y, -1)
         return xp.stack([1 - y, y], axis=1)
 
     def _predict_log_proba(self, X):


### PR DESCRIPTION
## Description

This PR fixes the shape of the predictions produced by GPU logistic regression to match what the CPU version would produce.

Note that method `decision_function` is explicitly not tested as it's currently not implemented for GPU - will be left for a later PR.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.
