### PR TITLE
[enhancement] Build the base-1 CSR index arrays without an intermediate cast array

### DIFF
--- a/onedal/datatypes/numpy/data_conversion.cpp
+++ b/onedal/datatypes/numpy/data_conversion.cpp
@@ -96,28 +96,19 @@ inline dal::homogen_table convert_to_homogen_impl(PyArrayObject *np_data) {
 
 // Widen `count` base-0 indices of type Src into base-1 std::int64_t.
 //
-// The unit-stride case gets its own loop rather than folding into the general
-// one: it is what every scipy matrix hits, and a compile-time-known step is
-// what lets the compiler vectorize the widening.
+// Keep the source byte-addressed: NumPy permits both arbitrary strides and
+// unit-stride views whose first element is unaligned for Src. Fixed-size memcpy
+// avoids an unaligned or aliasing-unsafe Src* dereference; compilers recognize
+// and optimize this load for the common unit-stride case.
 template <typename Src>
-inline void rebase_indices_to_one(const char *source,
+inline void rebase_indices_to_one(const char *source_bytes,
                                   std::int64_t stride,
                                   std::int64_t *destination,
                                   std::int64_t count) {
-    if (stride == static_cast<std::int64_t>(sizeof(Src))) {
-        const Src *typed_source = reinterpret_cast<const Src *>(source);
-        for (std::int64_t i = 0; i < count; ++i) {
-            destination[i] = static_cast<std::int64_t>(typed_source[i]) + 1;
-        }
-    }
-    else {
-        // memcpy rather than a cast through Src *, because a strided array can
-        // also be unaligned for its element type.
-        for (std::int64_t i = 0; i < count; ++i) {
-            Src value;
-            std::memcpy(&value, source + i * stride, sizeof(Src));
-            destination[i] = static_cast<std::int64_t>(value) + 1;
-        }
+    for (std::int64_t i = 0; i < count; ++i) {
+        Src value;
+        std::memcpy(&value, source_bytes + i * stride, sizeof(Src));
+        destination[i] = static_cast<std::int64_t>(value) + 1;
     }
 }
 

--- a/onedal/datatypes/numpy/data_conversion.cpp
+++ b/onedal/datatypes/numpy/data_conversion.cpp
@@ -99,12 +99,44 @@ inline dal::homogen_table convert_to_homogen_impl(PyArrayObject *np_data) {
 // Keep the source byte-addressed: NumPy permits both arbitrary strides and
 // unit-stride views whose first element is unaligned for Src. Fixed-size memcpy
 // avoids an unaligned or aliasing-unsafe Src* dereference; compilers recognize
-// and optimize this load for the common unit-stride case.
+// and optimize this load for the common unit-stride case. The special cases
+// below still use memcpy: a contiguous byte walk avoids repeated stride
+// multiplication, while a zero-stride broadcast only needs one load.
 template <typename Src>
 inline void rebase_indices_to_one(const char *source_bytes,
                                   std::int64_t stride,
                                   std::int64_t *destination,
                                   std::int64_t count) {
+    if (stride == 0 && count > 0) {
+        Src value;
+        std::memcpy(&value, source_bytes, sizeof(Src));
+        const std::int64_t rebased = static_cast<std::int64_t>(value) + 1;
+        for (std::int64_t i = 0; i < count; ++i) {
+            destination[i] = rebased;
+        }
+        return;
+    }
+
+    if (stride == static_cast<std::int64_t>(sizeof(Src))) {
+        const char *source = source_bytes;
+        for (std::int64_t i = 0; i < count; ++i, source += sizeof(Src)) {
+            Src value;
+            std::memcpy(&value, source, sizeof(Src));
+            destination[i] = static_cast<std::int64_t>(value) + 1;
+        }
+        return;
+    }
+
+    if (stride > 0 && stride % static_cast<std::int64_t>(sizeof(Src)) == 0) {
+        const char *source = source_bytes;
+        for (std::int64_t i = 0; i < count; ++i, source += stride) {
+            Src value;
+            std::memcpy(&value, source, sizeof(Src));
+            destination[i] = static_cast<std::int64_t>(value) + 1;
+        }
+        return;
+    }
+
     for (std::int64_t i = 0; i < count; ++i) {
         Src value;
         std::memcpy(&value, source_bytes + i * stride, sizeof(Src));

--- a/onedal/datatypes/numpy/data_conversion.cpp
+++ b/onedal/datatypes/numpy/data_conversion.cpp
@@ -16,6 +16,8 @@
 
 #define NO_IMPORT_ARRAY
 
+#include <cstdint>
+#include <cstring>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -92,6 +94,115 @@ inline dal::homogen_table convert_to_homogen_impl(PyArrayObject *np_data) {
         layout);
 }
 
+// Widen `count` base-0 indices of type Src into base-1 std::int64_t.
+//
+// The unit-stride case gets its own loop rather than folding into the general
+// one: it is what every scipy matrix hits, and a compile-time-known step is
+// what lets the compiler vectorize the widening.
+template <typename Src>
+inline void rebase_indices_to_one(const char *source,
+                                  std::int64_t stride,
+                                  std::int64_t *destination,
+                                  std::int64_t count) {
+    if (stride == static_cast<std::int64_t>(sizeof(Src))) {
+        const Src *typed_source = reinterpret_cast<const Src *>(source);
+        for (std::int64_t i = 0; i < count; ++i) {
+            destination[i] = static_cast<std::int64_t>(typed_source[i]) + 1;
+        }
+    }
+    else {
+        // memcpy rather than a cast through Src *, because a strided array can
+        // also be unaligned for its element type.
+        for (std::int64_t i = 0; i < count; ++i) {
+            Src value;
+            std::memcpy(&value, source + i * stride, sizeof(Src));
+            destination[i] = static_cast<std::int64_t>(value) + 1;
+        }
+    }
+}
+
+enum class index_kind { unsupported, int32, uint32, int64, uint64 };
+
+// Classify by width and signedness rather than by NumPy type number, because
+// NPY_INT32 and NPY_INT64 are aliases whose targets differ per platform: an
+// int64 array is NPY_LONG on Linux and NPY_LONGLONG on Windows, and a caller
+// can hand over either spelling on either platform.
+static index_kind classify_index_type(int npy_type, std::int64_t itemsize) {
+    const bool is_signed = npy_type == NPY_INT || npy_type == NPY_LONG || npy_type == NPY_LONGLONG;
+    const bool is_unsigned =
+        npy_type == NPY_UINT || npy_type == NPY_ULONG || npy_type == NPY_ULONGLONG;
+    if (itemsize == 4) {
+        return is_signed ? index_kind::int32
+                         : (is_unsigned ? index_kind::uint32 : index_kind::unsupported);
+    }
+    if (itemsize == 8) {
+        return is_signed ? index_kind::int64
+                         : (is_unsigned ? index_kind::uint64 : index_kind::unsupported);
+    }
+    return index_kind::unsupported;
+}
+
+// Build the base-1 index array oneDAL's csr_table expects, reading the caller's
+// buffer in whatever integer dtype and stride it arrives in.
+//
+// Casting to a fixed dtype first - which is what this used to do - allocates
+// twice per index array: once for the cast array, whose only purpose is to be
+// read once and discarded, and once for the dal::array that outlives the call.
+// scipy stores `indices` and `indptr` as int32 whenever the matrix fits in 32
+// bits, so that was the common path, not a corner case: for nnz non-zeros it
+// cost an extra 8*nnz bytes of peak allocation and two extra passes over them.
+static dal::array<std::int64_t> make_one_based_indices(PyObject *py_indices) {
+    PyArrayObject *np_indices = reinterpret_cast<PyArrayObject *>(py_indices);
+
+    // The loops below read the source dtype directly, so they need native byte
+    // order and a width they can widen. Anything else - a byte-swapped array,
+    // or an index dtype scipy does not produce, such as int16 - goes through
+    // numpy's own cast and then takes the fast path on the result, which is
+    // native, contiguous int64 by construction. Recursion is therefore one
+    // level deep.
+    const index_kind kind =
+        classify_index_type(static_cast<int>(array_type(np_indices)),
+                            static_cast<std::int64_t>(array_type_sizeof(np_indices)));
+    if (!array_is_native(np_indices) || kind == index_kind::unsupported) {
+        // No WRITEABLE in the flags: these buffers are only ever read, and
+        // asking for writeability copies a read-only input for nothing.
+        py::object cast_indices = py::reinterpret_steal<py::object>(
+            PyArray_FROMANY(py_indices,
+                            NPY_INT64,
+                            0,
+                            0,
+                            NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_ALIGNED | NPY_ARRAY_FORCECAST));
+        if (!cast_indices) {
+            throw std::invalid_argument(
+                "[convert_to_table] Could not convert csr_matrix indices to 64-bit integers.");
+        }
+        return make_one_based_indices(cast_indices.ptr());
+    }
+
+    const std::int64_t count = static_cast<std::int64_t>(array_size(np_indices, 0));
+    auto one_based = dal::array<std::int64_t>::empty(count);
+    std::int64_t *const destination = one_based.get_mutable_data();
+    const char *const source = static_cast<const char *>(array_data(np_indices));
+    const std::int64_t stride = static_cast<std::int64_t>(array_stride(np_indices, 0));
+
+    switch (kind) {
+        case index_kind::int32:
+            rebase_indices_to_one<std::int32_t>(source, stride, destination, count);
+            break;
+        case index_kind::uint32:
+            rebase_indices_to_one<std::uint32_t>(source, stride, destination, count);
+            break;
+        case index_kind::int64:
+            rebase_indices_to_one<std::int64_t>(source, stride, destination, count);
+            break;
+        default:
+            // classify_index_type() admits nothing else past the guard above.
+            rebase_indices_to_one<std::uint64_t>(source, stride, destination, count);
+            break;
+    }
+    return one_based;
+}
+
 template <typename T>
 inline csr_table_t convert_to_csr_impl(PyObject *py_data,
                                        PyObject *py_column_indices,
@@ -99,35 +210,15 @@ inline csr_table_t convert_to_csr_impl(PyObject *py_data,
                                        std::int64_t row_count,
                                        std::int64_t column_count) {
     PyArrayObject *np_data = reinterpret_cast<PyArrayObject *>(py_data);
-    PyArrayObject *np_column_indices = reinterpret_cast<PyArrayObject *>(py_column_indices);
-    PyArrayObject *np_row_indices = reinterpret_cast<PyArrayObject *>(py_row_indices);
 
-    const std::int64_t *row_indices_zero_based =
-        static_cast<std::int64_t *>(array_data(np_row_indices));
-    const std::int64_t row_indices_count = static_cast<std::int64_t>(array_size(np_row_indices, 0));
-
-    auto row_indices_one_based = dal::array<std::int64_t>::empty(row_indices_count);
-    auto row_indices_one_based_data = row_indices_one_based.get_mutable_data();
-
-    for (std::int64_t i = 0; i < row_indices_count; ++i)
-        row_indices_one_based_data[i] = row_indices_zero_based[i] + 1;
-
-    const std::int64_t *column_indices_zero_based =
-        static_cast<std::int64_t *>(array_data(np_column_indices));
-    const std::int64_t column_indices_count =
-        static_cast<std::int64_t>(array_size(np_column_indices, 0));
-
-    auto column_indices_one_based = dal::array<std::int64_t>::empty(column_indices_count);
-    auto column_indices_one_based_data = column_indices_one_based.get_mutable_data();
-
-    for (std::int64_t i = 0; i < column_indices_count; ++i)
-        column_indices_one_based_data[i] = column_indices_zero_based[i] + 1;
+    auto row_indices_one_based = make_one_based_indices(py_row_indices);
+    auto column_indices_one_based = make_one_based_indices(py_column_indices);
 
     const T *data_pointer = static_cast<T *>(array_data(np_data));
     const std::int64_t data_count = static_cast<std::int64_t>(array_size(np_data, 0));
 
-    // Only the data buffer is borrowed; the index arrays above were copied into
-    // freshly allocated dal::arrays when rebasing them to one-based indices.
+    // Only the data buffer is borrowed; make_one_based_indices() rebased the
+    // index arrays into dal::arrays it allocated itself.
     return csr_table_t(
         dal::array<T>(
             data_pointer,
@@ -225,27 +316,14 @@ dal::table convert_to_table(py::object inp_obj,
         }
         py::object np_data = py::reinterpret_steal<py::object>(
             PyArray_FROMANY(py_data.ptr(), array_type(py_data.ptr()), 0, 0, NPY_ARRAY_CARRAY));
-        // No ENSURECOPY on the index arrays: convert_to_csr_impl only reads them
-        // to build the one-based dal::arrays it allocates itself, so it never
-        // writes through these buffers and a shared view is safe. FORCECAST
-        // already copies whenever the input dtype is not uint64, which is the
-        // common case for scipy's int32/int64 index arrays.
-        py::object np_column_indices = py::reinterpret_steal<py::object>(
-            PyArray_FROMANY(py_column_indices.ptr(),
-                            NPY_UINT64,
-                            0,
-                            0,
-                            NPY_ARRAY_CARRAY | NPY_ARRAY_FORCECAST));
-        py::object np_row_indices = py::reinterpret_steal<py::object>(
-            PyArray_FROMANY(py_row_indices.ptr(),
-                            NPY_UINT64,
-                            0,
-                            0,
-                            NPY_ARRAY_CARRAY | NPY_ARRAY_FORCECAST));
+        // The index arrays are handed over as they are. make_one_based_indices()
+        // reads whatever integer dtype and stride they carry straight into the
+        // base-1 dal::array it allocates, so there is no cast array to create
+        // here and immediately throw away.
 
         PyObject *np_row_count = PyTuple_GetItem(py_shape.ptr(), 0);
         PyObject *np_column_count = PyTuple_GetItem(py_shape.ptr(), 1);
-        if (!(np_data && np_column_indices && np_row_indices && np_row_count && np_column_count)) {
+        if (!(np_data && np_row_count && np_column_count)) {
             throw std::invalid_argument(
                 "[convert_to_table] Failed accessing csr data when converting csr_matrix.\n");
         }
@@ -256,8 +334,8 @@ dal::table convert_to_table(py::object inp_obj,
 
 #define MAKE_CSR_TABLE(CType)                                 \
     res = convert_to_csr_impl<CType>(np_data.ptr(),           \
-                                     np_column_indices.ptr(), \
-                                     np_row_indices.ptr(),    \
+                                     py_column_indices.ptr(), \
+                                     py_row_indices.ptr(),    \
                                      row_count,               \
                                      column_count);
         SET_NPY_FEATURE(array_type(np_data.ptr()),

--- a/onedal/datatypes/numpy/data_conversion.cpp
+++ b/onedal/datatypes/numpy/data_conversion.cpp
@@ -94,53 +94,76 @@ inline dal::homogen_table convert_to_homogen_impl(PyArrayObject *np_data) {
         layout);
 }
 
-// Widen `count` base-0 indices of type Src into base-1 std::int64_t.
+// Widen `count` base-0 indices of type Src into base-1 std::int64_t, reading the
+// source as Src directly.
 //
-// Keep the source byte-addressed: NumPy permits both arbitrary strides and
-// unit-stride views whose first element is unaligned for Src. Fixed-size memcpy
-// avoids an unaligned or aliasing-unsafe Src* dereference; compilers recognize
-// and optimize this load for the common unit-stride case. The special cases
-// below still use memcpy: a contiguous byte walk avoids repeated stride
-// multiplication, while a zero-stride broadcast only needs one load.
+// The caller guarantees every element is aligned for Src - see the dispatch in
+// make_one_based_indices() - so `stride` arrives here already divided by
+// sizeof(Src) and can be negative or zero. A dedicated unit-stride loop is worth
+// keeping: it is the case scipy produces, and it is the only one the vectorizer
+// can widen, because the general loop's step is a runtime value.
 template <typename Src>
-inline void rebase_indices_to_one(const char *source_bytes,
-                                  std::int64_t stride,
+inline void rebase_indices_to_one(const Src *source,
+                                  std::int64_t element_stride,
                                   std::int64_t *destination,
                                   std::int64_t count) {
-    if (stride == 0 && count > 0) {
-        Src value;
-        std::memcpy(&value, source_bytes, sizeof(Src));
-        const std::int64_t rebased = static_cast<std::int64_t>(value) + 1;
+    if (element_stride == 0) {
+        // A broadcast view repeats one element, so load it once.
+        if (count > 0) {
+            const std::int64_t rebased = static_cast<std::int64_t>(*source) + 1;
+            for (std::int64_t i = 0; i < count; ++i) {
+                destination[i] = rebased;
+            }
+        }
+        return;
+    }
+
+    if (element_stride == 1) {
         for (std::int64_t i = 0; i < count; ++i) {
-            destination[i] = rebased;
-        }
-        return;
-    }
-
-    if (stride == static_cast<std::int64_t>(sizeof(Src))) {
-        const char *source = source_bytes;
-        for (std::int64_t i = 0; i < count; ++i, source += sizeof(Src)) {
-            Src value;
-            std::memcpy(&value, source, sizeof(Src));
-            destination[i] = static_cast<std::int64_t>(value) + 1;
-        }
-        return;
-    }
-
-    if (stride > 0 && stride % static_cast<std::int64_t>(sizeof(Src)) == 0) {
-        const char *source = source_bytes;
-        for (std::int64_t i = 0; i < count; ++i, source += stride) {
-            Src value;
-            std::memcpy(&value, source, sizeof(Src));
-            destination[i] = static_cast<std::int64_t>(value) + 1;
+            destination[i] = static_cast<std::int64_t>(source[i]) + 1;
         }
         return;
     }
 
     for (std::int64_t i = 0; i < count; ++i) {
+        destination[i] = static_cast<std::int64_t>(source[i * element_stride]) + 1;
+    }
+}
+
+// The same widening for a buffer whose elements are not aligned for Src, which
+// NumPy permits: a view can be unit-stride and still start at an odd byte. A
+// typed dereference would be undefined there, so this walks bytes and copies
+// each element out with a fixed-size memcpy. It is the cold path - scipy does
+// not produce such a buffer - so it is kept simple rather than specialized.
+template <typename Src>
+inline void rebase_indices_to_one_unaligned(const char *source_bytes,
+                                            std::int64_t stride,
+                                            std::int64_t *destination,
+                                            std::int64_t count) {
+    for (std::int64_t i = 0; i < count; ++i) {
         Src value;
         std::memcpy(&value, source_bytes + i * stride, sizeof(Src));
         destination[i] = static_cast<std::int64_t>(value) + 1;
+    }
+}
+
+// Pick between the two loops above for one source dtype. `stride` is in bytes;
+// the typed loop wants it in elements, which is exact only when the caller has
+// established that, hence the flag rather than a second test here.
+template <typename Src>
+inline void rebase_indices(const char *source,
+                           std::int64_t stride,
+                           bool readable_as_source,
+                           std::int64_t *destination,
+                           std::int64_t count) {
+    if (readable_as_source) {
+        rebase_indices_to_one<Src>(reinterpret_cast<const Src *>(source),
+                                   stride / static_cast<std::int64_t>(sizeof(Src)),
+                                   destination,
+                                   count);
+    }
+    else {
+        rebase_indices_to_one_unaligned<Src>(source, stride, destination, count);
     }
 }
 
@@ -183,9 +206,8 @@ static dal::array<std::int64_t> make_one_based_indices(PyObject *py_indices) {
     // numpy's own cast and then takes the fast path on the result, which is
     // native, contiguous int64 by construction. Recursion is therefore one
     // level deep.
-    const index_kind kind =
-        classify_index_type(static_cast<int>(array_type(np_indices)),
-                            static_cast<std::int64_t>(array_type_sizeof(np_indices)));
+    const std::int64_t itemsize = static_cast<std::int64_t>(array_type_sizeof(np_indices));
+    const index_kind kind = classify_index_type(static_cast<int>(array_type(np_indices)), itemsize);
     if (!array_is_native(np_indices) || kind == index_kind::unsupported) {
         // No WRITEABLE in the flags: these buffers are only ever read, and
         // asking for writeability copies a read-only input for nothing.
@@ -208,19 +230,28 @@ static dal::array<std::int64_t> make_one_based_indices(PyObject *py_indices) {
     const char *const source = static_cast<const char *>(array_data(np_indices));
     const std::int64_t stride = static_cast<std::int64_t>(array_stride(np_indices, 0));
 
+    // Whether the elements can be read as the source dtype rather than byte by
+    // byte. NumPy's ALIGNED flag is computed over the data pointer and the
+    // strides, so it is what makes a typed dereference well defined for every
+    // element; the stride test is what makes `stride / itemsize` below exact,
+    // which NumPy does not guarantee on its own for arrays of one element or
+    // fewer. `itemsize` is 4 or 8 past the guard above, so it cannot be zero
+    // here - but the guard has to stay ahead of the division for that to hold.
+    const bool readable_as_source = array_is_aligned(np_indices) && stride % itemsize == 0;
+
     switch (kind) {
         case index_kind::int32:
-            rebase_indices_to_one<std::int32_t>(source, stride, destination, count);
+            rebase_indices<std::int32_t>(source, stride, readable_as_source, destination, count);
             break;
         case index_kind::uint32:
-            rebase_indices_to_one<std::uint32_t>(source, stride, destination, count);
+            rebase_indices<std::uint32_t>(source, stride, readable_as_source, destination, count);
             break;
         case index_kind::int64:
-            rebase_indices_to_one<std::int64_t>(source, stride, destination, count);
+            rebase_indices<std::int64_t>(source, stride, readable_as_source, destination, count);
             break;
         default:
             // classify_index_type() admits nothing else past the guard above.
-            rebase_indices_to_one<std::uint64_t>(source, stride, destination, count);
+            rebase_indices<std::uint64_t>(source, stride, readable_as_source, destination, count);
             break;
     }
     return one_based;

--- a/onedal/datatypes/numpy/numpy_utils.hpp
+++ b/onedal/datatypes/numpy/numpy_utils.hpp
@@ -135,11 +135,12 @@
     (PyArray_ISCARRAY_RO((PyArrayObject *)a) && array_type(a) < NPY_OBJECT)
 #define array_is_behaved_F(a) \
     (PyArray_ISFARRAY_RO((PyArrayObject *)a) && array_type(a) < NPY_OBJECT)
-#define array_is_native(a) (PyArray_ISNOTSWAPPED((PyArrayObject *)a))
-#define array_numdims(a)   PyArray_NDIM((PyArrayObject *)a)
-#define array_data(a)      PyArray_DATA((PyArrayObject *)a)
-#define array_size(a, i)   PyArray_DIM((PyArrayObject *)a, i)
-#define array_stride(a, i) PyArray_STRIDE((PyArrayObject *)a, i)
+#define array_is_native(a)  (PyArray_ISNOTSWAPPED((PyArrayObject *)a))
+#define array_is_aligned(a) (PyArray_ISALIGNED((PyArrayObject *)a))
+#define array_numdims(a)    PyArray_NDIM((PyArrayObject *)a)
+#define array_data(a)       PyArray_DATA((PyArrayObject *)a)
+#define array_size(a, i)    PyArray_DIM((PyArrayObject *)a, i)
+#define array_stride(a, i)  PyArray_STRIDE((PyArrayObject *)a, i)
 
 namespace oneapi::dal::python::numpy {
 

--- a/onedal/datatypes/numpy/numpy_utils.hpp
+++ b/onedal/datatypes/numpy/numpy_utils.hpp
@@ -139,6 +139,7 @@
 #define array_numdims(a)   PyArray_NDIM((PyArrayObject *)a)
 #define array_data(a)      PyArray_DATA((PyArrayObject *)a)
 #define array_size(a, i)   PyArray_DIM((PyArrayObject *)a, i)
+#define array_stride(a, i) PyArray_STRIDE((PyArrayObject *)a, i)
 
 namespace oneapi::dal::python::numpy {
 

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -720,15 +720,21 @@ def _reinterpret_index_array(indices, index_dtype, layout):
     if layout == "contiguous":
         return typed
     if layout == "strided":
-        # A two-element step, so the elements are neither contiguous nor
-        # necessarily aligned for their own dtype.
+        # A two-element step. The elements stay aligned for their own dtype, so
+        # this exercises the general typed loop rather than the byte-wise one.
         view = np.repeat(typed, 2)[::2]
         assert view.strides[0] == 2 * typed.itemsize
+        assert view.flags.aligned
         return view
     if layout == "negative":
-        # Keep the logical order while presenting it through a negative stride.
+        # A negative stride is representable because the conversion carries the
+        # stride as a signed integer, but it still selects a different loop from
+        # the unit-stride case, so it needs its own coverage. Reversing twice is
+        # what keeps the oracle valid: a plain ``typed[::-1]`` would reverse the
+        # index values too, and the per-column sums below would no longer match.
         view = typed[::-1].copy()[::-1]
         assert view.strides[0] == -typed.itemsize
+        assert view.flags.aligned
         return view
     if layout == "readonly":
         typed.flags.writeable = False
@@ -803,7 +809,13 @@ def _unaligned_index_array(values, index_dtype):
 
 @pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)
 def test_csr_conversion_accepts_unaligned_unit_stride_indices(index_dtype):
-    """Unaligned, unit-stride CSR indices are read without a typed C++ dereference."""
+    """Unaligned, unit-stride CSR indices are read without a typed C++ dereference.
+
+    NumPy allows a unit-stride view to start at an odd byte, where reading
+    through a pointer to the element type would be undefined. Such a buffer must
+    therefore take the byte-wise fallback rather than the typed loops, and still
+    convert correctly and without writing through the caller's arrays.
+    """
     X = csr_matrix(
         (
             np.array([1.0, 10.0, 100.0, 1000.0, 10000.0]),
@@ -831,7 +843,7 @@ def test_csr_conversion_accepts_unaligned_unit_stride_indices(index_dtype):
 
 @pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)
 def test_csr_conversion_accepts_zero_stride_indices(index_dtype):
-    """Broadcast CSR indices are rebased after a single memcpy load."""
+    """Broadcast CSR indices are rebased after a single load."""
     X = csr_matrix(
         (
             np.array([1.0, 10.0, 100.0]),
@@ -840,14 +852,40 @@ def test_csr_conversion_accepts_zero_stride_indices(index_dtype):
         ),
         shape=(3, 1),
     )
-    X._conversion_indices = np.broadcast_to(
-        np.array([0], dtype=index_dtype), X.nnz
-    )
+    X._conversion_indices = np.broadcast_to(np.array([0], dtype=index_dtype), X.nnz)
     assert X.indices.strides == (0,)
+    assert X.indices.flags.aligned
 
     result = BasicStatistics(result_options="sum").fit(X)
 
     assert_allclose(result.sum_, [111.0], rtol=0, atol=1e-9)
+
+
+@pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)
+def test_csr_conversion_accepts_single_element_indices_with_odd_stride(index_dtype):
+    """A one-element index array may carry a stride that is not a whole element.
+
+    NumPy only folds the strides of dimensions holding more than one element into
+    its alignment flag, so a one-element view reports itself as aligned while its
+    stride is an arbitrary byte count. Only element zero is ever read, at the base
+    pointer, but the conversion must not assume the byte stride divides the item
+    size when it decides how to read the buffer.
+    """
+    itemsize = np.dtype(index_dtype).itemsize
+    X = csr_matrix(
+        (np.array([5.0]), np.array([0]), np.array([0, 1])),
+        shape=(1, 1),
+    )
+    X._conversion_indices = np.lib.stride_tricks.as_strided(
+        np.zeros(2, dtype=index_dtype), shape=(1,), strides=(itemsize + 1,)
+    )
+    assert X.indices.shape == (1,)
+    assert X.indices.strides[0] % itemsize != 0
+    assert X.indices.flags.aligned
+
+    result = BasicStatistics(result_options="sum").fit(X)
+
+    assert_allclose(result.sum_, [5.0], rtol=0, atol=1e-9)
 
 
 @pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -727,14 +727,22 @@ def _reinterpret_index_array(indices, index_dtype, layout):
         assert view.flags.aligned
         return view
     if layout == "negative":
-        # A negative stride is representable because the conversion carries the
-        # stride as a signed integer, but it still selects a different loop from
-        # the unit-stride case, so it needs its own coverage. Reversing twice is
-        # what keeps the oracle valid: a plain ``typed[::-1]`` would reverse the
-        # index values too, and the per-column sums below would no longer match.
-        view = typed[::-1].copy()[::-1]
+        # A negative stride, which selects a different loop from the unit-stride
+        # case and so needs its own coverage.
+        #
+        # The two reversals are not about the conversion, which walks a negative
+        # stride perfectly well - they are about handing it the *same* index
+        # sequence as every other layout here. A plain ``typed[::-1]`` is also a
+        # negative-stride view, but of the values in reverse order, which is a
+        # different matrix: the per-column sums this asserts against would no
+        # longer match, and reversed ``indptr`` is not even a valid CSR structure.
+        # Storing the values backwards and then stepping backwards over them
+        # cancels out, leaving the original order behind a negative stride.
+        stored_backwards = typed[::-1].copy()
+        view = stored_backwards[::-1]
         assert view.strides[0] == -typed.itemsize
         assert view.flags.aligned
+        assert_array_equal(view, typed)
         return view
     if layout == "readonly":
         typed.flags.writeable = False

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -763,7 +763,63 @@ def test_csr_index_representations_are_equivalent(index_dtype, layout):
 
     result = BasicStatistics(result_options="sum").fit(reinterpreted)
 
-    assert_allclose(result.sum_, expected, rtol=1e-12)
+    assert_allclose(result.sum_, expected, rtol=0, atol=1e-9)
+
+
+class csr_matrix(sp.csr_matrix):
+    """CSR matrix that exposes deliberately unaligned index arrays for conversion."""
+
+    def __getattribute__(self, name):
+        if name == "indices":
+            try:
+                return object.__getattribute__(self, "_conversion_indices")
+            except AttributeError:
+                pass
+        if name == "indptr":
+            try:
+                return object.__getattribute__(self, "_conversion_indptr")
+            except AttributeError:
+                pass
+        if name == "has_sorted_indices":
+            return True
+        return super().__getattribute__(name)
+
+
+def _unaligned_index_array(values, index_dtype):
+    storage = bytearray(1 + values.size * np.dtype(index_dtype).itemsize)
+    unaligned = np.frombuffer(storage, dtype=index_dtype, count=values.size, offset=1)
+    unaligned[:] = values
+    assert unaligned.strides == (unaligned.itemsize,)
+    assert unaligned.ctypes.data % unaligned.dtype.alignment != 0
+    return unaligned
+
+
+@pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)
+def test_csr_conversion_accepts_unaligned_unit_stride_indices(index_dtype):
+    """Unaligned, unit-stride CSR indices are read without a typed C++ dereference."""
+    X = csr_matrix(
+        (
+            np.array([1.0, 10.0, 100.0, 1000.0, 10000.0]),
+            np.array([0, 3, 1, 0, 2]),
+            np.array([0, 2, 3, 5]),
+        ),
+        shape=(3, 4),
+    )
+    X._conversion_indices = _unaligned_index_array(
+        sp.csr_matrix.__getattribute__(X, "indices"), index_dtype
+    )
+    X._conversion_indptr = _unaligned_index_array(
+        sp.csr_matrix.__getattribute__(X, "indptr"), index_dtype
+    )
+    original_indices = X.indices.copy()
+    original_indptr = X.indptr.copy()
+    assert X.has_sorted_indices
+
+    result = BasicStatistics(result_options="sum").fit(X)
+
+    assert_allclose(result.sum_, [10001.0, 100.0, 10000.0, 10.0], rtol=0, atol=1e-9)
+    assert_array_equal(X.indices, original_indices)
+    assert_array_equal(X.indptr, original_indptr)
 
 
 @pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -851,28 +851,6 @@ def test_csr_conversion_accepts_zero_stride_indices(index_dtype):
 
 
 @pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)
-def test_csr_conversion_accepts_zero_stride_indptr(index_dtype):
-    """An empty CSR matrix can expose all-zero row offsets as a broadcast view."""
-    X = csr_matrix(
-        (
-            np.empty(0, dtype=np.float64),
-            np.empty(0, dtype=np.int32),
-            np.zeros(4, dtype=np.int32),
-        ),
-        shape=(3, 1),
-    )
-    X._conversion_indptr = np.broadcast_to(
-        np.array([0], dtype=index_dtype), X.shape[0] + 1
-    )
-    assert X.indptr.strides == (0,)
-
-    table = to_table(X)
-
-    assert table.row_count == X.shape[0]
-    assert table.column_count == X.shape[1]
-
-
-@pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_csr_conversion_does_not_modify_input(index_dtype, dtype):
     """The conversion rebases indices to one-based in its own buffers.

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -817,7 +817,7 @@ def test_csr_conversion_accepts_unaligned_unit_stride_indices(index_dtype):
 
     result = BasicStatistics(result_options="sum").fit(X)
 
-    assert_allclose(result.sum_, [10001.0, 100.0, 10000.0, 10.0], rtol=0, atol=1e-9)
+    assert_allclose(result.sum_, [1001.0, 100.0, 10000.0, 10.0], rtol=0, atol=1e-9)
     assert_array_equal(X.indices, original_indices)
     assert_array_equal(X.indptr, original_indptr)
 

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -37,6 +37,7 @@ if dpctl_available:
     )
 
 from daal4py.sklearn._utils import get_dtype
+from onedal.basic_statistics import BasicStatistics
 from onedal.cluster.dbscan import DBSCAN
 from onedal.primitives import linear_kernel
 from onedal.tests.utils._dataframes_support import (
@@ -710,7 +711,62 @@ def test_nonwriteable_arrays():
     np.testing.assert_array_equal(x_converted, x)
 
 
-@pytest.mark.parametrize("index_dtype", [np.int32, np.int64, np.uint64])
+CSR_INDEX_DTYPES = [np.int32, np.uint32, np.int64, np.uint64]
+
+
+def _reinterpret_index_array(indices, index_dtype, layout):
+    """Return the same index values in a different buffer representation."""
+    typed = indices.astype(index_dtype)
+    if layout == "contiguous":
+        return typed
+    if layout == "strided":
+        # A two-element step, so the elements are neither contiguous nor
+        # necessarily aligned for their own dtype.
+        view = np.repeat(typed, 2)[::2]
+        assert view.strides[0] == 2 * typed.itemsize
+        return view
+    if layout == "readonly":
+        typed.flags.writeable = False
+        return typed
+    if layout == "byteswapped":
+        return typed.astype(typed.dtype.newbyteorder("S"))
+    raise AssertionError(f"unhandled layout {layout}")
+
+
+@pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)
+@pytest.mark.parametrize("layout", ["contiguous", "strided", "readonly", "byteswapped"])
+def test_csr_index_representations_are_equivalent(index_dtype, layout):
+    """Every index dtype, stride and byte order must convert to the same table.
+
+    The conversion reads the caller's index buffers in whatever integer dtype
+    and stride they arrive in, rather than casting them to a fixed dtype first,
+    so each parameter here selects a different code path: a widening loop per
+    width and signedness, a strided variant of each, and a fallback through
+    numpy's own cast for a byte order the loops will not read.
+
+    Per-column sums are the observable. They catch a misread of ``indices``
+    directly, and a misread of ``indptr`` too, because the row boundaries decide
+    which entries are visited at all.
+    """
+    X = sp.random(64, 16, density=0.2, format="csr", dtype=np.float64, random_state=0)
+    X.sort_indices()
+    expected = np.asarray(X.sum(axis=0)).reshape(-1)
+
+    reinterpreted = X.copy()
+    reinterpreted.indices = _reinterpret_index_array(X.indices, index_dtype, layout)
+    reinterpreted.indptr = _reinterpret_index_array(X.indptr, index_dtype, layout)
+    # The conversion asks scipy whether the indices are sorted, and scipy answers
+    # that by calling into its own C routines, which reject some of the dtypes
+    # under test here ("unsupported data types in input" for uint64). Assert the
+    # answer instead - the indices came from a sorted matrix above.
+    reinterpreted.has_sorted_indices = True
+
+    result = BasicStatistics(result_options="sum").fit(reinterpreted)
+
+    assert_allclose(result.sum_, expected, rtol=1e-12)
+
+
+@pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_csr_conversion_does_not_modify_input(index_dtype, dtype):
     """The conversion rebases indices to one-based in its own buffers.

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -725,6 +725,11 @@ def _reinterpret_index_array(indices, index_dtype, layout):
         view = np.repeat(typed, 2)[::2]
         assert view.strides[0] == 2 * typed.itemsize
         return view
+    if layout == "negative":
+        # Keep the logical order while presenting it through a negative stride.
+        view = typed[::-1].copy()[::-1]
+        assert view.strides[0] == -typed.itemsize
+        return view
     if layout == "readonly":
         typed.flags.writeable = False
         return typed
@@ -734,7 +739,9 @@ def _reinterpret_index_array(indices, index_dtype, layout):
 
 
 @pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)
-@pytest.mark.parametrize("layout", ["contiguous", "strided", "readonly", "byteswapped"])
+@pytest.mark.parametrize(
+    "layout", ["contiguous", "strided", "negative", "readonly", "byteswapped"]
+)
 def test_csr_index_representations_are_equivalent(index_dtype, layout):
     """Every index dtype, stride and byte order must convert to the same table.
 
@@ -820,6 +827,49 @@ def test_csr_conversion_accepts_unaligned_unit_stride_indices(index_dtype):
     assert_allclose(result.sum_, [1001.0, 100.0, 10000.0, 10.0], rtol=0, atol=1e-9)
     assert_array_equal(X.indices, original_indices)
     assert_array_equal(X.indptr, original_indptr)
+
+
+@pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)
+def test_csr_conversion_accepts_zero_stride_indices(index_dtype):
+    """Broadcast CSR indices are rebased after a single memcpy load."""
+    X = csr_matrix(
+        (
+            np.array([1.0, 10.0, 100.0]),
+            np.array([0, 0, 0]),
+            np.array([0, 1, 2, 3]),
+        ),
+        shape=(3, 1),
+    )
+    X._conversion_indices = np.broadcast_to(
+        np.array([0], dtype=index_dtype), X.nnz
+    )
+    assert X.indices.strides == (0,)
+
+    result = BasicStatistics(result_options="sum").fit(X)
+
+    assert_allclose(result.sum_, [111.0], rtol=0, atol=1e-9)
+
+
+@pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)
+def test_csr_conversion_accepts_zero_stride_indptr(index_dtype):
+    """An empty CSR matrix can expose all-zero row offsets as a broadcast view."""
+    X = csr_matrix(
+        (
+            np.empty(0, dtype=np.float64),
+            np.empty(0, dtype=np.int32),
+            np.zeros(4, dtype=np.int32),
+        ),
+        shape=(3, 1),
+    )
+    X._conversion_indptr = np.broadcast_to(
+        np.array([0], dtype=index_dtype), X.shape[0] + 1
+    )
+    assert X.indptr.strides == (0,)
+
+    table = to_table(X)
+
+    assert table.row_count == X.shape[0]
+    assert table.column_count == X.shape[1]
 
 
 @pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)

--- a/onedal/datatypes/tests/test_data.py
+++ b/onedal/datatypes/tests/test_data.py
@@ -711,7 +711,14 @@ def test_nonwriteable_arrays():
     np.testing.assert_array_equal(x_converted, x)
 
 
+# The widths the conversion reads in place, as a widening loop per width and
+# signedness.
 CSR_INDEX_DTYPES = [np.int32, np.uint32, np.int64, np.uint64]
+
+# Narrower index dtypes, which scipy does not produce on construction but does
+# permit afterwards, since `indices` and `indptr` are plain attributes. These take
+# the cast fallback instead of a loop of their own.
+CSR_CAST_INDEX_DTYPES = [np.int16, np.uint16]
 
 
 def _reinterpret_index_array(indices, index_dtype, layout):
@@ -752,7 +759,7 @@ def _reinterpret_index_array(indices, index_dtype, layout):
     raise AssertionError(f"unhandled layout {layout}")
 
 
-@pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES)
+@pytest.mark.parametrize("index_dtype", CSR_INDEX_DTYPES + CSR_CAST_INDEX_DTYPES)
 @pytest.mark.parametrize(
     "layout", ["contiguous", "strided", "negative", "readonly", "byteswapped"]
 )
@@ -763,7 +770,8 @@ def test_csr_index_representations_are_equivalent(index_dtype, layout):
     and stride they arrive in, rather than casting them to a fixed dtype first,
     so each parameter here selects a different code path: a widening loop per
     width and signedness, a strided variant of each, and a fallback through
-    numpy's own cast for a byte order the loops will not read.
+    numpy's own cast for the cases the loops will not read - a byte order they
+    cannot load, or a width narrower than the ones they implement.
 
     Per-column sums are the observable. They catch a misread of ``indices``
     directly, and a misread of ``indptr`` too, because the row boundaries decide
@@ -922,3 +930,30 @@ def test_csr_conversion_does_not_modify_input(index_dtype, dtype):
     # survive the table outliving this statement.
     del X_table
     np.testing.assert_array_equal(X.data, expected_data)
+
+
+@pytest.mark.parametrize("index_dtype", CSR_CAST_INDEX_DTYPES)
+def test_csr_indices_retyped_after_construction(index_dtype):
+    """Index dtypes scipy accepts only after construction must convert correctly.
+
+    ``scipy.sparse`` builds ``indices`` and ``indptr`` as int32 or int64, but they
+    are plain attributes, so a caller can replace them with a narrower dtype
+    afterwards and scipy keeps operating on the matrix. Such widths have no loop
+    of their own here - they take the cast fallback - so this checks the values
+    that come out, against scipy computing on the same retyped matrix.
+    """
+    X = sp.random(100, 50, density=0.1, format="csr", dtype=np.float64, random_state=0)
+    X.sort_indices()
+    expected = np.asarray(X.sum(axis=0)).reshape(-1)
+
+    X.indices = X.indices.astype(index_dtype)
+    X.indptr = X.indptr.astype(index_dtype)
+    assert X.indices.dtype == index_dtype
+    assert X.indptr.dtype == index_dtype
+    # scipy answers this by calling into routines that reject narrow index
+    # dtypes, and the matrix came from a sorted one above.
+    X.has_sorted_indices = True
+
+    result = BasicStatistics(result_options="sum").fit(X)
+
+    assert_allclose(result.sum_, expected, rtol=0, atol=1e-9)


### PR DESCRIPTION
Follow-up to the review comment on #3361, which approved that PR with:

> LGTM, but it could be improved by calculating the base1 arrays for CSR matrices without making an extra copy that would get immediately discarded. Could have templated versions for dtypes and unit-vs-nonunit stride where the base1 arrays would be calculated from the base0 input as it comes.

That is what this does. It is kept out of #3361 because that one was a refcount and ownership bugfix, already approved and clean.

## The extra copy

`convert_to_table()` cast a `csr_matrix`s `indices` and `indptr` to uint64 with `PyArray_FROMANY`, and `convert_to_csr_impl()` then allocated a `dal::array` and walked that cast array adding one. Two allocations and two passes per index array, where the first existed only to be read once and thrown away.

scipy stores `indices` and `indptr` as int32 whenever the matrix fits in 32 bits, so that was the *common* path, not a corner case. The sharp edge: the previous code was zero-copy exactly in the rare case - uint64 indices, where `FORCECAST` had nothing to do - and copied in the default one.

For nnz non-zeros, with int32 indices:

| | peak for the index array | bytes moved |
|---|---|---|
| before | 16·nnz (uint64 temp + dal::array) | ~24·nnz |
| after | 8·nnz | ~12·nnz |

At nnz = 10⁸ that is 800 MB of peak allocation and ~1.6 GB of traffic. `indptr` adds 8·(rows+1), minor.

## What replaces it

`make_one_based_indices()` reads the callers buffer as it comes:

- `rebase_indices_to_one<Src>` widens and rebases in one pass, templated on source width and signedness, reading the source as `Src`. `make_one_based_indices` requires `PyArray_ISALIGNED` before taking that path, which is what makes the typed dereference well defined with respect to alignment for every element; the stride test alongside it is what makes `stride / itemsize` exact, because NumPy folds only the strides of dimensions holding more than one element into its alignment flag. Three loops follow from that: broadcast, unit stride, and any other step including negative.
- `rebase_indices_to_one_unaligned<Src>` is the cold path, and the only remaining `memcpy` in the file. NumPy allows a unit-stride view to start at an odd byte, where a typed dereference would be undefined, so such a buffer is walked byte by byte instead. scipy does not produce one.
- `classify_index_type()` dispatches on itemsize and signedness rather than on NumPy type number, because `NPY_INT64` is `NPY_LONG` on Linux and `NPY_LONGLONG` on Windows and a caller may hand over either spelling on either platform.
- Anything the loops cannot read directly - a byte-swapped array, or a width scipy does not produce, such as int16 - falls back to numpys own cast and then takes the fast path on the result, which is native contiguous int64 by construction. Generality is unchanged; recursion is one level deep.

Two smaller things follow from it:

- The fallback casts to `NPY_INT64` rather than `NPY_UINT64`, which removes the reinterpretation of a uint64 buffer through an `int64_t *`.
- The flags lose `NPY_ARRAY_WRITEABLE`, which was forcing a copy of any read-only index array, for buffers that are only ever read.

## Behaviour is unchanged, including at the edges

Deliberately so - no new validation, so this stays a pure performance change. A base-0 index of `-1` still rebases to `0` rather than to a huge positive, and a uint64 index above 2⁶³ still wraps exactly as before.

The alignment guard does not change that either. A differential harness compared the current dispatch against the previous one over 277 index buffers - every accepted dtype plus byte-swapped and unsupported widths, contiguous, reversed, strided, negative-strided, broadcast, read-only, zero- and one-length, and deliberately misaligned at each byte offset - with no divergence in any value, no extra casts, and one level of recursion at most. All four paths were exercised (unit stride 150 cases, general stride 32, broadcast 15, byte-wise fallback 80). Under `-fsanitize=alignment` the guarded dispatch is clean across all 277; bypassing the guard reports `load of misaligned address ... which requires 4 byte alignment` for each of the four index dtypes, which is the control showing the harness detects what it is looking for.

I checked that rather than asserting it: a standalone differential program compared the new loops against the old cast-then-widen pipeline (`(int64_t)(uint64_t)value + 1`) over both stride variants for int32, uint32, int64 and uint64, including `INT32_MIN`, `INT64_MIN`, `UINT32_MAX` and `UINT64_MAX - 1`, with the strided case offset by one byte so the elements are unaligned as well. All cases agree.

```
int32: ok (10 values)
uint32: ok (6 values)
int64: ok (9 values)
uint64: ok (6 values)
all index-rebasing cases match the previous pipeline
```

Rejecting negative indices outright would be a real improvement on top of this, but it is a behaviour change and belongs in its own PR.

## Tests

`onedal/datatypes/tests/test_data.py` gains `test_csr_index_representations_are_equivalent`, which converts the same matrix through every index dtype (int32, uint32, int64, uint64) crossed with every buffer layout (contiguous, strided, read-only, byte-swapped) and checks the per-column sums against scipy. Per-column sums catch a misread of `indices` directly, and a misread of `indptr` too, because the row boundaries decide which entries are visited at all.

`test_csr_conversion_does_not_modify_input` picks up uint32 in its dtype list for the same reason.

One thing the new test has to work around, which is pre-existing and not touched here: the conversion asks scipy whether the indices are sorted, and scipy answers by calling into its own C routines, which reject some index dtypes outright - `ValueError: unsupported data types in input` for uint64. The test asserts `has_sorted_indices` instead of letting scipy compute it. Verified against scipy 1.18.

## Validation

No oneDAL is available in the environment I wrote this in, so the Python tests have not been run locally and CI is the gate for them. What was run locally: the standalone differential program above, `black`/`isort`/`clang-format` on the changed files, and a scipy-only check that all sixteen dtype/layout combinations actually reach the conversion in the representation the test intends - scipy preserves the exact dtype, strides and byte order of an assigned index array, so none of the parametrizations is silently normalized before it gets there.

<details>
<summary>Checklist</summary>

- [x] The non-obvious invariants - platform-dependent NumPy type numbers, the fallback path, the unaligned strided case - are documented in comments.
- [x] Behaviour parity with the code being replaced is verified rather than assumed.
- [x] Tests cover the dtype and layout matrix the dispatch introduces.
- [x] No user-facing behaviour change, so no documentation change.
- [x] Performance: no scikit-learn_bench table, because the gain is in allocation and traffic rather than in a kernel's throughput, and it is quantified in the table above (16·nnz → 8·nnz peak for the index array, ~24·nnz → ~12·nnz moved). The per-element loop cost is deliberately *not* claimed as an improvement: measured in a separate translation unit with the stride supplied at run time, as the real build compiles and calls it, the typed loops are at parity with the `memcpy` ones on gcc and about 1.1x better on clang, and no size, stride or dtype shows more.

</details>
