### PR TITLE
DOC: Document lack of support for sparse torch tensors

### DIFF
--- a/doc/sources/array_api.rst
+++ b/doc/sources/array_api.rst
@@ -178,6 +178,11 @@ also extends to cases where :doc:`patching <patching>` is applied, but the ``.fi
 through |sklearn| as a fallback (see :doc:`algorithms` for details) - meaning: ``move_estimator_to`` cannot
 be used with classes from the |sklearnex| regardless of which backend was used to fit the estimator.
 
+Sparse arrays
+~~~~~~~~~~~~~
+
+Currently, sparse arrays from libraries other than SciPy (e.g. ``torch.sparse``) are not supported.
+
 Example usage
 =============
 


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

From some experiments, it appears that some cases with array API support in scikit-learn work fine with sparse torch arrays, even though these aren't strictly part of array API.

In sklearnex, the table convertors do not have any special handling of sparse torch arrays, so they usually error out. This PR documents the lack of support for them.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
