### PR TITLE
FIX: Don't change SCIPY_ARRAY_API at runtime

### DIFF
--- a/.ci/scripts/run_sklearn_tests.py
+++ b/.ci/scripts/run_sklearn_tests.py
@@ -25,8 +25,6 @@ import sys
 import pytest
 import sklearn
 
-from daal4py.sklearn._utils import sklearn_check_version
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -45,8 +43,7 @@ if __name__ == "__main__":
     if os.environ["SELECTED_TESTS"] == "all":
         os.environ["SELECTED_TESTS"] = ""
 
-    if sklearn_check_version("1.6"):
-        os.environ["SCIPY_ARRAY_API"] = "1"
+    os.environ["SCIPY_ARRAY_API"] = "1"
 
     pytest_args = (
         f"--rootdir={sklearn_file_dir} "

--- a/.circleci/run_xpu_tests.py
+++ b/.circleci/run_xpu_tests.py
@@ -83,6 +83,8 @@ if __name__ == "__main__":
     if args.json_report_file is not None:
         pytest_params += ["--json-report", f"--json-report-file={args.json_report_file}"]
 
+    os.environ["SCIPY_ARRAY_API"] = "1"
+
     if not args.no_intel_optimized:
         from sklearnex import patch_sklearn
 

--- a/sklearnex/_config.py
+++ b/sklearnex/_config.py
@@ -15,7 +15,6 @@
 # ==============================================================================
 
 from contextlib import contextmanager
-from os import environ
 
 from sklearn import get_config as skl_get_config
 from sklearn import set_config as skl_set_config
@@ -95,10 +94,6 @@ def set_config(
     non-default value (e.g ``cpu`` or ``gpu``) without this backend active
     will raise an error.
     """
-
-    array_api_dispatch = sklearn_configs.get("array_api_dispatch", False)
-    if array_api_dispatch and sklearn_check_version("1.6"):
-        environ["SCIPY_ARRAY_API"] = "1"
 
     skl_set_config(**sklearn_configs)
 


### PR DESCRIPTION
## Description

Attempt at removing runtime changes to environment variable `$SCIPY_ARRAY_API`, changing it instead in the test runners where appropriate, and changing it before importing anything that import scipy or sklearn.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
