### PR TITLE
FIX: Don't prevent oneDAL usage with non-PSD elasticnet/lasso

### DIFF
--- a/daal4py/sklearn/linear_model/_coordinate_descent.py
+++ b/daal4py/sklearn/linear_model/_coordinate_descent.py
@@ -695,9 +695,6 @@ class ElasticNet(ElasticNet_original):
         _X = check_array(
             X, accept_sparse=["csr", "csc", "coo"], dtype=[np.float64, np.float32]
         )
-        good_shape_for_daal = (
-            True if _X.ndim <= 1 else True if _X.shape[0] >= _X.shape[1] else False
-        )
 
         _patching_status = PatchingConditionsChain(
             "sklearn.linear_model.ElasticNet.predict"
@@ -706,11 +703,6 @@ class ElasticNet(ElasticNet_original):
             [
                 (hasattr(self, "daal_model_"), "oneDAL model was not trained."),
                 (not sp.issparse(_X), "X is sparse. Sparse input is not supported."),
-                (
-                    good_shape_for_daal,
-                    "The shape of X does not satisfy oneDAL requirements: "
-                    "number of features > number of samples.",
-                ),
             ]
         )
         _patching_status.write_log()
@@ -808,20 +800,12 @@ class Lasso(Lasso_original):
         _X = check_array(
             X, accept_sparse=["csr", "csc", "coo"], dtype=[np.float64, np.float32]
         )
-        good_shape_for_daal = (
-            True if _X.ndim <= 1 else True if _X.shape[0] >= _X.shape[1] else False
-        )
 
         _patching_status = PatchingConditionsChain("sklearn.linear_model.Lasso.predict")
         _dal_ready = _patching_status.and_conditions(
             [
                 (hasattr(self, "daal_model_"), "oneDAL model was not trained."),
                 (not sp.issparse(_X), "X is sparse. Sparse input is not supported."),
-                (
-                    good_shape_for_daal,
-                    "The shape of X does not satisfy oneDAL requirements: "
-                    "number of features > number of samples.",
-                ),
             ]
         )
         _patching_status.write_log()

--- a/daal4py/sklearn/linear_model/_coordinate_descent.py
+++ b/daal4py/sklearn/linear_model/_coordinate_descent.py
@@ -177,11 +177,7 @@ def _daal4py_fit_enet(self, X, y_, check_input):
         inputArgument = np.zeros((n_rows, n_cols), dtype=_fptype)
         for i in range(n_rows):
             inputArgument[i][0] = self.intercept_ if (n_rows == 1) else self.intercept_[i]
-            inputArgument[i][1:] = (
-                self.coef_[:].copy(order="C")
-                if (n_rows == 1)
-                else self.coef_[i, :].copy(order="C")
-            )
+            inputArgument[i][1:] = self.coef_[:] if (n_rows == 1) else self.coef_[i, :]
         cd_solver.setup(inputArgument)
     doUse_condition = self.copy_X is False or (
         self.fit_intercept and _normalize and self.copy_X

--- a/daal4py/sklearn/linear_model/tests/test_enet.py
+++ b/daal4py/sklearn/linear_model/tests/test_enet.py
@@ -1,0 +1,94 @@
+# ==============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import warnings
+
+import numpy as np
+import pytest
+from sklearn.datasets import make_regression
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.linear_model import ElasticNet as _sklElasticnet
+from sklearn.linear_model import Lasso as _sklLasso
+
+from daal4py.sklearn.linear_model import ElasticNet, Lasso
+
+
+@pytest.mark.parametrize("nrows", [10, 20])
+@pytest.mark.parametrize("ncols", [10, 20])
+@pytest.mark.parametrize("fit_intercept", [False, True])
+@pytest.mark.parametrize("positive", [False, True])
+@pytest.mark.parametrize("l1_ratio", [0.0, 1.0, 0.5])
+def test_enet_is_correct(nrows, ncols, fit_intercept, positive, l1_ratio):
+    X, y = make_regression(n_samples=nrows, n_features=ncols, random_state=123)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ConvergenceWarning)
+        model_d4p = ElasticNet(
+            fit_intercept=fit_intercept,
+            positive=positive,
+            l1_ratio=l1_ratio,
+            tol=1e-7,
+            max_iter=int(1e4),
+        ).fit(X, y)
+        model_skl = _sklElasticnet(
+            fit_intercept=fit_intercept,
+            positive=positive,
+            l1_ratio=l1_ratio,
+            tol=1e-7,
+            max_iter=int(1e4),
+        ).fit(X, y)
+
+    np.testing.assert_allclose(model_d4p.coef_, model_skl.coef_, atol=1e-6, rtol=1e-6)
+    if fit_intercept:
+        np.testing.assert_allclose(
+            model_d4p.intercept_, model_skl.intercept_, atol=1e-6, rtol=1e-6
+        )
+
+    if positive:
+        assert np.all(model_d4p.coef_ >= 0)
+
+
+@pytest.mark.parametrize("nrows", [10, 20])
+@pytest.mark.parametrize("ncols", [10, 20])
+@pytest.mark.parametrize("fit_intercept", [False, True])
+@pytest.mark.parametrize("positive", [False, True])
+@pytest.mark.parametrize("alpha", [1e-2, 1e2])
+def test_lasso_is_correct(nrows, ncols, fit_intercept, positive, alpha):
+    X, y = make_regression(n_samples=nrows, n_features=ncols, random_state=123)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ConvergenceWarning)
+        model_d4p = Lasso(
+            fit_intercept=fit_intercept,
+            positive=positive,
+            alpha=alpha,
+            tol=1e-7,
+            max_iter=int(1e4),
+        ).fit(X, y)
+        model_skl = _sklLasso(
+            fit_intercept=fit_intercept,
+            positive=positive,
+            alpha=alpha,
+            tol=1e-7,
+            max_iter=int(1e4),
+        ).fit(X, y)
+
+    tol = 1e-4 if alpha < 1 else 1e-6
+    np.testing.assert_allclose(model_d4p.coef_, model_skl.coef_, atol=tol, rtol=tol)
+    if fit_intercept:
+        np.testing.assert_allclose(
+            model_d4p.intercept_, model_skl.intercept_, atol=tol, rtol=tol
+        )
+
+    if positive:
+        assert np.all(model_d4p.coef_ >= 0)

--- a/daal4py/sklearn/linear_model/tests/test_enet.py
+++ b/daal4py/sklearn/linear_model/tests/test_enet.py
@@ -95,11 +95,11 @@ def test_lasso_is_correct(nrows, ncols, fit_intercept, positive, alpha):
 
 
 def test_warm_start():
-    X, y = make_regression(n_samples=100, n_features=10, random_state=123)
-    X1 = X[:50]
-    y1 = y[:50]
-    X2 = X[50:]
-    y2 = y[50:]
+    X, y = make_regression(n_samples=20, n_features=10, random_state=123)
+    X1 = X[:10]
+    y1 = y[:10]
+    X2 = X[10:]
+    y2 = y[10:]
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", ConvergenceWarning)

--- a/doc/sources/algorithms.rst
+++ b/doc/sources/algorithms.rst
@@ -131,12 +131,12 @@ Regression
      - All parameters are supported except:
 
        - ``sample_weight`` != `None`
-     - Multi-output and sparse data are not supported.
+     - Sparse data is supported.
    * - :obj:`sklearn.linear_model.Lasso`
      - All parameters are supported except:
 
        - ``sample_weight`` != `None`
-     - Multi-output and sparse data are not supported.
+     - Sparse data is not supported.
 
 Clustering
 **********

--- a/doc/sources/algorithms.rst
+++ b/doc/sources/algorithms.rst
@@ -131,7 +131,7 @@ Regression
      - All parameters are supported except:
 
        - ``sample_weight`` != `None`
-     - Sparse data is supported.
+     - Sparse data is not supported.
    * - :obj:`sklearn.linear_model.Lasso`
      - All parameters are supported except:
 

--- a/doc/sources/algorithms.rst
+++ b/doc/sources/algorithms.rst
@@ -117,26 +117,26 @@ Regression
      - All parameters are supported except:
 
        - ``sample_weight`` != `None`
-       - ``positive`` = `True`
+       - ``positive`` = `True` (this is supported through the class :obj:`sklearn.linear_model.ElasticNet`)
      - Only dense data is supported.
    * - :obj:`sklearn.linear_model.Ridge`
      - All parameters are supported except:
 
        - ``solver`` != `'auto'`
        - ``sample_weight`` != `None`
-       - ``positive`` = `True`
+       - ``positive`` = `True` (this is supported through the class :obj:`sklearn.linear_model.ElasticNet`)
        - ``alpha`` must be a scalar
      - Only dense data is supported.
    * - :obj:`sklearn.linear_model.ElasticNet`
      - All parameters are supported except:
 
        - ``sample_weight`` != `None`
-     - Multi-output and sparse data are not supported, `#observations` should be >= `#features`.
+     - Multi-output and sparse data are not supported.
    * - :obj:`sklearn.linear_model.Lasso`
      - All parameters are supported except:
 
        - ``sample_weight`` != `None`
-     - Multi-output and sparse data are not supported, `#observations` should be >= `#features`.
+     - Multi-output and sparse data are not supported.
 
 Clustering
 **********


### PR DESCRIPTION
## Description

For some reason, there were some checks that avoided calling oneDAL versions of enet and lasso when there are more columns than rows, even though this is actually supported on the C++ side and is the most common reason for wanting to run these algorithms in the first place.

This PR removes those checks, and adds tests to verify that the results match with sklearn.

Along the way, it also makes other corrections and suggestions in the support table for variants of linear regression, in order to accurately reflect the current status.

Note that the implementations match only up to some loose numerical tolerance, unless setting the tolerances to something very tight that would consume a large amount of time.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
