### PR TITLE
FIX: Fall back to sklearn for forest predictions on NaN data

### DIFF
--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -358,9 +358,11 @@ class BaseForest(oneDALEstimator, ABC):
                 return patching_status
             xp, _ = get_namespace(X)
             has_nan = xp.any(xp.isnan(X))
-            patching_status.and_conditions([
-                (not has_nan, "Missing values are not supported."),
-            ])
+            patching_status.and_conditions(
+                [
+                    (not has_nan, "Missing values are not supported."),
+                ]
+            )
 
             if method_name == "predict_proba":
                 patching_status.and_conditions(
@@ -405,7 +407,7 @@ class BaseForest(oneDALEstimator, ABC):
         elif method_name in self._n_jobs_supported_onedal_methods:
             X = data[0]
 
-            patching_status.and_conditions(
+            dal_ready = patching_status.and_conditions(
                 [
                     (hasattr(self, "_onedal_estimator"), "oneDAL model was not trained"),
                     (
@@ -421,6 +423,16 @@ class BaseForest(oneDALEstimator, ABC):
                         self.n_outputs_ == 1,
                         f"Number of outputs ({self.n_outputs_}) is not 1.",
                     ),
+                ]
+            )
+
+            if not dal_ready:
+                return patching_status
+            xp, _ = get_namespace(X)
+            has_nan = xp.any(xp.isnan(X))
+            patching_status.and_conditions(
+                [
+                    (not has_nan, "Missing values are not supported."),
                 ]
             )
 

--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -432,13 +432,17 @@ class BaseForest(oneDALEstimator, ABC):
 
             if not dal_ready:
                 return patching_status
-            xp, _ = get_namespace(X)
-            has_nan = xp.any(xp.isnan(X))
-            patching_status.and_conditions(
-                [
-                    (not has_nan, "Missing values are not supported."),
-                ]
-            )
+
+            try:
+                X_arr = _check_array(X)
+                assert_all_finite(X_arr)
+            except ValueError:
+                patching_status.and_conditions(
+                    [
+                        (False, "Missing values and infinites are not supported."),
+                    ]
+                )
+                return patching_status
 
         else:
             raise RuntimeError(

--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -338,7 +338,7 @@ class BaseForest(oneDALEstimator, ABC):
         elif method_name in self._n_jobs_supported_onedal_methods:
             X = data[0]
 
-            patching_status.and_conditions(
+            dal_ready = patching_status.and_conditions(
                 [
                     (hasattr(self, "_onedal_estimator"), "oneDAL model was not trained."),
                     (not is_sparse(X), "X is sparse. Sparse input is not supported."),
@@ -354,6 +354,13 @@ class BaseForest(oneDALEstimator, ABC):
                     ),
                 ]
             )
+            if not dal_ready:
+                return patching_status
+            xp, _ = get_namespace(X)
+            has_nan = xp.any(xp.isnan(X))
+            patching_status.and_conditions([
+                (not has_nan, "Missing values are not supported."),
+            ])
 
             if method_name == "predict_proba":
                 patching_status.and_conditions(

--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -812,11 +812,13 @@ class ForestClassifier(BaseForest, _sklearn_ForestClassifier):
         else:
             xp, is_array_api_compliant = get_namespace(X, self.classes_)
 
+        # Note: the data will already have been checked for NaNs in the dispatcher
         X = validate_data(
             self,
             X,
             dtype=[xp.float64, xp.float32],
             reset=False,
+            ensure_all_finite=False,
         )
 
         res = self._onedal_estimator.predict(X, queue=queue)
@@ -839,11 +841,13 @@ class ForestClassifier(BaseForest, _sklearn_ForestClassifier):
         else:
             xp, _ = get_namespace(X)
 
+        # Note: the data will already have been checked for NaNs in the dispatcher
         X = validate_data(
             self,
             X,
             dtype=[xp.float64, xp.float32],
             reset=False,
+            ensure_all_finite=False,
         )
 
         # TODO: fix probabilities out of [0, 1] interval on oneDAL side
@@ -1030,11 +1034,13 @@ class ForestRegressor(BaseForest, _sklearn_ForestRegressor):
         check_is_fitted(self, "_onedal_estimator")
         xp, _ = get_namespace(X)
 
+        # Note: the data will already have been checked for NaNs in the dispatcher
         X = validate_data(
             self,
             X,
             dtype=[xp.float64, xp.float32],
             reset=False,
+            ensure_all_finite=False,
         )  # Warning, order of dtype matters
 
         return self._onedal_estimator.predict(X, queue=queue)

--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -356,13 +356,17 @@ class BaseForest(oneDALEstimator, ABC):
             )
             if not dal_ready:
                 return patching_status
-            xp, _ = get_namespace(X)
-            has_nan = xp.any(xp.isnan(X))
-            patching_status.and_conditions(
-                [
-                    (not has_nan, "Missing values are not supported."),
-                ]
-            )
+
+            try:
+                X_arr = _check_array(X)
+                assert_all_finite(X_arr)
+            except ValueError:
+                patching_status.and_conditions(
+                    [
+                        (False, "Missing values and infinites are not supported."),
+                    ]
+                )
+                return patching_status
 
             if method_name == "predict_proba":
                 patching_status.and_conditions(

--- a/sklearnex/ensemble/tests/test_forest.py
+++ b/sklearnex/ensemble/tests/test_forest.py
@@ -344,3 +344,29 @@ def test_rf_mixed_devices(
         proba = model.predict_proba(X)
         assert proba.__class__ == X.__class__
     _ = model.score(X, y)
+
+@pytest.mark.allow_sklearn_fallback
+@pytest.mark.parametrize("estimator_class", [
+    "RandomForestRegressor",
+    "RandomForestClassifier",
+    "ExtraTreesRegressor",
+    "ExtraTreesClassifier",
+])
+def test_predict_with_nan(estimator_class):
+    from sklearnex import ensemble
+
+    model = getattr(ensemble, estimator_class)(n_estimators=2)
+    
+    rng = np.random.default_rng(seed=123)
+    X = rng.standard_normal(size=(10, 4))
+    if is_regressor(model):
+        y = rng.standard_normal(size=X.shape[0])
+    else:
+        y = rng.integers(2, size=X.shape[0])
+
+    model.fit(X, y)
+
+    X_nan = X.copy()
+    X_nan[:, 2:3] = np.nan
+    pred = model.predict(X_nan)
+    assert not np.any(np.isnan(pred))

--- a/sklearnex/ensemble/tests/test_forest.py
+++ b/sklearnex/ensemble/tests/test_forest.py
@@ -345,18 +345,22 @@ def test_rf_mixed_devices(
         assert proba.__class__ == X.__class__
     _ = model.score(X, y)
 
+
 @pytest.mark.allow_sklearn_fallback
-@pytest.mark.parametrize("estimator_class", [
-    "RandomForestRegressor",
-    "RandomForestClassifier",
-    "ExtraTreesRegressor",
-    "ExtraTreesClassifier",
-])
+@pytest.mark.parametrize(
+    "estimator_class",
+    [
+        "RandomForestRegressor",
+        "RandomForestClassifier",
+        "ExtraTreesRegressor",
+        "ExtraTreesClassifier",
+    ],
+)
 def test_predict_with_nan(estimator_class):
     from sklearnex import ensemble
 
     model = getattr(ensemble, estimator_class)(n_estimators=2)
-    
+
     rng = np.random.default_rng(seed=123)
     X = rng.standard_normal(size=(10, 4))
     if is_regressor(model):
@@ -370,3 +374,11 @@ def test_predict_with_nan(estimator_class):
     X_nan[:, 2:3] = np.nan
     pred = model.predict(X_nan)
     assert not np.any(np.isnan(pred))
+
+    score = model.score(X_nan, y)
+    assert not np.isnan(score)
+    assert not np.isinf(score)
+
+    if not is_regressor(model):
+        proba = model.predict_proba(X_nan)
+        assert not np.any(np.isnan(proba))


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

ref https://github.com/uxlfoundation/scikit-learn-intelex/issues/3356

Solves the first point in the issue, in which passing data with missing values to prediction-related methods generates an error, by falling back to scikit-learn in those cases.

Note that this still doesn't produce correct results due to the second problem in the issue (incorrect assignment of missing branches).

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
