### PR TITLE
DOC: Correct argument names for additional tree parameters

### DIFF
--- a/doc/sources/guide/acceleration.rst
+++ b/doc/sources/guide/acceleration.rst
@@ -60,7 +60,7 @@ created histogram.
      - Default value
      - Description
    * - ``max_bins``
-     - `[1, inf)`
+     - `[2, inf)`
      - ``256``
      - Number of bins in the histogram with the discretized training data.
    * - ``min_bin_size``

--- a/doc/sources/guide/acceleration.rst
+++ b/doc/sources/guide/acceleration.rst
@@ -59,26 +59,19 @@ created histogram.
      - Possible values
      - Default value
      - Description
-   * - ``maxBins``
+   * - ``max_bins``
      - `[0, inf)`
      - ``256``
      - Number of bins in the histogram with the discretized training data. The
        value ``0`` disables data discretization.
-   * - ``minBinSize``
+   * - ``min_bin_size``
      - `[1, inf)`
      - ``5``
      - Minimum number of training data points in each bin after discretization.
-   * - ``binningStrategy``
-     - ``quantiles, averages``
-     - ``quantiles``
-     - Selects the algorithm used to calculate bin edges. ``quantiles``
-       results in bins with a similar amount of training data points. ``averages``
-       divides the range of values observed in the training data set into
-       equal-width bins of size `(max - min) / maxBins`.
 
 Note that using discretized training data can greatly accelerate model training
 times, especially for larger data sets. However, due to the reduced fidelity of
 the data, the resulting model can present worse performance metrics compared to
 a model trained on the original data. In such cases, the number of bins can be
-increased with the ``maxBins`` parameter, or binning can be disabled entirely by
-setting ``maxBins=0``.
+increased with the ``max_bins`` parameter, or binning can be disabled entirely by
+setting ``max_bins=0``.

--- a/doc/sources/guide/acceleration.rst
+++ b/doc/sources/guide/acceleration.rst
@@ -60,10 +60,9 @@ created histogram.
      - Default value
      - Description
    * - ``max_bins``
-     - `[0, inf)`
+     - `[1, inf)`
      - ``256``
-     - Number of bins in the histogram with the discretized training data. The
-       value ``0`` disables data discretization.
+     - Number of bins in the histogram with the discretized training data.
    * - ``min_bin_size``
      - `[1, inf)`
      - ``5``

--- a/doc/sources/guide/acceleration.rst
+++ b/doc/sources/guide/acceleration.rst
@@ -72,5 +72,4 @@ Note that using discretized training data can greatly accelerate model training
 times, especially for larger data sets. However, due to the reduced fidelity of
 the data, the resulting model can present worse performance metrics compared to
 a model trained on the original data. In such cases, the number of bins can be
-increased with the ``max_bins`` parameter, or binning can be disabled entirely by
-setting ``max_bins=0``.
+increased with the ``max_bins`` parameter.


### PR DESCRIPTION
## Description

This PR updates the docs about additional parameters accepted by the forest estimators in sklearnex to use the actual names that the arguments take (snake_case, whereas docs use camelCase).

Along the way, it removes one of the parameters that is mentioned in the docs table but is not actually accepted by the estimators, and removes an incorrect description about allowed values for `max_bins`.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
