### PR TITLE
[infra] Stop third-party docs outages from failing the docs build

### DIFF
--- a/doc/sources/conf.py
+++ b/doc/sources/conf.py
@@ -92,6 +92,92 @@ intersphinx_mapping = {
     "skops": ("https://skops.readthedocs.io/en/stable/", None),
 }
 
+# Intersphinx has no timeout by default, so an unresponsive host stalls the
+# build until the connection gives up on its own (observed at over two minutes).
+intersphinx_timeout = 30
+
+suppress_warnings = []
+
+
+def _prefetch_inventories(mapping, timeout=intersphinx_timeout):
+    """Download each ``objects.inv`` up front and point intersphinx at the copy.
+
+    ``build-doc.sh`` builds with ``-W``, so any warning fails the build, while
+    intersphinx fetches an inventory per entry above over the network. When a
+    host is unreachable it warns once for the inventory and once per
+    cross-reference into it, so an outage at any single third-party
+    documentation site fails the docs build on every branch.
+
+    Fetching here rather than probing for reachability keeps the decision and
+    the download in the same request: a host that flaps between responses
+    cannot pass a probe and then fail the fetch that intersphinx does later.
+    Inventories that cannot be downloaded are dropped from the mapping, and
+    only then is the cross-reference check relaxed, so a build with every host
+    up still validates every reference. Sphinx emits the unreachable-inventory
+    warning without a type (``sphinx/ext/intersphinx/_load.py``), which is why
+    it cannot simply be listed in ``suppress_warnings``.
+    """
+    import atexit
+    import concurrent.futures
+    import posixpath
+    import shutil
+    import tempfile
+
+    # Sphinx's own wrapper, so this request carries the same user agent and TLS
+    # settings as the one it replaces, and a proxy or certificate bundle that
+    # intersphinx would have honoured is not mistaken for an unreachable host.
+    from sphinx.util import requests
+
+    tls_info = (globals().get("tls_verify", True), globals().get("tls_cacerts"))
+
+    cache = tempfile.mkdtemp(prefix="sklearnex-intersphinx-")
+    atexit.register(shutil.rmtree, cache, ignore_errors=True)
+
+    def fetch(item):
+        name, (target, inventory) = item
+        url = inventory or posixpath.join(target, "objects.inv")
+        if "://" not in url:
+            return name, inventory, None  # already a local inventory
+        try:
+            with requests.get(url, timeout=timeout, _tls_info=tls_info) as response:
+                response.raise_for_status()
+                content = response.content
+        except Exception as error:
+            # Anything that stops the download means there is no inventory to
+            # use. Parsing stays with intersphinx, so a corrupt inventory is
+            # still reported as a build warning rather than silently ignored.
+            return name, None, error
+        path = os.path.join(cache, f"{name}.inv")
+        with open(path, "wb") as inventory_file:
+            inventory_file.write(content)
+        return name, path, None
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(fetch, list(mapping.items())))
+
+    failures = {}
+    for name, path, error in results:
+        if error is None:
+            mapping[name] = (mapping[name][0], path)
+        else:
+            failures[name] = error
+
+    if not failures:
+        return
+
+    for name, error in sorted(failures.items()):
+        print(
+            f"conf.py: intersphinx inventory for {name!r} could not be "
+            f"downloaded ({error.__class__.__name__}: {error}); references "
+            "into it will render unlinked and will not be validated",
+            file=sys.stderr,
+        )
+        del mapping[name]
+    suppress_warnings.append("intersphinx.external")
+
+
+_prefetch_inventories(intersphinx_mapping)
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
### Description

The `Docs` pipeline is currently failing on `main` and on every PR that touches `doc/`, because `docs.scipy.org` is down. Recent runs of pipeline definition 19:

| build | branch | result |
|---|---|---|
| 63056 | `refs/pull/3412/merge` | failed |
| 63053 | `refs/pull/3412/merge` | failed |
| 63052 | `refs/pull/3413/merge` | failed |
| 63051 | `refs/pull/3412/merge` | failed |
| 63049 | `refs/heads/main` | failed |
| 63047 | `refs/pull/3325/merge` | failed |
| 63044 | `refs/pull/3411/merge` | succeeded |

All of them fail the same way:

```
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://docs.scipy.org/doc/scipy/objects.inv' not fetchable due to
<class 'requests.exceptions.ConnectTimeout'>: ... (connect timeout=None)
/home/vsts/work/1/s/doc/sources/input-types.rst:58: WARNING: inventory for external
cross-reference not found: 'scipy' [intersphinx.external]
build finished with problems, 2 warnings (with warnings treated as errors).
make: *** [Makefile:23: html] Error 1
```

`doc/build-doc.sh` exports `SPHINXOPTS="-W"`, and `intersphinx_mapping` has thirteen entries whose `objects.inv` intersphinx downloads at build time. So the docs gate depends on the uptime of thirteen third-party websites, and an outage at any one of them turns every docs build red until that site recovers. Nothing about our documentation is wrong in these builds.

### Changes

`doc/sources/conf.py` now downloads the inventories itself, writes them to a temporary directory, and points `intersphinx_mapping` at those local files. Inventories that cannot be downloaded are dropped from the mapping, and `intersphinx.external` is added to `suppress_warnings` only when something was actually dropped — so a build with every site up still validates every cross-reference exactly as before. The failure is printed to stderr so a degraded build is visible in the log rather than silent.

Two details worth calling out:

- **Why fetch rather than probe.** My first version probed each host for reachability and dropped the unreachable ones, leaving intersphinx to do the real download. That is racy against exactly the host causing this outage: probing `docs.scipy.org/doc/scipy/objects.inv` five times in a row while writing this gave `504, 504, 504, 504, 504`, but an earlier attempt minutes before returned `200`. A host that flaps can pass the probe and then fail intersphinx's download. Fetching once and reusing the result removes the window.
- **Why not just `suppress_warnings`.** The unreachable-inventory warning is emitted with no type or subtype (`sphinx/ext/intersphinx/_load.py:297`, `LOGGER.warning('%s\n%s', ...)`), so `suppress_warnings` cannot target it — only the `intersphinx.external` one is typed (`_resolve.py:383`). A config-only fix is therefore not available.

The download uses `sphinx.util.requests`, not plain `requests`, so it carries the same user agent and the same `tls_verify` / `tls_cacerts` handling as the request it replaces. Without that, a corporate proxy or custom certificate bundle that intersphinx would have honoured could be misread as an unreachable host and silently degrade the docs. `intersphinx_timeout` is also set, since it defaults to no timeout at all — the failing builds spent over two minutes waiting on the connection.

No new dependency: `requests` is already in `requirements-doc.txt`, and this fetches the same thirteen inventories the build already fetched.

### Verification

Against real Sphinx 8.2.3 (the version pinned in `requirements-doc.txt`), building with `-W` as `build-doc.sh` does:

| case | inventory state | expected | result |
|---|---|---|---|
| A | scipy unreachable, without this change | build fails | fails ✔ |
| B | scipy unreachable, with this change | build succeeds | succeeds ✔ |
| C | all reachable, with this change | build succeeds | succeeds ✔ |
| D | all reachable, misspelled inventory name in a reference | build fails | fails ✔ |
| E | all reachable, broken internal `:ref:` | build fails | fails ✔ |

D and E are the ones that matter for not blunting the gate: with every host up, a typo'd inventory name still produces `inventory for external cross-reference not found: 'pythn' [intersphinx.external]` and still fails the build, and unrelated warnings are untouched.

Evaluating the real `doc/sources/conf.py` against all thirteen live inventories keeps 13 and drops only `scipy`, with `suppress_warnings == ['intersphinx.external']`, and every kept entry resolves to a local file — confirmed by `sphinx-build -v` logging `loading intersphinx inventory 'python' from /tmp/sklearnex-intersphinx-*/python.inv`, i.e. no network fetch during the build itself.

`black`, `isort`, `codespell` and `numpydoc` all clean on the changed file.

### Notes

This only removes the outage as a *build failure*. While a site is down, references into its inventory render as unlinked literal text instead of links, which seems clearly preferable to a red gate on unrelated PRs. If you would rather the build keep failing loudly on any inventory problem, the alternative is vendoring the inventories, and I am happy to redo it that way.

---

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
