### PR TITLE
[WIP, do NOT merge yet] ENH: Try fallback to sklearnex-CPU from GPU calls before fallback to sklearn-CPU + document array API behavior

### DIFF
--- a/doc/sources/array_api.rst
+++ b/doc/sources/array_api.rst
@@ -73,7 +73,7 @@ The following patched classes have support for array API inputs:
 .. note::
     While full array API support is currently not implemented for all classes, :external+dpnp:doc:`dpnp.ndarray <reference/ndarray>`
     and :external+dpctl:doc:`dpctl.tensor <api_reference/dpctl/tensor>` inputs are supported by all the classes
-    that have `GPU support <oneapi_gpu>`__.
+    that have :ref:`GPU support <oneapi_gpu>`.
 
 
 Example usage

--- a/doc/sources/array_api.rst
+++ b/doc/sources/array_api.rst
@@ -85,22 +85,20 @@ DPNP ndarrays
 Example code showcasing how to use :external+dpnp:doc:`dpnp.ndarray <reference/ndarray>` arrays to
 run patched :obj:`sklearn.ensemble.RandomForestRegressor` on a GPU without ``config_context(array_api_dispatch=True)``:
 
-.. collapse:: Example code (click to expand)
+.. toggle::
 
     .. literalinclude:: ../../examples/sklearnex/random_forest_regressor_dpnp.py
            :language: python
-|
 
 DPCTL usm_ndarrays
 ------------------
 Example code showcasing how to use :external+dpctl:doc:`dpctl.tensor <api_reference/dpctl/tensor>` arrays to run
 patched :obj:`sklearn.ensemble.RandomForestClassifier` on a GPU without ``config_context(array_api_dispatch=True)``:
 
-.. collapse:: Example code (click to expand)
+.. toggle::
 
     .. literalinclude:: ../../examples/sklearnex/random_forest_classifier_dpctl.py
            :language: python
-|
 
 As on previous example, if |dpctl| array API namespace was used for training, then fitted attributes will be on the
 CPU, as :obj:`numpy.ndarray` class.
@@ -111,8 +109,7 @@ CPU, as :obj:`numpy.ndarray` class.
 Example code showcasing how to use `array-api-strict <https://github.com/data-apis/array-api-strict>`__
 arrays to run patched :obj:`sklearn.cluster.DBSCAN`.
 
-.. collapse:: Example code (click to expand)
+.. toggle::
 
     .. literalinclude:: ../../examples/sklearnex/dbscan_array_api.py
            :language: python
-|

--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -65,6 +65,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "nbsphinx",
     "sphinx_tabs.tabs",
+    "sphinx_toolbox.collapse",
     "notfound.extension",
     "sphinx_design",
     "sphinx_copybutton",
@@ -75,6 +76,7 @@ extensions = [
 intersphinx_mapping = {
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "dpctl": ("https://intelpython.github.io/dpctl/latest", None),
+    "dpnp": ("https://intelpython.github.io/dpnp", None),
     "mpi4py": ("https://mpi4py.readthedocs.io/en/stable/", None),
     "xgboost": ("https://xgboost.readthedocs.io/en/stable/", None),
     # from scikit-learn, in case some object in sklearnex points to them:

--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -65,7 +65,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "nbsphinx",
     "sphinx_tabs.tabs",
-    "sphinx_toolbox.collapse",
+    "sphinx_togglebutton",
     "notfound.extension",
     "sphinx_design",
     "sphinx_copybutton",

--- a/doc/sources/substitutions.rst
+++ b/doc/sources/substitutions.rst
@@ -13,6 +13,7 @@
 .. limitations under the License.
 
 .. |dpctl| replace:: :external+dpctl:doc:`dpctl <index>`
+.. |dpnp| replace:: :external+dpnp:doc:`dpnp <index>`
 .. |sklearn| replace:: :external+sklearn:doc:`scikit-learn <index>`
 .. |intelex_repo| replace:: |sklearnex| repository
 .. _intelex_repo: https://github.com/uxlfoundation/scikit-learn-intelex

--- a/onedal/utils/_sycl_queue_manager.py
+++ b/onedal/utils/_sycl_queue_manager.py
@@ -211,3 +211,25 @@ def manage_global_queue(queue, *args):
     finally:
         # restore the original queue
         update_global_queue(original_queue)
+
+
+@contextmanager
+def force_host():
+    """
+    Context manager that temporarily enforces a fall back to host.
+
+    Temporarily sets the global queue to the default host fallback and then
+    restores it. Intended to be used as a workaround to check if an operation
+    is supported by oneDAL on CPU even if the data is on GPU.
+
+    Yields
+    ------
+    None : None
+        ``None``, signaling that there's no queue.
+    """
+    original_queue = get_global_queue()
+    try:
+        fallback_to_host()
+        yield get_global_queue()
+    finally:
+        update_global_queue(original_queue)

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -58,6 +58,7 @@ sphinx-design==0.6.1
 sphinx_copybutton==0.5.2
 sphinx-notfound-page==1.1.0
 sphinx-tabs==3.4.7
+sphinx-toolbox==4.0.0
 sphinx_rtd_theme==3.0.2
 sphinxcontrib-applehelp==2.0.0
 sphinxcontrib-devhelp==2.0.0

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -57,7 +57,7 @@ sphinx-book-theme==1.1.3
 sphinx-design==0.6.1
 sphinx_copybutton==0.5.2
 sphinx-notfound-page==1.1.0
-sphinx-tabs==3.4.7
+sphinx-tabs==3.4.6
 sphinx-toolbox==4.0.0
 sphinx_rtd_theme==3.0.2
 sphinxcontrib-applehelp==2.0.0

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -57,8 +57,8 @@ sphinx-book-theme==1.1.3
 sphinx-design==0.6.1
 sphinx_copybutton==0.5.2
 sphinx-notfound-page==1.1.0
-sphinx-tabs==3.4.6
-sphinx-toolbox==4.0.0
+sphinx-tabs==3.4.7
+sphinx-togglebutton==0.3.2
 sphinx_rtd_theme==3.0.2
 sphinxcontrib-applehelp==2.0.0
 sphinxcontrib-devhelp==2.0.0

--- a/sklearnex/_device_offload.py
+++ b/sklearnex/_device_offload.py
@@ -156,6 +156,13 @@ def dispatch(
                 patching_status.write_log(transferred_to_host=False)
                 return branches["sklearn"](obj, *args, **kwargs)
             else:
+                # Will first attempt a fallback to CPU on oneDAL before falling back
+                # to stock scikit-learn.
+                with QM.force_host():
+                    backend, patching_status = _get_backend(obj, method_name, *hostargs)
+                    if backend:
+                        patching_status.write_log()
+                        return branches["onedal"](obj, *hostargs, **hostkwargs)
                 patching_status.write_log()
                 return branches["sklearn"](obj, *hostargs, **hostkwargs)
 


### PR DESCRIPTION
## Description

Currently, when an operation is attempted on GPU and the operation is not supported by oneDAL, sklearnex will fall back straight away to sklearn on CPU, even if the operation might be supported by oneDAL on CPU.

This PR modifies the logic such that it will first check if the operation on CPU would be supported by oneDAL and fall back to it instead of to sklearn.

Along the way, it updates the docs about array API to reflect the current situation in unambiguous terms, and removes lots of outdated things in that page that no longer apply.

A few notes:
* I'm not sure if oneDAL-CPU should have higher or lower priority than sklearn-arrayAPI. Currently, this will pass non-USM array-API inputs to sklearn without attempting a fallback to oneDAL-CPU, which I think is the most reasonable route.
* I am not entirely sure that the mechanism here won't break any kind of contrived setup that's currently working. Please give it a thorough review.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
