### PR TITLE
FIX: Avoid re-usage of non-reusable daal4py objects

### DIFF
--- a/daal4py/mb/logistic_regression_builders.py
+++ b/daal4py/mb/logistic_regression_builders.py
@@ -97,21 +97,6 @@ class LogisticDAALModel:
         )
         builder.set_beta(coefs, intercepts)
         self._model = builder.model
-        self._alg_pred_class = logistic_regression_prediction(
-            nClasses=self.n_classes_,
-            fptype=self._fptype,
-            resultsToEvaluate="computeClassLabels",
-        )
-        self._alg_pred_prob = logistic_regression_prediction(
-            nClasses=self.n_classes_,
-            fptype=self._fptype,
-            resultsToEvaluate="computeClassProbabilities",
-        )
-        self._alg_pred_logprob = logistic_regression_prediction(
-            nClasses=self.n_classes_,
-            fptype=self._fptype,
-            resultsToEvaluate="computeClassLogProbabilities",
-        )
 
     @property
     def coef_(self):
@@ -133,7 +118,12 @@ class LogisticDAALModel:
             The most probable class, as integer indexes
         """
         return (
-            self._alg_pred_class.compute(X, self._model)
+            logistic_regression_prediction(
+                nClasses=self.n_classes_,
+                fptype=self._fptype,
+                resultsToEvaluate="computeClassLabels",
+            )
+            .compute(X, self._model)
             .prediction.reshape(-1)
             .astype(int)
         )
@@ -151,7 +141,15 @@ class LogisticDAALModel:
         proba : array(n_samples, n_classes)
             The predicted probabilities for each class.
         """
-        return self._alg_pred_prob.compute(X, self._model).probabilities
+        return (
+            logistic_regression_prediction(
+                nClasses=self.n_classes_,
+                fptype=self._fptype,
+                resultsToEvaluate="computeClassProbabilities",
+            )
+            .compute(X, self._model)
+            .probabilities
+        )
 
     predict_proba.__doc__ = predict_proba.__doc__.replace(r"%docstring_X%", _docstring_X)
 
@@ -166,7 +164,15 @@ class LogisticDAALModel:
         log_proba : array(n_samples, n_classes)
             The logarithms of the predicted probabilities for each class.
         """
-        return self._alg_pred_logprob.compute(X, self._model).logProbabilities
+        return (
+            logistic_regression_prediction(
+                nClasses=self.n_classes_,
+                fptype=self._fptype,
+                resultsToEvaluate="computeClassLogProbabilities",
+            )
+            .compute(X, self._model)
+            .logProbabilities
+        )
 
     predict_log_proba.__doc__ = predict_log_proba.__doc__.replace(
         r"%docstring_X%", _docstring_X

--- a/daal4py/mb/logistic_regression_builders.py
+++ b/daal4py/mb/logistic_regression_builders.py
@@ -106,6 +106,15 @@ class LogisticDAALModel:
     def intercept_(self):
         return self._model.Beta[:, 0]
 
+    def _logistic_regression_prediction(
+        self, X: np.ndarray, resultsToEvaluate: str
+    ) -> classifier_prediction_result:
+        return logistic_regression_prediction(
+            nClasses=self.n_classes_,
+            fptype=self._fptype,
+            resultsToEvaluate=resultsToEvaluate,
+        ).compute(X, self._model)
+
     def predict(self, X) -> np.ndarray:
         """
         Predict most probable class
@@ -118,12 +127,7 @@ class LogisticDAALModel:
             The most probable class, as integer indexes
         """
         return (
-            logistic_regression_prediction(
-                nClasses=self.n_classes_,
-                fptype=self._fptype,
-                resultsToEvaluate="computeClassLabels",
-            )
-            .compute(X, self._model)
+            self._logistic_regression_prediction(X, "computeClassLabels")
             .prediction.reshape(-1)
             .astype(int)
         )
@@ -141,15 +145,9 @@ class LogisticDAALModel:
         proba : array(n_samples, n_classes)
             The predicted probabilities for each class.
         """
-        return (
-            logistic_regression_prediction(
-                nClasses=self.n_classes_,
-                fptype=self._fptype,
-                resultsToEvaluate="computeClassProbabilities",
-            )
-            .compute(X, self._model)
-            .probabilities
-        )
+        return self._logistic_regression_prediction(
+            X, "computeClassProbabilities"
+        ).probabilities
 
     predict_proba.__doc__ = predict_proba.__doc__.replace(r"%docstring_X%", _docstring_X)
 
@@ -164,15 +162,9 @@ class LogisticDAALModel:
         log_proba : array(n_samples, n_classes)
             The logarithms of the predicted probabilities for each class.
         """
-        return (
-            logistic_regression_prediction(
-                nClasses=self.n_classes_,
-                fptype=self._fptype,
-                resultsToEvaluate="computeClassLogProbabilities",
-            )
-            .compute(X, self._model)
-            .logProbabilities
-        )
+        return self._logistic_regression_prediction(
+            X, "computeClassLogProbabilities"
+        ).logProbabilities
 
     predict_log_proba.__doc__ = predict_log_proba.__doc__.replace(
         r"%docstring_X%", _docstring_X
@@ -212,11 +204,7 @@ class LogisticDAALModel:
             raise ValueError(
                 "Must request at least one of 'classes', 'proba', 'log_proba'."
             )
-        return logistic_regression_prediction(
-            nClasses=self.n_classes_,
-            fptype=self._fptype,
-            resultsToEvaluate=pred_request,
-        ).compute(X, self._model)
+        return self._logistic_regression_prediction(X, pred_request)
 
     predict_multiple.__doc__ = predict_multiple.__doc__.replace(
         r"%docstring_X%", _docstring_X

--- a/doc/sources/about_daal4py.rst
+++ b/doc/sources/about_daal4py.rst
@@ -61,6 +61,7 @@ idioms - instead, the process for calling procedures from the ``daal4py`` interf
   ``qr_algo = daal4py.qr()``.
 - Call the 'compute' method of that instantiated algorithm in order to obtain a 'result' object,
   passing it the data on which it will operate - for example: ``qr_result = qr_algo.compute(X)``.
+
     .. warning::
 
         Methods such as ``compute`` should only be called **once** on a daal4py object, unless the

--- a/doc/sources/about_daal4py.rst
+++ b/doc/sources/about_daal4py.rst
@@ -61,6 +61,13 @@ idioms - instead, the process for calling procedures from the ``daal4py`` interf
   ``qr_algo = daal4py.qr()``.
 - Call the 'compute' method of that instantiated algorithm in order to obtain a 'result' object,
   passing it the data on which it will operate - for example: ``qr_result = qr_algo.compute(X)``.
+    .. warning::
+
+        Methods such as ``compute`` should only be called **once** on a daal4py object, unless the
+        object is created in streaming mode (see rest of this doc page for more details). If subsequent
+        calls to the same method are needed (e.g. if one wishes to re-fit the model on new data), the
+        object providing this method should be re-created again - otherwise, crashes and spurious
+        errors might happen.
 - Access the relevant results in the 'result' object - for example: ``R = qr_result.matrixR``.
 
 
@@ -111,8 +118,10 @@ can still be loaded in smaller chunks, or for machine learning models that are c
 updated as new data is collected, for example.
 
 In order to use streaming mode, the algorithm constructor needs to be passed argument ``streaming=True``,
-method ``.compute()`` needs to be called multiple times with different data, and the 'result'
-object should be obtained by calling method ``.finalize()`` after all the data has been passed.
+method ``.compute()`` needs to be called multiple times with different data (but note again: methods
+such as ``compute()`` should **not** be called more than once when the algorithm is not in streaming
+mode), and the 'result' object should be obtained by calling method ``.finalize()`` after all the data
+has been passed.
 
 Example: ::
 

--- a/tests/test_model_builders.py
+++ b/tests/test_model_builders.py
@@ -2146,6 +2146,24 @@ def test_logreg_builder_with_deleted_arrays():
     )
 
 
+# This just checks that it doesn't segfault
+def test_logreg_builder_sequential_calls():
+    rng = np.random.default_rng(seed=123)
+    X = rng.standard_normal(size=(5, 10))
+    coefs = rng.standard_normal(size=(3, 10))
+    intercepts = np.zeros(3)
+    ref_pred = X @ coefs.T
+    ref_probs = softmax(ref_pred, axis=1)
+
+    model_d4p = d4p.mb.LogisticDAALModel(coefs, intercepts)
+    pred = model_d4p.predict_log_proba(X)
+    del pred
+    gc.collect()
+    pred = model_d4p.predict_log_proba(X)
+    del pred
+    gc.collect()
+
+
 # Note: these cases are safe to remove if scikit-learn later
 # on decides to disallow some of these combinations.
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

This PR fixes an issue in the model builders for logistic regression that was reusing daal4py objects whose internal C++ objects are destructed after their first use, by re-creating the objects every time.

Along the way, it also adds a big warning in the docs for daal4py that the objects that provide `compute` and similar are not meant to support repeated calls to that method.

Fixes the segfault observed here: https://github.com/uxlfoundation/oneDAL/pull/3315

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.
