### PR TITLE
TEST: Put daal4py distributed examples under `main()` function body

### DIFF
--- a/examples/daal4py/linear_regression_spmd.py
+++ b/examples/daal4py/linear_regression_spmd.py
@@ -22,10 +22,8 @@ from numpy import loadtxt
 
 import daal4py as d4p
 
-if __name__ == "__main__":
-    # Initialize SPMD mode
-    d4p.daalinit()
 
+def main():
     # Each process gets its own data
     infile = (
         "./data/distributed/linear_regression_train_" + str(d4p.my_procid() + 1) + ".csv"
@@ -59,5 +57,10 @@ if __name__ == "__main__":
         # The prediction result provides prediction
         assert predict_result.prediction.shape == (pdata.shape[0], dep_data.shape[1])
 
+
+if __name__ == "__main__":
+    # Initialize SPMD mode
+    d4p.daalinit()
+    main()
     print("All looks good!")
     d4p.daalfini()

--- a/examples/daal4py/naive_bayes_spmd.py
+++ b/examples/daal4py/naive_bayes_spmd.py
@@ -24,10 +24,8 @@ from numpy import loadtxt
 
 import daal4py as d4p
 
-if __name__ == "__main__":
-    # Initialize SPMD mode
-    d4p.daalinit()
 
+def main():
     # Each process gets its own data
     data_path = Path(__file__).parent / "data" / "batch"
     infile = data_path / "naivebayes_train_dense.csv"
@@ -55,6 +53,10 @@ if __name__ == "__main__":
         # Prediction result provides prediction
         assert presult.prediction.shape == (pdata.shape[0], 1)
 
-        print("All looks good!")
 
+if __name__ == "__main__":
+    # Initialize SPMD mode
+    d4p.daalinit()
+    main()
+    print("All looks good!")
     d4p.daalfini()

--- a/examples/daal4py/pca_spmd.py
+++ b/examples/daal4py/pca_spmd.py
@@ -24,10 +24,8 @@ from numpy import allclose, loadtxt
 
 import daal4py as d4p
 
-if __name__ == "__main__":
-    # Initialize SPMD mode
-    d4p.daalinit()
 
+def main():
     # Each process gets its own data
     data_path = Path(__file__).parent / "data" / "distributed"
     infile = data_path / f"pca_normalized_{d4p.my_procid() + 1}.csv"
@@ -55,5 +53,10 @@ if __name__ == "__main__":
         or allclose(result1.variances, result2.variances)
     )
 
+
+if __name__ == "__main__":
+    # Initialize SPMD mode
+    d4p.daalinit()
+    main()
     print("All looks good!")
     d4p.daalfini()

--- a/examples/daal4py/ridge_regression_spmd.py
+++ b/examples/daal4py/ridge_regression_spmd.py
@@ -23,10 +23,8 @@ from numpy import loadtxt
 
 import daal4py as d4p
 
-if __name__ == "__main__":
-    # Initialize SPMD mode
-    d4p.daalinit()
 
+def main():
     # Each process gets its own data
     infile = (
         "./data/distributed/linear_regression_train_" + str(d4p.my_procid() + 1) + ".csv"
@@ -60,5 +58,10 @@ if __name__ == "__main__":
         # The prediction result provides prediction
         assert predict_result.prediction.shape == (pdata.shape[0], dep_data.shape[1])
 
+
+if __name__ == "__main__":
+    # Initialize SPMD mode
+    d4p.daalinit()
+    main()
     print("All looks good!")
     d4p.daalfini()


### PR DESCRIPTION
## Description

Currently, test runners for distributed daaal4py examples execute code that's put under a function named `main`, but some distributed examples lack this function and thus do not get executed. This PR fixes that.

Note that these tests are not triggered in CI jobs here.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
