### PR TITLE
MAINT: Reuse onedal utils to check X shape in SVM dispatcher

### DIFF
--- a/sklearnex/svm/_base.py
+++ b/sklearnex/svm/_base.py
@@ -34,6 +34,7 @@ from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_is_fitted, column_or_1d
 
 from daal4py.sklearn._utils import sklearn_check_version
+from onedal.utils.validation import _num_samples
 
 if sklearn_check_version("1.9"):
     from sklearn.utils._sparse import _align_api_if_sparse
@@ -418,7 +419,7 @@ class BaseSVM(oneDALEstimator):
                             not self._is_multi_class_classifier()
                             and (
                                 not sp.issparse(self.support_vectors_)
-                                or (hasattr(X, "shape") and X.shape[0] > 1)
+                                or (_num_samples(X) > 1)
                             )
                         ),
                         "Single-row prediction from a scikit-learn model has"


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Reuses a util from onedal to check shapes instead of looking for shapes attributes before array enforcement.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
