### PR TITLE
Deselect PCA dtype test for sklearn=1.4

### DIFF
--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -125,7 +125,7 @@ deselected_tests:
 
   # sklearn 1.4 has different absolute and relative tolerances for this test,
   # set of available solvers and corresponding sklearnex rules to choose one
-  # than newer versions resulting in test failure on specific HW
+  # than newer versions resulting in test failure on specific systems
   - decomposition/tests/test_pca.py::test_pca_dtype_preservation[full] ==1.4
 
   # Non-critical, but there are significant differences due to different implementations

--- a/deselected_tests.yaml
+++ b/deselected_tests.yaml
@@ -123,6 +123,11 @@ deselected_tests:
   - decomposition/tests/test_pca.py::test_pca_svd_solver_auto[1000-500-400-full] >=1.5
   - decomposition/tests/test_pca.py::test_pca_svd_solver_auto[1000-500-0.5-full] >=1.5
 
+  # sklearn 1.4 has different absolute and relative tolerances for this test,
+  # set of available solvers and corresponding sklearnex rules to choose one
+  # than newer versions resulting in test failure on specific HW
+  - decomposition/tests/test_pca.py::test_pca_dtype_preservation[full] ==1.4
+
   # Non-critical, but there are significant differences due to different implementations
   - linear_model/tests/test_common.py::test_balance_property[42-True-LinearRegression]
   - neighbors/tests/test_lof.py::test_lof_dtype_equivalence[0.5-True-brute]


### PR DESCRIPTION
## Description

Deselect `test_pca_dtype_preservation` for sklearn 1.4

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

N/A