### PR TITLE
[FIX][ArrayAPI]  Add explicit support for oneDAL tables in SYCL namespace detection

### DIFF
--- a/onedal/utils/_array_api.py
+++ b/onedal/utils/_array_api.py
@@ -23,6 +23,11 @@ import numpy as np
 
 from ..utils._third_party import _is_subclass_fast
 
+try:
+    from onedal._onedal_py_dpc import table as onedal_table_type
+except ImportError:
+    onedal_table_type = type(None)
+
 
 def _supports_buffer_protocol(obj):
     # the array_api standard mandates conversion with the buffer protocol,
@@ -91,5 +96,7 @@ def _get_sycl_namespace(*arrays):
             _cls_to_sycl_namespace(type(X)),
             hasattr(X, "__array_namespace__"),
         )
+    elif any(isinstance(x, onedal_table_type) for x in arrays):
+        return True, np, False
 
     return sua_iface, np, False


### PR DESCRIPTION
## Add explicit support for oneDAL tables in SYCL namespace detection

### Summary
This PR addresses an issue where `onedal_table` objects (`onedal._onedal_py_dpc.table`) were not recognized properly by the `_get_sycl_namespace` function, causing compatibility issues and raising `TypeError`.

The current implementation does not handle cases when inputs are Intel oneDAL tables explicitly, which can occur frequently when using Intel's scikit-learn extension (sklearnex).

### Changes

- Explicitly checks if any inputs provided to `_get_sycl_namespace` are of type `onedal_table`, ensuring proper handling.
- Avoids potential `NameError` by correctly iterating through input arrays when SYCL interfaces are not detected.

### Example issue fixed:

```python
TypeError: table is not a supported array type
```

---

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
