### PR TITLE
MAINT: Relax test conditions for log-probabilities in model builders

### DIFF
--- a/tests/test_model_builders.py
+++ b/tests/test_model_builders.py
@@ -2072,10 +2072,16 @@ def test_logreg_builder(fit_intercept, stochastic, n_classes):
     )
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", RuntimeWarning)
-        np.testing.assert_almost_equal(
-            model_d4p.predict_log_proba(X[::-1]),
-            model_skl.predict_log_proba(X[::-1]),
-        )
+        try:
+            np.testing.assert_almost_equal(
+                model_d4p.predict_log_proba(X[::-1]),
+                model_skl.predict_log_proba(X[::-1]),
+            )
+        except AssertionError:
+            np.testing.assert_almost_equal(
+                np.exp(model_d4p.predict_log_proba(X[::-1])),
+                np.exp(model_skl.predict_log_proba(X[::-1])),
+            )
 
     np.testing.assert_almost_equal(
         model_d4p.coef_,


### PR DESCRIPTION
## Description

Preliminary work to enable the CI to pass in https://github.com/uxlfoundation/oneDAL/pull/3315

This PR changes a bit the logic of the test for the log-probabilities produced by model builders, to compare the actual probabilities that they translate to in cases where the probabilities are too close to 0 or to 1 and might turn the log-probabilities into infinites or very large numbers.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
