### PR TITLE
FIX: Set branch for missing values in sklearn tree structures

### DIFF
--- a/onedal/primitives/tree_visitor.cpp
+++ b/onedal/primitives/tree_visitor.cpp
@@ -299,7 +299,7 @@ void init_get_tree_state(py::module_& m) {
 
             // Sets the 'missing_go_to_left' values on non-terminal nodes.
             // Note that this requires having the values in the arrays
-            // already filled-in for the children of node, so it cannot be
+            // already filled-in for the children of each node, so it cannot be
             // done in the same pass that sets these initial values.
             py::array_t<skl_tree_node>& node_ar = tsv.node_ar;
             skl_tree_node* nodes = static_cast<skl_tree_node*>(node_ar.request().ptr);

--- a/onedal/primitives/tree_visitor.cpp
+++ b/onedal/primitives/tree_visitor.cpp
@@ -296,6 +296,21 @@ void init_get_tree_state(py::module_& m) {
                                                      n_classes);
             node_visitor<Task, decltype(tsv)> tsv_decorator{ &tsv };
             model.traverse_depth_first(iTree, std::move(tsv_decorator));
+
+            // Sets the 'missing_go_to_left' values on non-terminal nodes.
+            // Note that this requires having the values in the arrays
+            // already filled-in for the children of node, so it cannot be
+            // done in the same pass that sets these initial values.
+            py::array_t<skl_tree_node>& node_ar = tsv.node_ar;
+            skl_tree_node* nodes = static_cast<skl_tree_node*>(node_ar.request().ptr);
+            for (size_t node_index = 0; node_index < node_ar.size(); node_index++) {
+                skl_tree_node& node = nodes[node_index];
+                if (node.left_child >= 0 && node.right_child >= 0) {
+                    node.missing_go_to_left = nodes[node.left_child].n_node_samples >=
+                                              nodes[node.right_child].n_node_samples;
+                }
+            }
+
             tree_state_t output = tree_state_t(tsv);
             // convert the value_ar to fractional values, rather than total ones
             // the last axis (2) is the n_classes, which must be summed for the

--- a/onedal/primitives/tree_visitor.cpp
+++ b/onedal/primitives/tree_visitor.cpp
@@ -303,7 +303,7 @@ void init_get_tree_state(py::module_& m) {
             // done in the same pass that sets these initial values.
             py::array_t<skl_tree_node>& node_ar = tsv.node_ar;
             skl_tree_node* nodes = static_cast<skl_tree_node*>(node_ar.request().ptr);
-            for (size_t node_index = 0; node_index < node_ar.size(); node_index++) {
+            for (Py_ssize_t node_index = 0; node_index < node_ar.size(); node_index++) {
                 skl_tree_node& node = nodes[node_index];
                 if (node.left_child >= 0 && node.right_child >= 0) {
                     node.missing_go_to_left = nodes[node.left_child].n_node_samples >=


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

ref https://github.com/uxlfoundation/scikit-learn-intelex/issues/3356

Sets the branch for missing values in decision tree objects according to the same logic that scikit-learn uses.

Note that the branch for missing values is set in the trees according to a majority logic when the input doesn't contain missing values; and this piece of information is still used by scikit-learn when falling back on predictions.

I am not sure if this is all that's needed as I see that the generated trees forwarded to sklearn on .predict() with missing values would still not match against predictions from treelite, for instance.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
