### PR TITLE
Update DPC version in CI

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -60,7 +60,7 @@ steps:
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
       # dpep installation is set to pypi to avoid conflict of numpy versions from pip and conda
-      if [ [ $(SKLEARN_VERSION) != "1.0" ] && [ -z ${NO_DPC} ]; then pip install dpctl==0.20.* dpnp==0.18.*; fi
+      if [ $(SKLEARN_VERSION) != "1.0" ] && [ -z ${NO_DPC} ]; then pip install dpctl==0.20.* dpnp==0.18.*; fi
       if [ -z "${NO_DPC}" ]; then pip install dpcpp-cpp-rt==2025.2.*; fi
       pip list
     env:

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -61,6 +61,7 @@ steps:
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
       # dpep installation is set to pypi to avoid conflict of numpy versions from pip and conda
       if [ [ $(SKLEARN_VERSION) != "1.0" ] && [ -z ${NO_DPC} ]; then pip install dpctl==0.20.* dpnp==0.18.*; fi
+      if [ -z "${NO_DPC}" ]; then pip install dpcpp-cpp-rt==2025.2.*; fi
       pip list
     env:
       NO_DPC: ${{ variables.NO_DPC }}

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -60,7 +60,8 @@ steps:
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
       # dpep installation is set to pypi to avoid conflict of numpy versions from pip and conda
-      if [ $(SKLEARN_VERSION) != "1.0" ] && [ -z ${NO_DPC} ]; then pip install dpctl==0.20.* dpnp==0.18.*; fi
+      if [ $(SKLEARN_VERSION) != "1.0" ] && [ -z ${NO_DPC} ]; then pip install dpctl==0.18.* dpnp==0.16.*; fi
+      # conda-forge dpcpp-cpp-rt is needed to use the dpc build
       if [ -z "${NO_DPC}" ]; then pip install dpcpp-cpp-rt==2025.2.*; fi
       pip list
     env:

--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -60,10 +60,7 @@ steps:
       pip install --upgrade -r requirements-test.txt
       pip install $(python .ci/scripts/get_compatible_scipy_version.py)
       # dpep installation is set to pypi to avoid conflict of numpy versions from pip and conda
-      # py312 is disabled due to segfault on exit of program with usage of dpctl
-      if [ $(echo $(PYTHON_VERSION) | grep '3.9\|3.10\|3.11') ] && [ $(SKLEARN_VERSION) != "1.0" ] && [ -z ${NO_DPC} ]; then pip install dpctl==0.18.* dpnp==0.16.*; fi
-      # issues exist with conda-forge dpcpp-cpp-rt=2025.1.1 it is needed to use the dpc build
-      if [ -z "${NO_DPC}" ]; then pip install dpcpp-cpp-rt==2025.1.*; fi
+      if [ [ $(SKLEARN_VERSION) != "1.0" ] && [ -z ${NO_DPC} ]; then pip install dpctl==0.20.* dpnp==0.18.*; fi
       pip list
     env:
       NO_DPC: ${{ variables.NO_DPC }}

--- a/.ci/scripts/install_dpcpp.sh
+++ b/.ci/scripts/install_dpcpp.sh
@@ -21,5 +21,5 @@ rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
 echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
 sudo add-apt-repository -y "deb https://apt.repos.intel.com/oneapi all main"
 sudo apt-get update
-sudo apt-get install -y intel-dpcpp-cpp-compiler-2025.1
+sudo apt-get install -y intel-dpcpp-cpp-compiler-2025.2
 sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'


### PR DESCRIPTION
## Description



---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
