### PR TITLE
MAINT: Use scikit-learn on RandomForest with single-column data on CPU

### DIFF
--- a/doc/sources/algorithms.rst
+++ b/doc/sources/algorithms.rst
@@ -73,7 +73,7 @@ Classification
        - ``bootstrap`` = ``True`` and/or ``max_samples`` != ``None`` are not supported when there are sample weights
        - Non-integer ``max_samples`` larger than 1 or integer ``max_samples`` greater than number of rows, with ``bootstrap=True``
      - Multi-output and sparse data are not supported. Missing values and infinite values are not supported.
-     - Number of classes must be at least 2. Nothing will be printed if ``verbose > 0``.
+     - Number of classes must be at least 2. Nothing will be printed if ``verbose > 0``. Fitting to single-column data is only supported in :doc:`preview mode <preview>`.
    * - :obj:`sklearn.ensemble.ExtraTreesClassifier`
      - All parameters are supported except:
 
@@ -84,7 +84,7 @@ Classification
        - ``bootstrap`` = ``True`` and/or ``max_samples`` != ``None`` are not supported when there are sample weights
        - Non-integer ``max_samples`` larger than 1 or integer ``max_samples`` greater than number of rows, with ``bootstrap=True``
      - Multi-output and sparse data are not supported. Missing values and infinite values are not supported.
-     - Number of classes must be at least 2. Nothing will be printed if ``verbose > 0``.
+     - Number of classes must be at least 2. Nothing will be printed if ``verbose > 0``. Fitting to single-column data is only supported in :doc:`preview mode <preview>`.
    * - :obj:`sklearn.neighbors.KNeighborsClassifier`
      -
        - For ``algorithm`` == ``'kd_tree'``:
@@ -149,7 +149,7 @@ Regression
        - ``bootstrap`` = ``True`` and/or ``max_samples`` != ``None`` are not supported when there are sample weights
        - Non-integer ``max_samples`` larger than 1 or integer ``max_samples`` greater than number of rows, with ``bootstrap=True``
        - Nothing will be printed if ``verbose > 0``
-     - Multi-output and sparse data are not supported. Missing values and infinite values are not supported.
+     - Multi-output and sparse data are not supported. Missing values and infinite values are not supported. Fitting to single-column data is only supported in :doc:`preview mode <preview>`.
    * - :obj:`sklearn.ensemble.ExtraTreesRegressor`
      - All parameters are supported except:
 
@@ -160,7 +160,7 @@ Regression
        - ``bootstrap`` = ``True`` and/or ``max_samples`` != ``None`` are not supported when there are sample weights
        - Non-integer ``max_samples`` larger than 1 or integer ``max_samples`` greater than number of rows, with ``bootstrap=True``
        - Nothing will be printed if ``verbose > 0``
-     - Multi-output and sparse data are not supported. Missing values and infinite values are not supported.
+     - Multi-output and sparse data are not supported. Missing values and infinite values are not supported. Fitting to single-column data is only supported in :doc:`preview mode <preview>`.
    * - :obj:`sklearn.neighbors.KNeighborsRegressor`
      -
        - For ``algorithm`` == ``'kd_tree'``:

--- a/sklearnex/ensemble/_forest.py
+++ b/sklearnex/ensemble/_forest.py
@@ -61,6 +61,7 @@ from onedal.utils.validation import _num_features
 from .._device_offload import dispatch, support_input_format, wrap_output_data
 from .._utils import PatchingConditionsChain, register_hyperparameters
 from ..base import oneDALEstimator
+from ..dispatcher import _is_preview_enabled
 from ..utils._array_api import enable_array_api
 from ..utils.class_weight import _compute_class_weight
 from ..utils.validation import _check_sample_weight, assert_all_finite, validate_data
@@ -356,6 +357,8 @@ class BaseForest(oneDALEstimator, ABC):
             f"sklearn.ensemble.{class_name}.{method_name}"
         )
 
+        X = data[0]
+
         if method_name == "fit":
             patching_status = self._onedal_fit_ready(patching_status, *data)
 
@@ -365,13 +368,15 @@ class BaseForest(oneDALEstimator, ABC):
                         daal_check_version((2023, "P", 200))
                         or self.estimator.__class__ == DecisionTreeClassifier,
                         "ExtraTrees only supported starting from oneDAL version 2023.2",
-                    )
+                    ),
+                    (
+                        (_num_features(X) > 1) or _is_preview_enabled(),
+                        "Single-feature trees are only available under preview mode.",
+                    ),
                 ]
             )
 
         elif method_name in self._n_jobs_supported_onedal_methods:
-            X = data[0]
-
             dal_ready = patching_status.and_conditions(
                 [
                     (hasattr(self, "_onedal_estimator"), "oneDAL model was not trained."),

--- a/sklearnex/ensemble/tests/test_forest.py
+++ b/sklearnex/ensemble/tests/test_forest.py
@@ -149,7 +149,7 @@ def test_sklearnex_import_et_regression(dataframe, queue):
     # defaults to seed=777, although it is set to 0
     rf = ExtraTreesRegressor(random_state=0).fit(X, y)
     assert "sklearnex" in rf.__module__
-    X_test = _convert_to_dataframe([[0]], sycl_queue=queue, target_df=dataframe)
+    X_test = _convert_to_dataframe([[0, 0]], sycl_queue=queue, target_df=dataframe)
     pred = _as_numpy(rf.predict(X_test))
 
     # Check that the prediction is within a reasonable range.

--- a/sklearnex/ensemble/tests/test_forest.py
+++ b/sklearnex/ensemble/tests/test_forest.py
@@ -142,7 +142,7 @@ def test_sklearnex_import_et_regression(dataframe, queue):
         pytest.skip("Skipping due to bug in histogram merges fixed in 2025.2.")
     from sklearnex.ensemble import ExtraTreesRegressor
 
-    X, y = make_regression(n_features=1, random_state=0, shuffle=False)
+    X, y = make_regression(n_features=2, random_state=0, shuffle=False)
     X = _convert_to_dataframe(X, sycl_queue=queue, target_df=dataframe)
     y = _convert_to_dataframe(y, sycl_queue=queue, target_df=dataframe)
     # For the 2023.2 release, random_state is not supported


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Turns out oneDAL performance for datasets that have a single column is oftentimes worse than scikit-learn's. This PR prefers scikit-learn when attempting to fit forests on CPU on single-column data.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
