### PR TITLE
Add SKLEARNEX_NO_ABS_RPATH flag for conda build

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -28,7 +28,11 @@ if [ -z "${DALROOT}" ]; then
 elif [ "${DALROOT}" != "${CONDA_PREFIX}" ] && [ ! -z "${CONDA_PREFIX}" ]; then
     # source oneDAL if DALROOT is set outside of conda-build
     source ${DALROOT}/env/vars.sh
-    export DALRPATH=--abs-rpath
+    # builds meant for redistribution set this: $DALROOT is a build-machine path there,
+    # which must not end up in the RPATH of the objects that get published
+    if [ -z "${SKLEARNEX_NO_ABS_RPATH}" ]; then
+        export DALRPATH=--abs-rpath
+    fi
 fi
 
 if [ -z "${MPIROOT}" ] && [ -z "${NO_DIST}" ]; then

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -28,8 +28,6 @@ if [ -z "${DALROOT}" ]; then
 elif [ "${DALROOT}" != "${CONDA_PREFIX}" ] && [ ! -z "${CONDA_PREFIX}" ]; then
     # source oneDAL if DALROOT is set outside of conda-build
     source ${DALROOT}/env/vars.sh
-    # builds meant for redistribution set this: $DALROOT is a build-machine path there,
-    # which must not end up in the RPATH of the objects that get published
     if [ -z "${SKLEARNEX_NO_ABS_RPATH}" ]; then
         export DALRPATH=--abs-rpath
     fi

--- a/doc/sources/building-from-source.rst
+++ b/doc/sources/building-from-source.rst
@@ -252,6 +252,7 @@ The following environment variables can be used to control setup aspects:
 - ``NO_STREAM``: set to '1', 'yes' or alike to build without support for streaming mode.
 - ``NO_DPC``: set to '1', 'yes' or alike to build without support of the |onedal| DPC++ interfaces (GPU). Note that building the DPC++ component (default) of this library requires also the DPC++ components of the |onedal| (packages ``dal-gpu`` / ``daal-gpu`` if installing it from ``conda`` or ``pip``).
 - ``MAKEFLAGS``: the last `-j` flag determines the number of threads for building the onedal extension. It will default to the number of CPU threads when not set.
+- ``SKLEARNEX_NO_ABS_RPATH``: set to a non-empty value to stop ``conda-recipe/build.sh`` from adding ``--abs-rpath`` when ``$DALROOT`` points outside of the active conda environment. Intended for builds whose artifacts are redistributed, where the absolute ``$DALROOT`` path only exists on the build machine. Has no effect on direct calls to ``setup.py``.
 
 .. note:: The ``-j`` flag in the ``MAKEFLAGS`` environment variable is superseded in ``setup.py`` modes which support the ``--parallel`` and ``-j`` command line flags.
 


### PR DESCRIPTION
## Description

Published PyPI wheels carry absolute build-machine paths in their `.so` RPATHs. From the current
nightly of `main`:

```
_daal4py...so   RPATH  [<ws>/<hash>/.pixi/envs/build/lib:<ws>/build/.../daal/latest/lib/intel64:$ORIGIN/../../../]
```

Harmless at runtime — `$ORIGIN/../../../` is what resolves oneDAL, from the `daal` wheel — but it leaks
internal build layout into a public artifact.

The `daal/latest/lib/intel64` entry originates here. When `$DALROOT` points outside the active conda
environment, `conda-recipe/build.sh` passes `--abs-rpath`, which makes `setup.py:326` prepend
`$DALROOT/lib/intel64` to the setuptools-built extensions and `scripts/CMakeLists.txt:57` prepend
`${oneDAL_LIBRARY_DIR}` to the CMake-built ones (plus `$MKLROOT/lib` for the two DPC++ ones). That is the
right default for a local build against an out-of-env oneDAL, and wrong only when the artifacts get
shipped to another machine. `SKLEARNEX_NO_ABS_RPATH=1` opts out. Default behavior is unchanged, and
`conda-build` / the conda-forge feedstock never took this branch anyway (`DALROOT` is unset there).

**Scope:** this clears the `$DALROOT`- and `$MKLROOT`-derived entries — 35 of the 43 absolute entries in
the current nightly, and all three CMake-built extensions completely. The other 8 are the first entry in
the example above: conda-forge python reports `-Wl,-rpath,<env>/lib` in `LDSHARED` and setuptools links
with it verbatim, so it reaches the setuptools-built extensions no matter what the recipe passes. No
recipe-level flag can suppress that one, and it is out of scope here.

**Heads-up:** `setup.py` adds the `-s` link flag only when `--abs-rpath` is absent, so setting this also
strips `_daal4py.so` (9,957,160 → 7,433,280 bytes) and `mpi_transceiver.so` (29,504 → 22,904). That
matches what the `conda-build` path has always produced; decoupling the two in `setup.py` would be a
separate change if unwanted.

**Verified** in an internal CI build of this branch. The flag observably takes effect — the `-s` coupling
above is visible in the binaries — and Linux tests, examples and conformance are green on Python
3.10–3.14. The 35-of-43 split is derived from the code paths above measured against a nightly baseline;
that CI run also had a post-link RPATH rewrite active, so it does not isolate this change's effect on its
own.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>

