### PR TITLE
MAINT: Add `NO_DIST=1` for CI jobs that don't run distributed mode

### DIFF
--- a/.ci/pipeline/build-and-test-lnx.yml
+++ b/.ci/pipeline/build-and-test-lnx.yml
@@ -79,6 +79,7 @@ steps:
     env:
       TBBROOT: ${{ variables.TBBROOT }}
       COVERAGE_RCFILE: ${{ variables.COVERAGE_RCFILE }}
+      NO_DIST: 1
     displayName: "Sklearnex testing"
   - script: |
       . /usr/share/miniconda/etc/profile.d/conda.sh
@@ -91,6 +92,7 @@ steps:
       TBBROOT: ${{ variables.TBBROOT }}
       COVERAGE_RCFILE: ${{ variables.COVERAGE_RCFILE }}
       NO_DPC: ${{ variables.NO_DPC }}
+      NO_DIST: 1
     displayName: "Sklearn testing"
     condition: succeededOrFailed()
   - script: |
@@ -103,5 +105,6 @@ steps:
       TBBROOT: ${{ variables.TBBROOT }}
       NO_DPC: ${{ variables.NO_DPC }}
       SKLEARNEX_PREVIEW: "YES"
+      NO_DIST: 1
     displayName: "Sklearn testing [preview]"
     condition: succeededOrFailed()

--- a/.ci/pipeline/build-and-test-win.yml
+++ b/.ci/pipeline/build-and-test-win.yml
@@ -65,6 +65,7 @@ steps:
       COVERAGE_RCFILE: ${{ variables.COVERAGE_RCFILE }}
       DALROOT: ${{ variables.DALROOT }}
       TBBROOT: ${{ variables.TBBROOT }}
+      NO_DIST: 1
   - script: |
       call activate CB
       if defined DALROOT call "%DALROOT%\env\vars.bat"
@@ -77,6 +78,7 @@ steps:
       COVERAGE_RCFILE: ${{ variables.COVERAGE_RCFILE }}
       DALROOT: ${{ variables.DALROOT }}
       TBBROOT: ${{ variables.TBBROOT }}
+      NO_DIST: 1
   - script: |
       call activate CB
       if defined DALROOT call "%DALROOT%\env\vars.bat"
@@ -86,5 +88,6 @@ steps:
       SKLEARNEX_PREVIEW: "YES"
       DALROOT: ${{ variables.DALROOT }}
       TBBROOT: ${{ variables.TBBROOT }}
+      NO_DIST: 1
     displayName: 'Sklearn testing [preview]'
     condition: succeededOrFailed()


### PR DESCRIPTION
## Description

Adds env. variable `$NO_DIST=1` for the CI jobs that are ran here, since they do not install the necessary MPI stack and do not run in distributed mode either.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
