### PR TITLE
FIX: Ensure sparse support vectors retain full shape

### DIFF
--- a/onedal/svm/svm.py
+++ b/onedal/svm/svm.py
@@ -17,6 +17,7 @@
 from abc import ABC, abstractmethod
 from math import sqrt
 
+import numpy as np
 from scipy import sparse as sp
 
 from daal4py.sklearn._utils import is_sparse
@@ -112,10 +113,20 @@ class BaseSVM(ABC):
             # Note: the coefficients from oneDAL come as dense, but
             # scikit-learn stores them as sparse, hence the conversion
             self.dual_coef_ = _csr_array(from_table(result.coeffs).T)
-            self.support_vectors_ = _csr_array(
-                from_table(result.support_vectors),
-                shape=(result.support_vectors.shape[0], result.support_vectors.shape[1]),
-            )
+            if result.support_vectors.shape[0]:
+                self.support_vectors_ = _csr_array(
+                    from_table(result.support_vectors),
+                    shape=(
+                        result.support_vectors.shape[0],
+                        result.support_vectors.shape[1],
+                    ),
+                )
+            else:
+                # In this case, oneDAL might either error out or output a
+                # matrix with shape (0,0). If this changes in the future
+                # once empty support vectors are handled better, this
+                # condition can be removed
+                self.support_vectors_ = _csr_array(np.empty((0, X.shape[1])))
         else:
             self.dual_coef_ = from_table(result.coeffs, like=X).T
             self.support_vectors_ = from_table(result.support_vectors, like=X)

--- a/onedal/svm/svm.py
+++ b/onedal/svm/svm.py
@@ -109,8 +109,13 @@ class BaseSVM(ABC):
         result = self.train(params, *data_t)
 
         if self._sparse:
+            # Note: the coefficients from oneDAL come as dense, but
+            # scikit-learn stores them as sparse, hence the conversion
             self.dual_coef_ = _csr_array(from_table(result.coeffs).T)
-            self.support_vectors_ = _csr_array(from_table(result.support_vectors))
+            self.support_vectors_ = _csr_array(
+                from_table(result.support_vectors),
+                shape=(result.support_vectors.shape[0], result.support_vectors.shape[1]),
+            )
         else:
             self.dual_coef_ = from_table(result.coeffs, like=X).T
             self.support_vectors_ = from_table(result.support_vectors, like=X)

--- a/sklearnex/svm/tests/test_svm.py
+++ b/sklearnex/svm/tests/test_svm.py
@@ -594,3 +594,13 @@ def test_svc_mixed_devices(X_xp, X_device, y_xp, y_device, with_array_api):
     decision_scores = model.decision_function(X)
     assert decision_scores.__class__ == X.__class__
     _ = model.score(X, y)
+
+
+def test_sparse_support_vectors_retain_shape():
+    from sklearnex.svm import SVC
+
+    X, y = make_classification(n_samples=20, n_features=5, random_state=123)
+    X = np.c_[X, np.zeros((X.shape[0], 10))]
+    X_sp = csr_class(X, shape=X.shape)
+    model = SVC().fit(X_sp, y)
+    assert model.support_vectors_.shape[1] == X.shape[1]


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

When assigning sparse support vectors in CSR format in SVMs, they are constructed from CSR arrays, but if there are empty columns, the resulting shape might be different than what SciPy would deduce from those arrays.

This PR sets the shape explicitly in order to avoid discarding empty columns.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/doc/sources/contribute.rst) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
