### PR TITLE
resolve kmeans spmd example issues:

### DIFF
--- a/sklearnex/cluster/k_means.py
+++ b/sklearnex/cluster/k_means.py
@@ -476,6 +476,10 @@ if daal_check_version((2023, "P", 200)):
             self.n_iter_ = self._onedal_estimator.n_iter_
             self.n_features_in_ = self._onedal_estimator.n_features_in_
 
+            self._warn_on_degenerate_clustering()
+
+        def _warn_on_degenerate_clustering(self):
+            """Warn when fewer than n_clusters clusters received any point."""
             xp, _ = get_namespace(self.labels_)
             unique_func = getattr(xp, "unique_values", np.unique)
             distinct_clusters = unique_func(self.labels_).shape[0]

--- a/sklearnex/spmd/cluster/kmeans.py
+++ b/sklearnex/spmd/cluster/kmeans.py
@@ -20,6 +20,11 @@ from ...cluster import KMeans as base_KMeans
 
 
 class KMeans(base_KMeans):
+    def _warn_on_degenerate_clustering(self):
+        # labels_ only covers this rank's shard, so a cluster missing from it means no
+        # point of that cluster landed here -- not that the global clustering degenerated.
+        pass
+
     def _initialize_onedal_estimator(self):
         """Override to use SPMD backend instead of batch backend."""
         onedal_params = {

--- a/sklearnex/spmd/cluster/tests/test_kmeans_spmd.py
+++ b/sklearnex/spmd/cluster/tests/test_kmeans_spmd.py
@@ -18,7 +18,6 @@ import warnings
 
 import numpy as np
 import pytest
-from mpi4py import MPI
 from numpy.testing import assert_allclose
 from sklearn.exceptions import ConvergenceWarning
 
@@ -198,17 +197,19 @@ def test_kmeans_spmd_synthetic(
 )
 @pytest.mark.mpi
 def test_kmeans_spmd_no_convergence_warning_on_partial_shard(dataframe, queue):
-    # A rank whose shard holds points of only one cluster must not warn: labels_ is
-    # rank-local, so a local shortfall says nothing about the global clustering.
+    # A rank whose shard misses a cluster entirely must not warn: labels_ is rank-local,
+    # so a local shortfall says nothing about the global clustering.
     from sklearnex.spmd.cluster import KMeans as KMeans_SPMD
 
-    rank = MPI.COMM_WORLD.Get_rank()
-    n_clusters = MPI.COMM_WORLD.Get_size()
-
+    n_clusters = 4
     centers = np.arange(n_clusters, dtype=np.float64)[:, None] * 100.0
-    X = centers[rank % n_clusters] + np.linspace(-1.0, 1.0, 50)[:, None]
+    # Blobs laid out contiguously, so each rank's slice covers only some of them.
+    jitter = np.tile(np.linspace(-1.0, 1.0, 50), n_clusters)[:, None]
+    X = np.repeat(centers, 50, axis=0) + jitter
 
-    local_X = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
+    local_X = _convert_to_dataframe(
+        _get_local_tensor(X), sycl_queue=queue, target_df=dataframe
+    )
     local_init = _convert_to_dataframe(centers, sycl_queue=queue, target_df=dataframe)
 
     with config_context(array_api_dispatch=True):
@@ -218,5 +219,5 @@ def test_kmeans_spmd_no_convergence_warning_on_partial_shard(dataframe, queue):
                 local_X
             )
 
-    # Sanity: the shard really does cover a single cluster.
-    assert len(np.unique(_as_numpy(model.labels_))) == 1
+    if len(np.unique(_as_numpy(model.labels_))) == n_clusters:
+        pytest.skip("shard covers every cluster, so there is nothing to check")

--- a/sklearnex/spmd/cluster/tests/test_kmeans_spmd.py
+++ b/sklearnex/spmd/cluster/tests/test_kmeans_spmd.py
@@ -14,9 +14,13 @@
 # limitations under the License.
 # ==============================================================================
 
+import warnings
+
 import numpy as np
 import pytest
+from mpi4py import MPI
 from numpy.testing import assert_allclose
+from sklearn.exceptions import ConvergenceWarning
 
 from onedal.tests.utils._dataframes_support import (
     _convert_to_dataframe,
@@ -182,3 +186,37 @@ def test_kmeans_spmd_synthetic(
         batch_model.cluster_centers_,
         atol=atol,
     )
+
+
+@pytest.mark.skipif(
+    not _mpi_libs_and_gpu_available,
+    reason="GPU device and MPI libs required for test",
+)
+@pytest.mark.parametrize(
+    "dataframe,queue",
+    get_dataframes_and_queues(dataframe_filter_="dpnp,torch", device_filter_="gpu"),
+)
+@pytest.mark.mpi
+def test_kmeans_spmd_no_convergence_warning_on_partial_shard(dataframe, queue):
+    # A rank whose shard holds points of only one cluster must not warn: labels_ is
+    # rank-local, so a local shortfall says nothing about the global clustering.
+    from sklearnex.spmd.cluster import KMeans as KMeans_SPMD
+
+    rank = MPI.COMM_WORLD.Get_rank()
+    n_clusters = MPI.COMM_WORLD.Get_size()
+
+    centers = np.arange(n_clusters, dtype=np.float64)[:, None] * 100.0
+    X = centers[rank % n_clusters] + np.linspace(-1.0, 1.0, 50)[:, None]
+
+    local_X = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
+    local_init = _convert_to_dataframe(centers, sycl_queue=queue, target_df=dataframe)
+
+    with config_context(array_api_dispatch=True):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ConvergenceWarning)
+            model = KMeans_SPMD(n_clusters=n_clusters, init=local_init, n_init=1).fit(
+                local_X
+            )
+
+    # Sanity: the shard really does cover a single cluster.
+    assert len(np.unique(_as_numpy(model.labels_))) == 1


### PR DESCRIPTION
## Description

Addresses infrequent but persistent error in KMeans spmd examples where not all clusters are represented on a given rank by warning for non-spmd but not on spmd as it's a realistic scenario that shouldn't be a cause for concern.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
