### PR TITLE
FIX: Issue ConvergeWarning from KMeans

### DIFF
--- a/sklearnex/cluster/k_means.py
+++ b/sklearnex/cluster/k_means.py
@@ -261,6 +261,18 @@ if daal_check_version((2023, "P", 200)):
 
             self._save_attributes()
 
+            # This mimics a warning issued by scikit-learn.
+            # Added for compatibility.
+            n_distinct_cluisters = xp.unique_values(self.labels_).shape[0]
+            if n_distinct_cluisters != self.cluster_centers_.shape[0]:
+                warnings.warn(
+                    "Number of distinct clusters ({}) found smaller than "
+                    "n_clusters ({}). Possibly due to duplicate points "
+                    "in X.".format(n_distinct_cluisters, self.n_clusters),
+                    ConvergenceWarning,
+                    stacklevel=2,
+                )
+
         def _validate_sample_weight(self, sample_weight, X):
             """Check if sample_weight is acceptable for oneDAL.
 


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Follow up from https://github.com/uxlfoundation/oneDAL/pull/3742#discussion_r3875186909

When KMeans ends up with empty clusters, scikit-learn throws a warning. This PR mimics their behavior by throwing the same warning. This doesn't have tests right now because it depends on https://github.com/uxlfoundation/oneDAL/pull/3742 being merged to be able to make good tests.

Logic can be revisited in a future version if oneDAL starts outputting a flag about whether to throw this warning or not.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
