### PR TITLE
[fix] correct split threshold conversion in GBT model builders

### DIFF
--- a/daal4py/mb/gbt_convertors.py
+++ b/daal4py/mb/gbt_convertors.py
@@ -1125,10 +1125,13 @@ def get_gbt_model_from_treelite(
             class_ids, num_trees_per_class = np.unique(
                 model_json["class_id"], return_counts=True
             )
+            # Note: classes without any tree are missing from 'class_ids', hence
+            # the counts cannot be indexed by class number directly.
+            trees_per_class = dict(zip(class_ids.tolist(), num_trees_per_class.tolist()))
             max_tree_per_class = num_trees_per_class.max()
-            num_tree_add_per_class = max_tree_per_class - num_trees_per_class
             for class_ind in range(num_class):
-                for tree in range(num_tree_add_per_class[class_ind]):
+                num_tree_add = max_tree_per_class - trees_per_class.get(class_ind, 0)
+                for _ in range(num_tree_add):
                     add_empty_tree_to_treelite_json(model_json, class_ind)
 
         tree_class_orders = model_json["class_id"]

--- a/daal4py/mb/gbt_convertors.py
+++ b/daal4py/mb/gbt_convertors.py
@@ -115,6 +115,7 @@ class Node:
         default_left: bool,
         feature: int,
         value: float,
+        left_inclusive: bool = False,
         n_children: int = 0,
         left_child: "Optional[Node]" = None,
         right_child: "Optional[Node]" = None,
@@ -126,6 +127,10 @@ class Node:
         self.default_left = default_left
         self.__feature = feature
         self.value = value
+        # whether an observation whose feature value is exactly equal to
+        # 'value' goes to the left child ('x <= value') or to the right
+        # one ('x < value') in the model being converted
+        self.left_inclusive = left_inclusive
         self.n_children = n_children
         self.left_child = left_child
         self.right_child = right_child
@@ -159,6 +164,8 @@ class Node:
             default_left=default_left,
             feature=feature,
             value=input_dict["leaf"] if is_leaf else input_dict["split_condition"],
+            # XGBoost sends observations to the left child when 'x < threshold'
+            left_inclusive=False,
             n_children=n_children,
             left_child=left_child,
             right_child=right_child,
@@ -193,6 +200,8 @@ class Node:
             default_left=tree.get("default_left", 0),
             feature=tree.get("split_feature"),
             value=value,
+            # LightGBM sends observations to the left child when 'x <= threshold'
+            left_inclusive=True,
             n_children=n_children,
             left_child=left_child,
             right_child=right_child,
@@ -219,16 +228,19 @@ class Node:
             right_child = None
 
         value = this_node["leaf_value"] if is_leaf else this_node["threshold"]
+        left_inclusive = False
         if not is_leaf:
             comp = this_node["comparison_op"]
-            if comp == "<=":
-                value = float(np.nextafter(value, np.inf))
-            elif comp in [">", ">="]:
+            if comp in ("<", "<="):
+                left_inclusive = comp == "<="
+            elif comp in (">", ">="):
+                # in oneDAL, the left child always holds the lower values, so
+                # the children are swapped: 'x > t' becomes 'x <= t' and
+                # 'x >= t' becomes 'x < t'
                 left_child, right_child = right_child, left_child
                 default_left = not default_left
-                if comp == ">":
-                    value = float(np.nextafter(value, -np.inf))
-            elif comp != "<":
+                left_inclusive = comp == ">"
+            else:
                 raise TypeError(
                     f"Model to convert contains unsupported split type: {comp}."
                 )
@@ -239,14 +251,31 @@ class Node:
             default_left=default_left,
             feature=this_node.get("split_feature_id"),
             value=value,
+            left_inclusive=left_inclusive,
             n_children=n_children,
             left_child=left_child,
             right_child=right_child,
         )
 
-    def get_value_closest_float_downward(self) -> np.float64:
-        """Get the closest exact fp value smaller than self.value"""
-        return np.nextafter(np.single(self.value), np.single(-np.inf))
+    def get_split_threshold(self) -> np.float32:
+        """Get the split threshold in the form that oneDAL expects
+
+        oneDAL sends an observation to the left child when 'x <= feature_value'
+        and stores the split value as float32, so what needs to be passed is the
+        largest float32 that reproduces the comparison from the model being
+        converted - that is, 'x <= self.value' if 'self.left_inclusive',
+        otherwise 'x < self.value'.
+
+        Note that this is exact for float32 inputs only: float64 values that
+        fall between the returned float32 and the original threshold end up in
+        a different child than they would in the model being converted.
+        """
+        threshold = np.float32(self.value)
+        # Note: casting to float32 rounds to nearest, which might round upwards
+        rounded = float(threshold)
+        if rounded > self.value or (not self.left_inclusive and rounded == self.value):
+            threshold = np.nextafter(threshold, np.float32(-np.inf))
+        return threshold
 
     def get_children(self) -> "Optional[Tuple[Node, Node]]":
         if not self.left_child or not self.right_child:
@@ -433,7 +462,7 @@ def get_gbt_model_from_tree_list(
         parent_id = mb.add_split(
             tree_id=tree_id,
             feature_index=root_node.feature,
-            feature_value=root_node.get_value_closest_float_downward(),
+            feature_value=root_node.get_split_threshold(),
             cover=root_node.cover,
             default_left=root_node.default_left,
         )
@@ -464,7 +493,7 @@ def get_gbt_model_from_tree_list(
                 parent_id = mb.add_split(
                     tree_id=tree_id,
                     feature_index=node.feature,
-                    feature_value=node.get_value_closest_float_downward(),
+                    feature_value=node.get_split_threshold(),
                     cover=node.cover,
                     default_left=node.default_left,
                     parent_id=node.parent_id,

--- a/tests/test_model_builders.py
+++ b/tests/test_model_builders.py
@@ -1622,6 +1622,61 @@ def test_model_from_booster():
     assert tree1.value == 0.2
 
 
+@pytest.mark.parametrize("value", [0.5, 3.25, -1.5, 2.5, 12345.6789, 1e10 + 0.5])
+@pytest.mark.parametrize("left_inclusive", [False, True])
+def test_split_threshold(value, left_inclusive):
+    # oneDAL sends an observation to the left child when 'x <= threshold', so
+    # the converted threshold must route every float32 input to the same child
+    # as the comparison from the model being converted.
+    node = gbt_convertors.Node(
+        cover=1.0,
+        is_leaf=False,
+        default_left=False,
+        feature=0,
+        value=value,
+        left_inclusive=left_inclusive,
+    )
+    threshold = float(node.get_split_threshold())
+
+    # check every float32 within 'n_ulps' of the threshold, from below to above
+    n_ulps = 4
+    x = np.float32(value)
+    for _ in range(n_ulps):
+        x = np.nextafter(x, np.float32(-np.inf))
+    for _ in range(2 * n_ulps + 1):
+        goes_left = (float(x) <= value) if left_inclusive else (float(x) < value)
+        assert (float(x) <= threshold) == goes_left
+        x = np.nextafter(x, np.float32(np.inf))
+
+
+@pytest.mark.parametrize(
+    "comparison_op,left_inclusive,swaps_children",
+    [("<", False, False), ("<=", True, False), (">=", False, True), (">", True, True)],
+)
+def test_treelite_comparison_ops(comparison_op, left_inclusive, swaps_children):
+    nodes = [
+        {
+            "node_id": 0,
+            "split_feature_id": 1,
+            "threshold": 2.0,
+            "comparison_op": comparison_op,
+            "default_left": True,
+            "left_child": 1,
+            "right_child": 2,
+        },
+        {"node_id": 1, "leaf_value": 5.0},
+        {"node_id": 2, "leaf_value": 7.0},
+    ]
+    node = gbt_convertors.Node.from_treelite_dict(nodes, 0)
+
+    assert node.left_inclusive == left_inclusive
+    assert node.default_left == (not swaps_children)
+    assert node.left_child.value == (7.0 if swaps_children else 5.0)
+    assert node.right_child.value == (5.0 if swaps_children else 7.0)
+    # an observation with x == 2.0 must land on the same side as in treelite
+    assert (2.0 <= float(node.get_split_threshold())) == left_inclusive
+
+
 @pytest.mark.skip(reason="causes timeouts in CI")
 @pytest.mark.parametrize("from_treelite", [False, True])
 def test_unsupported_multiclass(from_treelite):


### PR DESCRIPTION
`Node.get_value_closest_float_downward` assumed every split threshold was an exactly representable float32 belonging to an `x < threshold` split. That holds for XGBoost, but the same helper served the LightGBM and treelite conversions, whose splits can be inclusive:

* **LightGBM** compares `x <= threshold`, with genuine float64 thresholds. Stepping down one ulp misroutes observations exactly equal to a threshold, and the unconditional step after the cast lost up to two float32 ulps — `12345.6789` was converted to `12345.677734375`.
* **treelite** nudged the threshold by one *float64* ulp, which the cast to float32 undoes, turning a `<=` split into `<`. The nudge for `>` also went the wrong way: swapping children turns `x > t` into `x <= t`, not `x < t`.

XGBoost predictions are unchanged.

## Testing

Six of the added cases fail before this change. Beyond them, 280 model configurations (8 XGBoost objectives, 8 LightGBM, sklearn GB/RF, each direct and through treelite, across depths, leaf counts, tree counts and seeds) were converted and compared against the source library, scored on random rows plus one row per split sitting exactly on that split's threshold:

| | matched | mismatched |
| --- | --- | --- |
| main | 120 | 160 |
| this branch | 270 | 10 |

150 configurations fixed, none broken.

The 10 remaining all involve a split whose threshold is exactly `-kZeroThreshold` ([`1e-35f`](https://github.com/microsoft/LightGBM/blob/v4.7.0/include/LightGBM/meta.h#L57)) evaluated on an observation equal to it. LightGBM's dense prediction path [drops features with `|value| <= kZeroThreshold` from the row](https://github.com/microsoft/LightGBM/blob/v4.7.0/src/c_api.cpp#L2933-L2947) as a sparsity optimization, leaving `0.0` in their place, so [the comparison it actually performs](https://github.com/microsoft/LightGBM/blob/v4.7.0/include/LightGBM/tree.h#L351) is `0.0 <= -kZeroThreshold` and the observation goes right. The dumped tree says `<=`, which is what both [treelite's GTIL](https://github.com/dmlc/treelite/blob/4.7.0/src/gtil/predict.cc#L98-L124) and this converter follow. Pre-existing and unrelated to this change; matching it would mean disagreeing with treelite on the same model.
