### PR TITLE
FIX: Fix `__version__` attribute in daal4py and onedal modules

### DIFF
--- a/daal4py/__init__.py
+++ b/daal4py/__init__.py
@@ -68,6 +68,8 @@ except ImportError as e:
 
     raise
 
+__version__ = ".".join([str(v) for v in eval(_get__version__())[:3]])
+
 from . import mb, sklearn
 
-__all__ = ["mb", "sklearn"]
+__all__ = ["__version__", "mb", "sklearn"]

--- a/doc/sources/building-from-source.rst
+++ b/doc/sources/building-from-source.rst
@@ -244,7 +244,7 @@ Environment variables
 
 The following environment variables can be used to control setup aspects:
 
-- ``SKLEARNEX_VERSION``: sets the package version.
+- ``SKLEARNEX_VERSION``: sets the ``__version__`` attribute for the ``sklearnex`` module. Note that the ``onedal_py_*`` and ``daal4py`` modules instead determine their ``__version__`` string at runtime according to the version from |onedal| that gets loaded.
 - ``DALROOT``: sets the |onedal| path.
 - ``MKLROOT``: path to the oneMKL runtime libraries, which are used for the DPC module. This variable is optional and only has an effect when using the option ``abs-rpath`` on Linux* (see the rest of this page for details).
 - ``MPIROOT``: sets the path to the MPI library. If this variable is not set but ``I_MPI_ROOT`` is found, will use ``I_MPI_ROOT`` instead. Not used when using ``NO_DIST=1``.

--- a/onedal/__init__.py
+++ b/onedal/__init__.py
@@ -218,8 +218,11 @@ def onedal_check_version(
     return _v >= (major, minor, update)
 
 
+__version__ = ".".join([str(v) for v in _default_backend.__version_tuple__])
+
 # Core modules and functions to export
 __all__ = [
+    "__version__",
     "_ensure_dpc_available",
     "_host_backend",
     "_default_backend",
@@ -244,5 +247,3 @@ if onedal_check_version(2023, 2, 0):
 # Exports if SPMD backend is available
 if _spmd_backend is not None:
     __all__ += ["spmd"]
-
-__version__ = "2199.9.9"

--- a/setup.py
+++ b/setup.py
@@ -439,7 +439,7 @@ class onedal_build:
         self.onedal_post_build()
         if hasattr(self, "build_lib"):
             # swap out __version__ before install
-            for p in ["onedal", "sklearnex"]:
+            for p in ["sklearnex"]:
                 loc = os.sep.join((self.build_lib, p, "__init__.py"))
                 if os.path.isfile(loc):
                     with open(loc, "r+") as f:

--- a/setup.py
+++ b/setup.py
@@ -439,14 +439,13 @@ class onedal_build:
         self.onedal_post_build()
         if hasattr(self, "build_lib"):
             # swap out __version__ before install
-            for p in ["sklearnex"]:
-                loc = os.sep.join((self.build_lib, p, "__init__.py"))
-                if os.path.isfile(loc):
-                    with open(loc, "r+") as f:
-                        data = f.read().replace("2199.9.9", sklearnex_version)
-                        f.seek(0)
-                        f.write(data)
-                        f.truncate()
+            loc = os.sep.join((self.build_lib, "sklearnex", "__init__.py"))
+            if os.path.isfile(loc):
+                with open(loc, "r+") as f:
+                    data = f.read().replace("2199.9.9", sklearnex_version)
+                    f.seek(0)
+                    f.write(data)
+                    f.truncate()
 
     def onedal_run(self):
         n_threads = self.parallel


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

This attribute is not present in daal4py and is hard-coded in the onedal module, but it can be queried at runtime instead of being set at install time.

ref https://github.com/uxlfoundation/scikit-learn-intelex/issues/3377

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
