### PR TITLE
Separate dummy revisions from array api force update

### DIFF
--- a/onedal/dummy/dummy_onedal.hpp
+++ b/onedal/dummy/dummy_onedal.hpp
@@ -19,7 +19,7 @@
 #include "onedal/common.hpp"
 #include "onedal/version.hpp"
 #include "oneapi/dal/table/common.hpp"
-#include "oneapi/dal/table/detail/homogen_utils.hpp"
+#include "oneapi/dal/table/row_accessor.hpp"
 #include "oneapi/dal/train.hpp"
 #include "oneapi/dal/infer.hpp"
 #include "oneapi/dal/detail/policy.hpp"
@@ -212,6 +212,23 @@ dal::homogen_table create_full_table(const data_parallel_policy& ctx,
 }
 #endif
 
+// Table data must always be read through an accessor. Dereferencing the
+// table's pointer directly is undefined behavior when it is device USM,
+// which is the case whenever the fitted attribute came from a framework
+// that allocates on device (e.g. a torch xpu tensor).
+template <typename float_t>
+float_t read_first_element(const host_policy& ctx, const dal::table& tbl) {
+    return dal::row_accessor<const float_t>{ tbl }.pull({ 0, 1 })[0];
+}
+
+#ifdef ONEDAL_DATA_PARALLEL
+template <typename float_t>
+float_t read_first_element(const data_parallel_policy& ctx, const dal::table& tbl) {
+    auto queue = ctx.get_queue();
+    return dal::row_accessor<const float_t>{ tbl }.pull(queue, { 0, 1 }, sycl::usm::alloc::host)[0];
+}
+#endif
+
 ////////////////////////////// train_ops.hpp //////////////////////////////
 namespace dummy {
 namespace detail {
@@ -270,33 +287,10 @@ struct infer_ops {
         // Due to the simplicity of this algorithm, implement it here.
         auto row_c = input.data.get_row_count();
         auto col_c = input.constant.get_column_count();
-        assert(input.constant.get_kind() == dal::homogen_table::kind());
         result_t result;
-        const byte_t* ptr =
-            dal::detail::get_original_data(static_cast<const dal::homogen_table&>(input.constant))
-                .get_data();
-
-        float_t inp;
-        // only switch those types which can be converted from python to dal tables
-        switch (input.constant.get_metadata().get_data_type(0)) {
-            case dal::data_type::float32: {
-                inp = static_cast<float_t>(*reinterpret_cast<const float*>(ptr));
-                break;
-            }
-            case dal::data_type::float64: {
-                inp = static_cast<float_t>(*reinterpret_cast<const double*>(ptr));
-                break;
-            }
-            case dal::data_type::int32: {
-                inp = static_cast<float_t>(*reinterpret_cast<const std::int32_t*>(ptr));
-                break;
-            }
-            case dal::data_type::int64: {
-                inp = static_cast<float_t>(*reinterpret_cast<const std::int64_t*>(ptr));
-                break;
-                default: throw std::runtime_error("incompatible input type");
-            }
-        }
+        // The accessor converts from the table's own data type, so no dispatch
+        // over 'get_metadata().get_data_type(0)' is needed here.
+        const float_t inp = read_first_element<float_t>(ctx, input.constant);
         result.set_data(create_full_table<float_t>(ctx, row_c, col_c, inp));
         return result;
     }


### PR DESCRIPTION
The dummy backend's infer_ops dereferenced the constant table's data pointer directly. That is a host read, so it segfaults rather than raising once the fitted attribute is device USM, which happens whenever constant_ comes from a framework that allocates on device (e.g. a torch xpu tensor).

Pull the value through dal::row_accessor<const float_t> instead: pull({0,1}) on the host policy, pull(queue, {0,1}, sycl::usm::alloc::host) under ONEDAL_DATA_PARALLEL. The accessor also converts from the table's own data type, so the manual switch over get_metadata().get_data_type(0) is no longer needed.

Note this removes the assert corrected in #3360: the code no longer casts to homogen_table, so there is nothing left for it to guard.

## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
