### PR TITLE
FIX: Fix potential use-after-free in array views from CSR tables

### DIFF
--- a/onedal/datatypes/numpy/data_conversion.cpp
+++ b/onedal/datatypes/numpy/data_conversion.cpp
@@ -494,6 +494,13 @@ static PyObject *convert_to_py_from_csr_impl(const detail::csr_table &table) {
 
 // dal::csr_table class is valid
 // zero- and one-based indeices are supported
+// Note: this creates deep copies of all the data arrays in the CSR matrix,
+// with both the resulting NumPy arrays and the oneDAL table being responsible
+// for freeing their own data. It is purposefully done this way instead of
+// creating NumPy arrays out of raw data pointers, because the resulting NumPy
+// arrays might outlive the oneDAL table. If a better approach is found in the
+// future, it would be better to have shared pointers instead, like it is done
+// for dense oneDAL tables.
 template <int NpType, typename T>
 static PyObject *convert_to_py_from_csr_impl(const csr_table &table) {
     PyObject *result = PyTuple_New(3);
@@ -525,7 +532,8 @@ static PyObject *convert_to_py_from_csr_impl(const csr_table &table) {
     }
 
     const T *data = table.get_data<T>();
-    auto data_array = dal::array<T>::wrap(data, non_zero_count);
+    dal::array<T> data_array = dal::array<T>::empty(non_zero_count);
+    std::copy(data, data + non_zero_count, data_array.get_mutable_data());
 
     PyObject *py_data = convert_to_numpy_impl<NpType, T>(data_array, non_zero_count);
     PyTuple_SetItem(result, 0, py_data);


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Follow up from https://github.com/uxlfoundation/scikit-learn-intelex/pull/3403

This is a workaround that prevents a potential memory safety issue when a numpy array with non-owning data is generated from a pointer that came out of a oneDAL CSR table and that table gets destructed while the resulting array is still alive.

It is quite inefficient as it is duplicating the data, but I cannot think of any better solution given the public interfaces from oneDAL classes.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
